### PR TITLE
fix: deduplicate session ID and fix resume bugs in web/ACP/TUI

### DIFF
--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -388,16 +388,8 @@ func (a *acpAgent) LoadSession(ctx context.Context, params acp.LoadSessionReques
 		rec.SetUUID(resumeUUID)
 	}
 
-	// Convert entries to message history.
-	history := make([]*schema.Message, 0, len(entries))
-	for _, entry := range entries {
-		switch entry.Type {
-		case session.EntryUser:
-			history = append(history, &schema.Message{Role: "user", Content: entry.Content})
-		case session.EntryAssistant:
-			history = append(history, &schema.Message{Role: "assistant", Content: entry.Content})
-		}
-	}
+	// Reconstruct full message history (including tool calls/results).
+	history := session.ReconstructHistory(entries)
 
 	sess, err := a.buildAgentSession(ctx, cfg, pwd, params.SessionId, rec, history)
 	if err != nil {

--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -44,13 +44,16 @@ type acpSession struct {
 	mu            sync.Mutex
 }
 
-// acpAgent implements the acp.Agent interface, exposing jcode as an ACP server.
+// acpAgent implements the acp.Agent and acp.AgentLoader interfaces, exposing jcode as an ACP server.
 type acpAgent struct {
 	conn *acp.AgentSideConnection
 
 	mu       sync.Mutex
 	sessions map[acp.SessionId]*acpSession
 }
+
+// Ensure acpAgent implements acp.AgentLoader interface.
+var _ acp.AgentLoader = (*acpAgent)(nil)
 
 func NewACPCmd() *cobra.Command {
 	return &cobra.Command{
@@ -90,6 +93,7 @@ func (a *acpAgent) Initialize(_ context.Context, params acp.InitializeRequest) (
 			PromptCapabilities: acp.PromptCapabilities{
 				EmbeddedContext: true,
 			},
+			LoadSession: true,
 		},
 		AgentInfo: &acp.Implementation{
 			Name:    "jcode",
@@ -115,6 +119,36 @@ func (a *acpAgent) NewSession(ctx context.Context, params acp.NewSessionRequest)
 	if pwd == "" {
 		pwd = util.GetWorkDir()
 	}
+
+	providerName, modelName := cfg.GetProviderModel()
+	rec, _ := session.NewRecorder(pwd, providerName, modelName)
+	sessionID := acp.SessionId(fmt.Sprintf("sess_%s", rec.UUID()))
+
+	sess, err := a.buildAgentSession(ctx, cfg, pwd, sessionID, rec, nil)
+	if err != nil {
+		return acp.NewSessionResponse{}, err
+	}
+
+	a.mu.Lock()
+	a.sessions[sessionID] = sess
+	a.mu.Unlock()
+
+	config.Logger().Printf("[acp] Session created: %s", sessionID)
+	return acp.NewSessionResponse{SessionId: sessionID}, nil
+}
+
+// buildAgentSession creates the env, tools, middlewares, and agent shared by
+// NewSession and LoadSession. The caller is responsible for creating the
+// Recorder (so the session ID can be derived from it) and for storing the
+// returned session in a.sessions.
+func (a *acpAgent) buildAgentSession(
+	ctx context.Context,
+	cfg *config.Config,
+	pwd string,
+	sessionID acp.SessionId,
+	rec *session.Recorder,
+	history []*schema.Message,
+) (*acpSession, error) {
 	platform := util.GetSystemInfo()
 	envInfo := util.CollectEnvInfo(pwd)
 
@@ -125,7 +159,7 @@ func (a *acpAgent) NewSession(ctx context.Context, params acp.NewSessionRequest)
 	providers := cfg.GetProviders()
 	providerCfg := providers[providerName]
 	if providerCfg == nil {
-		return acp.NewSessionResponse{}, fmt.Errorf("provider %q not found in config", providerName)
+		return nil, fmt.Errorf("provider %q not found in config", providerName)
 	}
 
 	registry := internalmodel.NewModelRegistry()
@@ -138,7 +172,7 @@ func (a *acpAgent) NewSession(ctx context.Context, params acp.NewSessionRequest)
 		Model: modelName, APIKey: providerCfg.APIKey, BaseURL: baseURL,
 	})
 	if err != nil {
-		return acp.NewSessionResponse{}, fmt.Errorf("error creating model: %w", err)
+		return nil, fmt.Errorf("error creating model: %w", err)
 	}
 
 	env := tools.NewEnv(pwd, platform)
@@ -162,17 +196,12 @@ func (a *acpAgent) NewSession(ctx context.Context, params acp.NewSessionRequest)
 	systemPrompt := prompts.GetSystemPrompt(platform, pwd, "local", envInfo, skillLoader.Descriptions())
 	approvalState := runner.NewApprovalState(pwd, cfg.AutoApprove)
 
-	// Session ID
-	sessionID := acp.SessionId(fmt.Sprintf("sess_%s", generateSessionID()))
-
 	// Create ACPHandler
 	acpHandler := handler.NewACPHandler(a.conn, sessionID)
 	approvalState.SetHandler(acpHandler)
 
-	// Session recorder
-	rec, _ := session.NewRecorder(pwd, providerName, modelName)
-	env.TodoStore.OnUpdate = func(items []tools.TodoItem) {
-		if rec != nil {
+	if rec != nil {
+		env.TodoStore.OnUpdate = func(items []tools.TodoItem) {
 			snapItems := make([]session.TodoSnapshotItem, len(items))
 			for i, it := range items {
 				snapItems[i] = session.TodoSnapshotItem{
@@ -236,7 +265,7 @@ func (a *acpAgent) NewSession(ctx context.Context, params acp.NewSessionRequest)
 
 	ag, err := agent.NewAgent(ctx, chatModel, allTools, systemPrompt, approvalState.RequestApproval, nil, handlers)
 	if err != nil {
-		return acp.NewSessionResponse{}, fmt.Errorf("error creating agent: %w", err)
+		return nil, fmt.Errorf("error creating agent: %w", err)
 	}
 
 	sess := &acpSession{
@@ -247,16 +276,10 @@ func (a *acpAgent) NewSession(ctx context.Context, params acp.NewSessionRequest)
 		rec:           rec,
 		todoStore:     env.TodoStore,
 		tracer:        tracer,
+		history:       history,
 	}
 
-	a.mu.Lock()
-	a.sessions[sessionID] = sess
-	a.mu.Unlock()
-
-	config.Logger().Printf("[acp] Session created: %s", sessionID)
-	return acp.NewSessionResponse{
-		SessionId: sessionID,
-	}, nil
+	return sess, nil
 }
 
 func (a *acpAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
@@ -337,7 +360,54 @@ func (a *acpAgent) SetSessionMode(_ context.Context, params acp.SetSessionModeRe
 	return acp.SetSessionModeResponse{}, nil
 }
 
-func generateSessionID() string {
-	id, _ := os.Hostname()
-	return fmt.Sprintf("%s_%d", id, os.Getpid())
+func (a *acpAgent) LoadSession(ctx context.Context, params acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
+	config.Logger().Printf("[acp] LoadSession: sessionId=%s", params.SessionId)
+
+	// Extract the internal session UUID from the ACP session ID.
+	resumeUUID := strings.TrimPrefix(string(params.SessionId), "sess_")
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return acp.LoadSessionResponse{}, fmt.Errorf("config error: %w", err)
+	}
+
+	// Load session history from disk.
+	entries, err := session.LoadSession(resumeUUID)
+	if err != nil {
+		return acp.LoadSessionResponse{}, fmt.Errorf("failed to load session: %w", err)
+	}
+
+	pwd := params.Cwd
+	if pwd == "" {
+		pwd = util.GetWorkDir()
+	}
+
+	providerName, modelName := cfg.GetProviderModel()
+	rec, _ := session.NewRecorder(pwd, providerName, modelName)
+	if rec != nil {
+		rec.SetUUID(resumeUUID)
+	}
+
+	// Convert entries to message history.
+	history := make([]*schema.Message, 0, len(entries))
+	for _, entry := range entries {
+		switch entry.Type {
+		case session.EntryUser:
+			history = append(history, &schema.Message{Role: "user", Content: entry.Content})
+		case session.EntryAssistant:
+			history = append(history, &schema.Message{Role: "assistant", Content: entry.Content})
+		}
+	}
+
+	sess, err := a.buildAgentSession(ctx, cfg, pwd, params.SessionId, rec, history)
+	if err != nil {
+		return acp.LoadSessionResponse{}, err
+	}
+
+	a.mu.Lock()
+	a.sessions[params.SessionId] = sess
+	a.mu.Unlock()
+
+	config.Logger().Printf("[acp] Session loaded: %s, messages=%d", params.SessionId, len(sess.history))
+	return acp.LoadSessionResponse{}, nil
 }

--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -1048,6 +1048,11 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 		if targetEnv := resumeState.EnvTarget; targetEnv != "local" {
 			st.sessionResumeWarning = st.attemptSSHResume(targetEnv)
 		}
+
+		// Reuse the existing session UUID so new messages are appended to the same file
+		if st.rec != nil {
+			st.rec.SetUUID(resumeUUID)
+		}
 	}
 
 	// Capture a git baseline so the exit summary only shows changes from this session.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -128,9 +128,31 @@ func NewRecorder(project, provider, model string) (*Recorder, error) {
 // UUID returns the session identifier.
 func (r *Recorder) UUID() string { return r.uuid }
 
+// ValidateSessionID checks that a session ID is safe for use as a filename.
+// It rejects empty IDs, path traversal sequences, and path separators.
+func ValidateSessionID(id string) error {
+	if id == "" {
+		return fmt.Errorf("session ID must not be empty")
+	}
+	if id == "." || id == ".." {
+		return fmt.Errorf("invalid session ID: %q", id)
+	}
+	if strings.ContainsAny(id, "/\\" ) {
+		return fmt.Errorf("session ID must not contain path separators: %q", id)
+	}
+	if strings.Contains(id, "..") {
+		return fmt.Errorf("session ID must not contain path traversal: %q", id)
+	}
+	return nil
+}
+
 // SetUUID overrides the session identifier. Used when resuming an existing session
 // so that new messages are appended to the same session file.
 func (r *Recorder) SetUUID(id string) {
+	if err := ValidateSessionID(id); err != nil {
+		config.Logger().Printf("[session] SetUUID rejected: %v", err)
+		return
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.uuid = id
@@ -452,6 +474,9 @@ func ListSessions(project string) ([]SessionMeta, error) {
 
 // LoadSession reads all entries from a session JSONL file identified by uuid.
 func LoadSession(id string) ([]Entry, error) {
+	if err := ValidateSessionID(id); err != nil {
+		return nil, err
+	}
 	dir, err := config.SessionsDir()
 	if err != nil {
 		return nil, err

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -137,7 +137,7 @@ func ValidateSessionID(id string) error {
 	if id == "." || id == ".." {
 		return fmt.Errorf("invalid session ID: %q", id)
 	}
-	if strings.ContainsAny(id, "/\\" ) {
+	if strings.ContainsAny(id, "/\\") {
 		return fmt.Errorf("session ID must not contain path separators: %q", id)
 	}
 	if strings.Contains(id, "..") {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -107,6 +107,9 @@ type Recorder struct {
 	// Per-teammate fields (empty for leader recorder).
 	customDir string // leader UUID for subagent path
 	agentID   string // teammate agent ID
+	// resuming is true when loading an existing session via --resume.
+	// In this mode, ensureFile opens the existing file for append instead of creating new.
+	resuming bool
 }
 
 // NewRecorder returns a Recorder that will create the session file only when
@@ -124,6 +127,21 @@ func NewRecorder(project, provider, model string) (*Recorder, error) {
 
 // UUID returns the session identifier.
 func (r *Recorder) UUID() string { return r.uuid }
+
+// SetUUID overrides the session identifier. Used when resuming an existing session
+// so that new messages are appended to the same session file.
+func (r *Recorder) SetUUID(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.uuid = id
+	r.resuming = true
+	// If a file was already opened with the old UUID, close it so the next
+	// write opens the correct file for append.
+	if r.file != nil {
+		_ = r.file.Close()
+		r.file = nil
+	}
+}
 
 // HasRecording reports whether any message has been recorded (i.e. the
 // session file has been created).  Returns false for sessions where the
@@ -259,6 +277,16 @@ func (r *Recorder) ensureFile() error {
 			return fmt.Errorf("create sessions dir: %w", err)
 		}
 		filePath = filepath.Join(dir, r.uuid+".json")
+	}
+
+	// When resuming an existing session, open the file for append instead of creating new.
+	if r.resuming {
+		f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			return fmt.Errorf("open session file for append: %w", err)
+		}
+		r.file = f
+		return nil
 	}
 
 	f, err := os.Create(filePath)

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -84,8 +84,32 @@ type SessionEntry struct {
 	Args         string
 	Output       string
 	Error        string
+	ToolCallID   string
 	SubagentName string
 	SubagentType string
+
+	// Plan fields
+	PlanStatus  string
+	PlanTitle   string
+	PlanContent string
+	Feedback    string
+
+	// Todo fields
+	Todos []TodoSnapshotItem
+
+	// Mode change
+	Mode string
+
+	// Compact fields
+	Summary    string
+	CompactedN int
+}
+
+// TodoSnapshotItem mirrors session.TodoSnapshotItem for TUI display.
+type TodoSnapshotItem struct {
+	ID     int    `json:"id"`
+	Title  string `json:"title"`
+	Status string `json:"status"`
 }
 
 // SessionResumedMsg is sent by the main goroutine to replay a session in the TUI.

--- a/internal/tui/session_helper.go
+++ b/internal/tui/session_helper.go
@@ -10,6 +10,20 @@ func ConvertSessionEntries(entries []session.Entry) []SessionEntry {
 		if e.Type == session.EntrySessionStart {
 			continue
 		}
+
+		// Convert todos
+		var todos []TodoSnapshotItem
+		if len(e.Todos) > 0 {
+			todos = make([]TodoSnapshotItem, len(e.Todos))
+			for i, t := range e.Todos {
+				todos[i] = TodoSnapshotItem{
+					ID:     t.ID,
+					Title:  t.Title,
+					Status: t.Status,
+				}
+			}
+		}
+
 		result = append(result, SessionEntry{
 			Type:         string(e.Type),
 			Content:      e.Content,
@@ -17,8 +31,21 @@ func ConvertSessionEntries(entries []session.Entry) []SessionEntry {
 			Args:         e.Args,
 			Output:       e.Output,
 			Error:        e.Error,
+			ToolCallID:   e.ToolCallID,
 			SubagentName: e.SubagentName,
 			SubagentType: e.SubagentType,
+			// Plan fields
+			PlanStatus:  e.PlanStatus,
+			PlanTitle:   e.PlanTitle,
+			PlanContent: e.PlanContent,
+			Feedback:    e.Feedback,
+			// Todo fields
+			Todos: todos,
+			// Mode change
+			Mode: e.Mode,
+			// Compact fields
+			Summary:    e.Summary,
+			CompactedN: e.CompactedN,
 		})
 	}
 	return result

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1540,12 +1540,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 					m.lines = append(m.lines, rendered)
 				}
 			case string(session.EntryToolCall):
-				icon := toolIconSuccess
-				if e.Error != "" {
-					icon = toolIconError
-				}
+				// Tool calls always show running icon (they don't have error status yet)
 				m.lines = append(m.lines, fmt.Sprintf("  %s %s %s",
-					icon,
+					toolIconRunning,
 					toolNameStyle.Render(e.Name),
 					toolArgsStyle.Render(truncate(sanitize(e.Args), 100)),
 				))
@@ -1575,6 +1572,42 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 						toolSuccessStyle.Render("✓ Subagent Done:"),
 						toolResultStyle.Render(truncate(sanitize(e.Output), maxToolOutputLen))))
 				}
+			case string(session.EntryPlanUpdate):
+				statusIcon := "📝"
+				switch e.PlanStatus {
+				case "approved":
+					statusIcon = "✅"
+				case "rejected":
+					statusIcon = "❌"
+				case "submitted":
+					statusIcon = "📤"
+				}
+				m.lines = append(m.lines, fmt.Sprintf("  %s Plan %s: %s",
+					toolLabelStyle.Render(statusIcon),
+					toolNameStyle.Render(e.PlanStatus),
+					toolArgsStyle.Render(e.PlanTitle)))
+			case string(session.EntryTodoSnapshot):
+				if len(e.Todos) > 0 {
+					m.lines = append(m.lines, toolLabelStyle.Render("  📋 Todo List:"))
+					for _, t := range e.Todos {
+						statusIcon := "⬜"
+						if t.Status == "completed" || t.Status == "done" {
+							statusIcon = "✅"
+						}
+						m.lines = append(m.lines, fmt.Sprintf("     %s %d: %s",
+							statusIcon, t.ID, t.Title))
+					}
+				}
+			case string(session.EntryModeChange):
+				m.lines = append(m.lines, fmt.Sprintf("  %s Mode changed to: %s",
+					toolLabelStyle.Render("🔄"),
+					toolNameStyle.Render(e.Mode)))
+			case string(session.EntryCompact):
+				m.lines = append(m.lines, fmt.Sprintf("  %s Context compacted: %d messages summarized",
+					toolSuccessStyle.Render("✓"),
+					e.CompactedN))
+			case string(session.EntryBudgetWarning):
+				m.lines = append(m.lines, toolErrorStyle.Render("  ⚠️ Budget warning"))
 			}
 		}
 		m.lines = append(m.lines, "")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -463,24 +463,32 @@ func (s *Server) handleNewSession(w http.ResponseWriter, r *http.Request) {
 	if req.SessionID != "" {
 		// Resuming: load prior conversation into history so the agent has context.
 		entries, _ := session.LoadSession(req.SessionID)
-		s.history = nil
-		for _, e := range entries {
-			switch e.Type {
-			case session.EntryUser:
-				s.history = append(s.history, schema.UserMessage(e.Content))
-			case session.EntryAssistant:
-				s.history = append(s.history, &schema.Message{Role: schema.Assistant, Content: e.Content})
+		// Reconstruct full message history (including tool calls/results).
+		s.history = session.ReconstructHistory(entries)
+		// Restore todos from the last snapshot in the session.
+		if s.todoStore != nil {
+			var lastTodos []session.TodoSnapshotItem
+			for _, e := range entries {
+				if e.Type == session.EntryTodoSnapshot {
+					lastTodos = e.Todos
+				}
+			}
+			if len(lastTodos) > 0 {
+				items := make([]tools.TodoItem, len(lastTodos))
+				for i, t := range lastTodos {
+					items[i] = tools.TodoItem{ID: t.ID, Title: t.Title, Status: tools.TodoStatus(t.Status)}
+				}
+				s.todoStore.Update(items)
 			}
 		}
 	} else {
 		s.history = nil
+		// Reset todos.
+		if s.todoStore != nil {
+			s.todoStore.Update(nil)
+		}
 	}
 	s.mu.Unlock()
-
-	// Reset todos.
-	if s.todoStore != nil {
-		s.todoStore.Update(nil)
-	}
 
 	// Notify clients. When resuming an existing session, do NOT broadcast session_reset
 	// (which would wipe the UI that the frontend is about to repopulate from history).

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -437,15 +437,44 @@ func (s *Server) handleNewSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Parse optional request body for resume session ID.
+	var req struct {
+		SessionID string `json:"session_id,omitempty"`
+	}
+	_ = json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req)
+
 	// Close the old recorder.
 	if s.recorder != nil {
 		s.recorder.Close()
 		s.recorder = nil
 	}
 
-	// Reset conversation history.
+	// Create new recorder.
+	rec, _ := session.NewRecorder(s.pwd, s.providerName, s.modelName)
+	if rec != nil {
+		// If resuming an existing session, use its UUID.
+		if req.SessionID != "" {
+			rec.SetUUID(req.SessionID)
+		}
+		s.recorder = rec
+	}
+
 	s.mu.Lock()
-	s.history = nil
+	if req.SessionID != "" {
+		// Resuming: load prior conversation into history so the agent has context.
+		entries, _ := session.LoadSession(req.SessionID)
+		s.history = nil
+		for _, e := range entries {
+			switch e.Type {
+			case session.EntryUser:
+				s.history = append(s.history, schema.UserMessage(e.Content))
+			case session.EntryAssistant:
+				s.history = append(s.history, &schema.Message{Role: schema.Assistant, Content: e.Content})
+			}
+		}
+	} else {
+		s.history = nil
+	}
 	s.mu.Unlock()
 
 	// Reset todos.
@@ -453,9 +482,12 @@ func (s *Server) handleNewSession(w http.ResponseWriter, r *http.Request) {
 		s.todoStore.Update(nil)
 	}
 
-	// Notify clients.
-	s.broker.Broadcast(SSEEvent{Event: "session_reset", Data: map[string]string{}})
-	s.wsBroker.Broadcast(WSEvent{Type: "session_reset", Data: map[string]string{}})
+	// Notify clients. When resuming an existing session, do NOT broadcast session_reset
+	// (which would wipe the UI that the frontend is about to repopulate from history).
+	if req.SessionID == "" {
+		s.broker.Broadcast(SSEEvent{Event: "session_reset", Data: map[string]string{}})
+		s.wsBroker.Broadcast(WSEvent{Type: "session_reset", Data: map[string]string{}})
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status": "ok",

--- a/web/src/composables/api.ts
+++ b/web/src/composables/api.ts
@@ -38,7 +38,11 @@ export const api = {
   session: (id: string) => request<SessionEntry[]>(`/api/sessions/${encodeURIComponent(id)}`),
   deleteSession: (id: string) =>
     request<{ status: string }>(`/api/sessions/${encodeURIComponent(id)}`, { method: 'DELETE' }),
-  newSession: () => request<{ status: string; session_id: string }>('/api/sessions', { method: 'POST' }),
+  newSession: (sessionId?: string) =>
+    request<{ status: string; session_id: string }>('/api/sessions', {
+      method: 'POST',
+      body: sessionId ? JSON.stringify({ session_id: sessionId }) : undefined,
+    }),
   files: (path?: string) => {
     const q = path ? `?path=${encodeURIComponent(path)}` : ''
     return request<FileItem[]>(`/api/files${q}`)

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -376,7 +376,12 @@ export const useChatStore = defineStore('chat', () => {
   async function loadSession(uuid: string) {
     try {
       const entries = await api.session(uuid)
+
+      // Notify backend to switch to this session (resume) before clearing UI.
+      await api.newSession(uuid)
+
       clearChat()
+
       // Track pending tool calls by tool_call_id so we can match results
       const pendingToolCalls = new Map<string, ToolCall>()
       for (const e of entries) {


### PR DESCRIPTION
- ACP: derive session ID from recorder UUID (sess_{uuid}) instead of hostname_pid, eliminating duplicates across restarts
- ACP: extract buildAgentSession() shared by NewSession and LoadSession; implement LoadSession handler and advertise LoadSession capability
- session: add SetUUID() / resuming flag so resumed recorders append to the existing JSONL file instead of creating a new one
- interactive (TUI): call rec.SetUUID(resumeUUID) so TUI resume also appends to the correct file
- web: on resume (session_id provided), load prior history into s.history so the agent keeps conversation context; skip session_reset broadcast to prevent the WS event from wiping the UI after history is rendered
- tui: forward all entry types (plan, todo, mode, compact, budget) when replaying a resumed session; use toolIconRunning for tool_call replay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume and restore previous sessions (client-provided session ID) with full history and todo state restored.
  * Client API accepts optional session ID when creating sessions.

* **UI**
  * Session view enhanced with plan updates, todo snapshots, mode-change lines, compacted-context summaries, and budget warnings.
  * Tool-call entries now render consistently during resume.

* **Bug Fixes**
  * Session recorder now preserves correct session identifiers when resuming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->