### PR TITLE
refactor: simplify token usage tracking

### DIFF
--- a/internal/model/chatmodel.go
+++ b/internal/model/chatmodel.go
@@ -21,6 +21,7 @@ type TokenUsage struct {
 	PromptTokens     int64
 	CompletionTokens int64
 	TotalTokens      int64
+	LastTotalTokens  int64
 	byModel          map[string]int64
 	mu               sync.RWMutex
 }
@@ -33,6 +34,7 @@ func (t *TokenUsage) Add(prompt, completion, total int) {
 	atomic.AddInt64(&t.PromptTokens, int64(prompt))
 	atomic.AddInt64(&t.CompletionTokens, int64(completion))
 	atomic.AddInt64(&t.TotalTokens, int64(total))
+	atomic.StoreInt64(&t.LastTotalTokens, int64(total))
 }
 
 // Get returns the current token usage
@@ -40,6 +42,11 @@ func (t *TokenUsage) Get() (prompt, completion, total int64) {
 	return atomic.LoadInt64(&t.PromptTokens),
 		atomic.LoadInt64(&t.CompletionTokens),
 		atomic.LoadInt64(&t.TotalTokens)
+}
+
+// GetLastTotal returns the last API call's total tokens (current context usage)
+func (t *TokenUsage) GetLastTotal() int64 {
+	return atomic.LoadInt64(&t.LastTotalTokens)
 }
 
 // Reset resets the token tracker

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -110,8 +110,6 @@ type AgentsMdMsg struct {
 
 // TokenUpdateMsg is sent periodically to update token usage display
 type TokenUpdateMsg struct {
-	PromptTokens      int64
-	CompletionTokens  int64
 	TotalTokens       int64
 	ModelContextLimit int // 0 if unknown
 }


### PR DESCRIPTION
## Summary

Streamline token usage tracking by removing unused per-field counters from handler/TUI types and adding a `LastTotalTokens` field for per-call context window tracking.

## Changes

- **model/chatmodel.go**: add `LastTotalTokens` field + `GetLastTotal()` accessor to track the most recent API call token count (current context usage vs. cumulative total)
- **tui/messages.go**: remove unused `PromptTokens` and `CompletionTokens` from `TokenUpdateMsg` (only `TotalTokens` is displayed)

## Motivation

The TUI and web UI only display total tokens. Carrying `PromptTokens`/`CompletionTokens` through the entire handler → TUI message chain was unnecessary overhead. `LastTotalTokens` provides the current context window usage for the progress bar.

## Test Plan

- [x] `make lint` passes
- [x] Token display in TUI status bar unchanged (shows total)
- [x] Web UI token display unchanged