### PR TITLE
feat: improve TUI display and session recording

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -124,11 +124,12 @@ func runInner(
 					h.OnTodoUpdate()
 				}
 				if rec != nil {
-					rec.RecordToolResult(toolName, output, nil)
+					rec.RecordToolResult(toolName, output, mo.Message.ToolCallID, nil)
 				}
 			} else if mo.IsStreaming {
 				var sb strings.Builder
 				var toolErr error
+				var toolCallID string
 				for {
 					chunk, err := mo.MessageStream.Recv()
 					if err == io.EOF {
@@ -141,6 +142,9 @@ func runInner(
 					}
 					if chunk != nil {
 						sb.WriteString(chunk.Content)
+						if toolCallID == "" && chunk.ToolCallID != "" {
+							toolCallID = chunk.ToolCallID
+						}
 					}
 				}
 				if toolErr == nil {
@@ -149,10 +153,10 @@ func runInner(
 						h.OnTodoUpdate()
 					}
 					if rec != nil {
-						rec.RecordToolResult(toolName, sb.String(), nil)
+						rec.RecordToolResult(toolName, sb.String(), toolCallID, nil)
 					}
 				} else if rec != nil {
-					rec.RecordToolResult(toolName, "", toolErr)
+					rec.RecordToolResult(toolName, "", toolCallID, toolErr)
 				}
 			}
 			continue
@@ -163,6 +167,13 @@ func runInner(
 		}
 
 		if mo.IsStreaming {
+			// Accumulate streaming tool call names, args, and IDs across chunks.
+			type pendingTC struct {
+				name string
+				id   string
+				args strings.Builder
+			}
+			pending := make(map[int]*pendingTC)
 			for {
 				chunk, err := mo.MessageStream.Recv()
 				if err == io.EOF {
@@ -174,14 +185,17 @@ func runInner(
 				if chunk == nil {
 					continue
 				}
-				if len(chunk.ToolCalls) > 0 {
-					for _, tc := range chunk.ToolCalls {
-						if tc.Function.Name != "" {
-							h.OnToolCall(tc.Function.Name, tc.Function.Arguments)
-							if rec != nil {
-								rec.RecordToolCall(tc.Function.Name, tc.Function.Arguments)
-							}
-						}
+				for _, tc := range chunk.ToolCalls {
+					idx := 0
+					if tc.Index != nil {
+						idx = *tc.Index
+					}
+					if tc.Function.Name != "" {
+						p := &pendingTC{name: tc.Function.Name, id: tc.ID}
+						p.args.WriteString(tc.Function.Arguments)
+						pending[idx] = p
+					} else if p, ok := pending[idx]; ok {
+						p.args.WriteString(tc.Function.Arguments)
 					}
 				}
 				if chunk.Content != "" {
@@ -189,12 +203,19 @@ func runInner(
 					h.OnAgentText(chunk.Content)
 				}
 			}
+			// Notify and record accumulated tool calls.
+			for _, p := range pending {
+				h.OnToolCall(p.name, p.args.String())
+				if rec != nil {
+					rec.RecordToolCall(p.name, p.args.String(), p.id)
+				}
+			}
 		} else if mo.Message != nil {
 			if len(mo.Message.ToolCalls) > 0 {
 				for _, tc := range mo.Message.ToolCalls {
 					h.OnToolCall(tc.Function.Name, tc.Function.Arguments)
 					if rec != nil {
-						rec.RecordToolCall(tc.Function.Name, tc.Function.Arguments)
+						rec.RecordToolCall(tc.Function.Name, tc.Function.Arguments, tc.ID)
 					}
 				}
 			}

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -9,8 +9,8 @@ import (
 
 // ReconstructHistory converts a slice of recorded session entries back into
 // LLM history messages suitable for resuming a conversation.
-// Only user and assistant text messages are included; tool calls are omitted
-// because reconstructing matching tool-call IDs is non-trivial.
+// It reconstructs tool call and tool result messages so that resumed sessions
+// retain full context.
 func ReconstructHistory(entries []Entry) []adk.Message {
 	var msgs []adk.Message
 	for _, e := range entries {
@@ -21,6 +21,21 @@ func ReconstructHistory(entries []Entry) []adk.Message {
 			if e.Content != "" {
 				msgs = append(msgs, &schema.Message{Role: schema.Assistant, Content: e.Content})
 			}
+		case EntryToolCall:
+			tc := schema.ToolCall{
+				ID:       e.ToolCallID,
+				Function: schema.FunctionCall{Name: e.Name, Arguments: e.Args},
+			}
+			// Merge into preceding assistant message if it exists, otherwise create one.
+			if n := len(msgs); n > 0 {
+				if last := msgs[n-1]; last.Role == schema.Assistant {
+					last.ToolCalls = append(last.ToolCalls, tc)
+					continue
+				}
+			}
+			msgs = append(msgs, &schema.Message{Role: schema.Assistant, ToolCalls: []schema.ToolCall{tc}})
+		case EntryToolResult:
+			msgs = append(msgs, schema.ToolMessage(e.Output, e.ToolCallID, schema.WithToolName(e.Name)))
 		}
 	}
 	return msgs
@@ -65,6 +80,39 @@ func ReconstructState(entries []Entry) *SessionState {
 				msgs = append(msgs, &schema.Message{Role: schema.Assistant, Content: e.Content})
 			}
 
+		case EntryToolCall:
+			tc := schema.ToolCall{
+				ID:       e.ToolCallID,
+				Function: schema.FunctionCall{Name: e.Name, Arguments: e.Args},
+			}
+			merged := false
+			if n := len(msgs); n > 0 {
+				if last := msgs[n-1]; last.Role == schema.Assistant {
+					last.ToolCalls = append(last.ToolCalls, tc)
+					merged = true
+				}
+			}
+			if !merged {
+				msgs = append(msgs, &schema.Message{Role: schema.Assistant, ToolCalls: []schema.ToolCall{tc}})
+			}
+			if e.Name == "switch_env" {
+				type args struct {
+					Target string `json:"target"`
+				}
+				var a args
+				if err := json.Unmarshal([]byte(e.Args), &a); err == nil {
+					lastTarget = a.Target
+				}
+			}
+
+		case EntryToolResult:
+			msgs = append(msgs, schema.ToolMessage(e.Output, e.ToolCallID, schema.WithToolName(e.Name)))
+			if e.Name == "switch_env" {
+				if e.Error == "" && lastTarget != "" {
+					state.EnvTarget = lastTarget
+				}
+			}
+
 		case EntryCompact:
 			// Discard accumulated history and use the compact summary as base.
 			msgs = []adk.Message{
@@ -89,24 +137,6 @@ func ReconstructState(entries []Entry) *SessionState {
 
 		case EntryModeChange:
 			state.Mode = e.Mode
-
-		case EntryToolCall:
-			if e.Name == "switch_env" {
-				type args struct {
-					Target string `json:"target"`
-				}
-				var a args
-				if err := json.Unmarshal([]byte(e.Args), &a); err == nil {
-					lastTarget = a.Target
-				}
-			}
-
-		case EntryToolResult:
-			if e.Name == "switch_env" {
-				if e.Error == "" && lastTarget != "" {
-					state.EnvTarget = lastTarget
-				}
-			}
 		}
 	}
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -44,17 +44,18 @@ type TodoSnapshotItem struct {
 
 // Entry is one line of the JSONL session file.
 type Entry struct {
-	Type      EntryType `json:"type"`
-	UUID      string    `json:"uuid,omitempty"`
-	Project   string    `json:"project,omitempty"`
-	Provider  string    `json:"provider,omitempty"`
-	Model     string    `json:"model,omitempty"`
-	Content   string    `json:"content,omitempty"`
-	Name      string    `json:"name,omitempty"`   // tool name
-	Args      string    `json:"args,omitempty"`   // tool args JSON
-	Output    string    `json:"output,omitempty"` // tool output
-	Error     string    `json:"error,omitempty"`  // tool error
-	Timestamp string    `json:"timestamp"`
+	Type       EntryType `json:"type"`
+	UUID       string    `json:"uuid,omitempty"`
+	Project    string    `json:"project,omitempty"`
+	Provider   string    `json:"provider,omitempty"`
+	Model      string    `json:"model,omitempty"`
+	Content    string    `json:"content,omitempty"`
+	Name       string    `json:"name,omitempty"`         // tool name
+	Args       string    `json:"args,omitempty"`         // tool args JSON
+	Output     string    `json:"output,omitempty"`       // tool output
+	Error      string    `json:"error,omitempty"`        // tool error
+	ToolCallID string    `json:"tool_call_id,omitempty"` // links tool_call ↔ tool_result
+	Timestamp  string    `json:"timestamp"`
 
 	// plan_update fields
 	PlanStatus  string `json:"plan_status,omitempty"`
@@ -144,17 +145,17 @@ func (r *Recorder) RecordAssistant(content string) {
 }
 
 // RecordToolCall appends a tool-call entry.
-func (r *Recorder) RecordToolCall(name, args string) {
-	_ = r.writeEntry(Entry{Type: EntryToolCall, Name: name, Args: args})
+func (r *Recorder) RecordToolCall(name, args, toolCallID string) {
+	_ = r.writeEntry(Entry{Type: EntryToolCall, Name: name, Args: args, ToolCallID: toolCallID})
 }
 
 // RecordToolResult appends a tool-result entry.
-func (r *Recorder) RecordToolResult(name, output string, err error) {
+func (r *Recorder) RecordToolResult(name, output, toolCallID string, err error) {
 	errStr := ""
 	if err != nil {
 		errStr = err.Error()
 	}
-	_ = r.writeEntry(Entry{Type: EntryToolResult, Name: name, Output: output, Error: errStr})
+	_ = r.writeEntry(Entry{Type: EntryToolResult, Name: name, Output: output, ToolCallID: toolCallID, Error: errStr})
 }
 
 // RecordPlanUpdate appends a plan state change entry.

--- a/internal/tools/subagent.go
+++ b/internal/tools/subagent.go
@@ -266,8 +266,12 @@ func (s *subagentTool) runSubagent(ctx context.Context, ag *adk.ChatModelAgent, 
 			toolName := mo.ToolName
 			if !mo.IsStreaming && mo.Message != nil {
 				s.notifyProgress(input.Name, "tool_result", toolName, mo.Message.Content)
+				if s.deps.Recorder != nil {
+					s.deps.Recorder.RecordToolResult(toolName, mo.Message.Content, mo.Message.ToolCallID, nil)
+				}
 			} else if mo.IsStreaming {
 				var sb strings.Builder
+				var toolCallID string
 				for {
 					chunk, err := mo.MessageStream.Recv()
 					if err == io.EOF {
@@ -278,9 +282,15 @@ func (s *subagentTool) runSubagent(ctx context.Context, ag *adk.ChatModelAgent, 
 					}
 					if chunk != nil {
 						sb.WriteString(chunk.Content)
+						if toolCallID == "" && chunk.ToolCallID != "" {
+							toolCallID = chunk.ToolCallID
+						}
 					}
 				}
 				s.notifyProgress(input.Name, "tool_result", toolName, sb.String())
+				if s.deps.Recorder != nil {
+					s.deps.Recorder.RecordToolResult(toolName, sb.String(), toolCallID, nil)
+				}
 			}
 			continue
 		}
@@ -290,6 +300,12 @@ func (s *subagentTool) runSubagent(ctx context.Context, ag *adk.ChatModelAgent, 
 		}
 
 		if mo.IsStreaming {
+			// Accumulate streaming tool call names and arguments across chunks.
+			type pendingTC struct {
+				name string
+				args strings.Builder
+			}
+			pending := make(map[int]*pendingTC)
 			for {
 				chunk, err := mo.MessageStream.Recv()
 				if err != nil {
@@ -298,14 +314,28 @@ func (s *subagentTool) runSubagent(ctx context.Context, ag *adk.ChatModelAgent, 
 				if chunk == nil {
 					continue
 				}
-				// Forward tool call events.
 				for _, tc := range chunk.ToolCalls {
+					idx := 0
+					if tc.Index != nil {
+						idx = *tc.Index
+					}
 					if tc.Function.Name != "" {
-						s.notifyProgress(input.Name, "tool_call", tc.Function.Name, tc.Function.Arguments)
+						p := &pendingTC{name: tc.Function.Name}
+						p.args.WriteString(tc.Function.Arguments)
+						pending[idx] = p
+					} else if p, ok := pending[idx]; ok {
+						p.args.WriteString(tc.Function.Arguments)
 					}
 				}
 				if chunk.Content != "" {
 					assistantText.WriteString(chunk.Content)
+				}
+			}
+			// Notify and record accumulated tool calls.
+			for _, p := range pending {
+				s.notifyProgress(input.Name, "tool_call", p.name, p.args.String())
+				if s.deps.Recorder != nil {
+					s.deps.Recorder.RecordToolCall(p.name, p.args.String(), "")
 				}
 			}
 			reportTokens()
@@ -314,6 +344,9 @@ func (s *subagentTool) runSubagent(ctx context.Context, ag *adk.ChatModelAgent, 
 			for _, tc := range mo.Message.ToolCalls {
 				if tc.Function.Name != "" {
 					s.notifyProgress(input.Name, "tool_call", tc.Function.Name, tc.Function.Arguments)
+					if s.deps.Recorder != nil {
+						s.deps.Recorder.RecordToolCall(tc.Function.Name, tc.Function.Arguments, tc.ID)
+					}
 				}
 			}
 			if mo.Message.Content != "" {

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -16,14 +16,14 @@ func formatToolArgs(argsJSON string) string {
 	}
 	var args map[string]interface{}
 	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
-		return truncate(sanitize(argsJSON), 120)
+		return sanitize(argsJSON)
 	}
 	parts := make([]string, 0, len(args))
 	for k, v := range args {
-		val := truncate(sanitize(fmt.Sprintf("%v", v)), 60)
+		val := sanitize(fmt.Sprintf("%v", v))
 		parts = append(parts, fmt.Sprintf("%s=%s", k, val))
 	}
-	return truncate(strings.Join(parts, " "), 200)
+	return strings.Join(parts, " ")
 }
 
 // ansiRe matches ANSI escape sequences (CSI, OSC, etc.).

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -86,12 +86,14 @@ type ResumeRequestMsg struct{ UUID string }
 
 // SessionEntry is a display-ready record from a replayed session.
 type SessionEntry struct {
-	Type    string
-	Content string
-	Name    string
-	Args    string
-	Output  string
-	Error   string
+	Type         string
+	Content      string
+	Name         string
+	Args         string
+	Output       string
+	Error        string
+	SubagentName string
+	SubagentType string
 }
 
 // SessionResumedMsg is sent by the main goroutine to replay a session in the TUI.

--- a/internal/tui/session_helper.go
+++ b/internal/tui/session_helper.go
@@ -11,12 +11,14 @@ func ConvertSessionEntries(entries []session.Entry) []SessionEntry {
 			continue
 		}
 		result = append(result, SessionEntry{
-			Type:    string(e.Type),
-			Content: e.Content,
-			Name:    e.Name,
-			Args:    e.Args,
-			Output:  e.Output,
-			Error:   e.Error,
+			Type:         string(e.Type),
+			Content:      e.Content,
+			Name:         e.Name,
+			Args:         e.Args,
+			Output:       e.Output,
+			Error:        e.Error,
+			SubagentName: e.SubagentName,
+			SubagentType: e.SubagentType,
 		})
 	}
 	return result

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1352,6 +1352,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 				} else {
 					m.lines = append(m.lines, formatToolResult(e.Name, e.Output, m.width)...)
 				}
+			case string(session.EntrySubagentStart):
+				typeLabel := e.SubagentType
+				if typeLabel == "" {
+					typeLabel = "explore"
+				}
+				m.lines = append(m.lines, fmt.Sprintf("  %s %s %s",
+					subagentLabelStyle.Render("🤖 Subagent:"),
+					toolNameStyle.Render(e.SubagentName),
+					toolArgsStyle.Render("("+typeLabel+")"),
+				))
+			case string(session.EntrySubagentResult):
+				if e.Error != "" {
+					m.lines = append(m.lines, fmt.Sprintf("   %s %s",
+						toolErrorStyle.Render("✗ Subagent Error:"),
+						toolResultStyle.Render(truncate(sanitize(e.Error), maxToolOutputLen))))
+				} else {
+					m.lines = append(m.lines, fmt.Sprintf("   %s %s",
+						toolSuccessStyle.Render("✓ Subagent Done:"),
+						toolResultStyle.Render(truncate(sanitize(e.Output), maxToolOutputLen))))
+				}
 			}
 		}
 		m.lines = append(m.lines, "")


### PR DESCRIPTION
- Preserve tool call parameters in session JSONL with ToolCallID linking
- Reconstruct full tool call/result history on session resume
- Fix streaming tool call args: accumulate across chunks before notifying TUI
- Record subagent inner tool calls and results to session JSONL
- Show subagent_start and subagent_result entries on session resume
- Add SubagentName/SubagentType to SessionEntry for display
- Remove truncation from formatToolArgs for full audit visibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls and results are now properly linked for better tracking.
  * Subagent lifecycle events (start, completion) are now displayed in session history.
  * Subagent type labels are included in the UI.

* **Bug Fixes**
  * Improved streaming tool result handling and consolidation.
  * Tool arguments are now displayed in full without truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->