### PR TITLE
fix: resolve gocritic, staticcheck and ineffassign lint warnings

### DIFF
--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -109,7 +109,7 @@ func runWebServer(port int, host string) error {
 	// Wrap handler with NotifyingHandler for WeChat push notifications.
 	// Callbacks check wechatClient.State() before sending, so this is safe
 	// even when the channel is disabled or not yet configured.
-	var finalHandler handler.AgentEventHandler = webHandler
+	var finalHandler handler.AgentEventHandler
 	wechatClient := weixin.NewClient()
 
 	// Auto-enable if credentials exist and channel.web_enabled is true.

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -342,13 +342,14 @@ func (g *grepTool) formatFilesWithMatches(lines []string, pwd string, maxResults
 		result.WriteString("\n")
 	}
 
-	if truncated {
+	switch {
+	case truncated:
 		fmt.Fprintf(&result, "\nFound %d files (showing %d, offset %d — use offset=%d for next page)\n",
 			totalFiles, len(entries), offset, offset+maxResults)
-	} else if offset > 0 {
+	case offset > 0:
 		fmt.Fprintf(&result, "\nFound %d files (showing %d, offset %d)\n",
 			totalFiles, len(entries), offset)
-	} else {
+	default:
 		fmt.Fprintf(&result, "\nFound %d files\n", len(entries))
 	}
 

--- a/internal/tui/channel_panel.go
+++ b/internal/tui/channel_panel.go
@@ -79,7 +79,7 @@ func (m Model) showChannelActions(channelID string, cmds []tea.Cmd) (tea.Model, 
 	}
 
 	m.channelMenu.SetItems(items)
-	m.channelMenu.Title = fmt.Sprintf("↑/↓ navigate · Enter confirm · Esc cancel")
+	m.channelMenu.Title = "↑/↓ navigate · Enter confirm · Esc cancel"
 	return m, tea.Batch(cmds...)
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -89,8 +89,6 @@ type Model struct {
 
 	todoStore *tools.TodoStore
 
-	promptTokens      int64
-	completionTokens  int64
 	totalTokens       int64
 	modelContextLimit int
 
@@ -1332,9 +1330,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 		m.lines = append(m.lines, toolLabelStyle.Render("📡 "+msg.Message))
 		if msg.QRCodeContent != "" {
 			qrLines := renderQRCode(msg.QRCodeContent)
-			for _, line := range qrLines {
-				m.lines = append(m.lines, line)
-			}
+			m.lines = append(m.lines, qrLines...)
 		}
 		m.refreshViewport()
 
@@ -1551,8 +1547,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 		cmds = append(cmds, m.spinner.Tick)
 
 	case TokenUpdateMsg:
-		m.promptTokens = msg.PromptTokens
-		m.completionTokens = msg.CompletionTokens
 		m.totalTokens = msg.TotalTokens
 		m.modelContextLimit = msg.ModelContextLimit
 


### PR DESCRIPTION
## Summary

Fix multiple lint warnings across 4 files.

## Changes

- `internal/tools/grep.go`: convert if/else chain to switch statement (gocritic: ifElseChain)
- `internal/command/web.go`: remove ineffectual initial assignment of `finalHandler` (ineffassign)
- `internal/tui/channel_panel.go`: remove unnecessary `fmt.Sprintf` on plain string literal (staticcheck: S1039)
- `internal/tui/tui.go`: replace for-loop append with variadic `append(slice, items...)` (staticcheck: S1011)

## Test Plan

- [x] `make lint` passes with zero warnings
- [x] No behavioral changes — all fixes are structural/idiomatic