### PR TITLE
fix: handle unchecked error returns in BLE code

### DIFF
--- a/internal/channel/ble/ble_cgo.go
+++ b/internal/channel/ble/ble_cgo.go
@@ -100,7 +100,7 @@ func (n *Notifier) Close() {
 	n.closed = true
 	if n.ready {
 		n.ready = false
-		go n.device.Disconnect()
+		go func() { _ = n.device.Disconnect() }()
 	}
 }
 
@@ -125,7 +125,7 @@ func (n *Notifier) connect() {
 		if strings.HasPrefix(name, "JCODE-") {
 			logger.Printf("[ble] found device: %s (RSSI: %d)", name, result.RSSI)
 			found = result
-			adapter.StopScan()
+			_ = adapter.StopScan()
 			close(foundCh)
 		}
 	})
@@ -146,7 +146,7 @@ func (n *Notifier) connect() {
 	case <-foundCh:
 	case <-time.After(10 * time.Second):
 		logger.Printf("[ble] no JCODE device found within timeout")
-		n.adapter.StopScan()
+		_ = n.adapter.StopScan()
 		n.mu.Lock()
 		n.connecting = false
 		n.mu.Unlock()
@@ -166,7 +166,7 @@ func (n *Notifier) connect() {
 	services, err := device.DiscoverServices([]bluetooth.UUID{nusServiceUUID})
 	if err != nil || len(services) == 0 {
 		logger.Printf("[ble] NUS service not found")
-		device.Disconnect()
+		_ = device.Disconnect()
 		n.mu.Lock()
 		n.connecting = false
 		n.mu.Unlock()
@@ -176,7 +176,7 @@ func (n *Notifier) connect() {
 	chars, err := services[0].DiscoverCharacteristics([]bluetooth.UUID{nusRXCharUUID})
 	if err != nil || len(chars) == 0 {
 		logger.Printf("[ble] RX characteristic not found")
-		device.Disconnect()
+		_ = device.Disconnect()
 		n.mu.Lock()
 		n.connecting = false
 		n.mu.Unlock()

--- a/script/poc/ble.go
+++ b/script/poc/ble.go
@@ -43,7 +43,7 @@ func main() {
 		if strings.HasPrefix(name, "JCODE-") {
 			fmt.Printf("  Found: %s (RSSI: %d)\n", name, result.RSSI)
 			foundDevice = result
-			adapter.StopScan()
+			_ = adapter.StopScan()
 			close(found)
 		}
 	})
@@ -143,7 +143,7 @@ func main() {
 		switch {
 		case line == "quit" || line == "exit":
 			fmt.Println("Disconnecting...")
-			device.Disconnect()
+			_ = device.Disconnect()
 			fmt.Println("Bye!")
 			return
 


### PR DESCRIPTION
## Summary

Fix `errcheck` lint warnings in BLE channel and POC code.

## Changes

- Wrap `Disconnect()` and `StopScan()` return values with `_ =` to explicitly acknowledge errors in cleanup/best-effort paths
- `internal/channel/ble/ble_cgo.go` (5 occurrences)
- `script/poc/ble.go` (2 occurrences)

## Test Plan

- [x] `make lint` passes with zero warnings
- [x] BLE functionality unchanged (same runtime behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling practices for Bluetooth Low Energy operations to maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->