### PR TITLE
feat: refine tool display, session UX, and UI polish

### DIFF
--- a/internal/handler/tui.go
+++ b/internal/handler/tui.go
@@ -33,7 +33,13 @@ func (h *TUIHandler) OnAgentText(text string) {
 }
 
 func (h *TUIHandler) OnToolCall(name, args, _ string) {
-	h.p.Send(tui.ToolCallMsg{Name: name, Args: args})
+	info := extractToolDisplayInfo(name, args)
+	h.p.Send(tui.ToolCallMsg{
+		Name:     name,
+		Args:     args,
+		Title:    info.Title,
+		Subtitle: info.Subtitle,
+	})
 }
 
 func (h *TUIHandler) OnToolResult(name, output, _ string, err error) {

--- a/internal/handler/web.go
+++ b/internal/handler/web.go
@@ -156,13 +156,11 @@ func cleanToolOutput(name, output string) string {
 	}
 	lines := strings.Split(output, "\n")
 	var clean []string
-	skipPrefixes := true
 	for _, line := range lines {
-		// Skip STDOUT:/STDERR: header lines
-		if skipPrefixes && (line == "STDOUT:" || line == "STDERR:") {
+		// Skip STDOUT:/STDERR: header lines anywhere in output
+		if line == "STDOUT:" || line == "STDERR:" {
 			continue
 		}
-		skipPrefixes = false
 		// Skip metadata lines at the end
 		if strings.HasPrefix(line, "[Exit code:") ||
 			strings.HasPrefix(line, "[Completed in") ||

--- a/internal/handler/web.go
+++ b/internal/handler/web.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -20,17 +21,174 @@ type WebTextData struct {
 
 // WebToolCallData carries tool invocation info.
 type WebToolCallData struct {
-	Name       string `json:"name"`
-	Args       string `json:"args"`
-	ToolCallID string `json:"tool_call_id,omitempty"`
+	Name        string           `json:"name"`
+	Args        string           `json:"args"`
+	ToolCallID  string           `json:"tool_call_id,omitempty"`
+	DisplayInfo *ToolDisplayInfo `json:"display_info,omitempty"`
+}
+
+// ToolDisplayInfo carries human-readable tool metadata for UI rendering.
+type ToolDisplayInfo struct {
+	Title    string `json:"title"`              // Human-readable tool name (e.g. "Read", "Edit", "Shell")
+	Subtitle string `json:"subtitle,omitempty"` // Context info (file path, command description, pattern)
+	Icon     string `json:"icon,omitempty"`     // Icon identifier
+	Category string `json:"category,omitempty"` // "context" (read-only), "mutation", "execution"
+}
+
+// extractToolDisplayInfo extracts display metadata from tool name and args.
+func extractToolDisplayInfo(name, argsJSON string) *ToolDisplayInfo {
+	info := &ToolDisplayInfo{}
+
+	// Parse args to extract contextual info
+	var args map[string]interface{}
+	_ = json.Unmarshal([]byte(argsJSON), &args)
+
+	getString := func(key string) string {
+		if v, ok := args[key]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+		return ""
+	}
+
+	switch name {
+	case "read":
+		info.Title = "Read"
+		info.Icon = "file"
+		info.Category = "context"
+		info.Subtitle = shortenPath(getString("file_path"))
+	case "write":
+		info.Title = "Write"
+		info.Icon = "file-edit"
+		info.Category = "mutation"
+		info.Subtitle = shortenPath(getString("file_path"))
+	case "edit":
+		info.Title = "Edit"
+		info.Icon = "file-edit"
+		info.Category = "mutation"
+		info.Subtitle = shortenPath(getString("file_path"))
+	case "multi_edit":
+		info.Title = "Multi Edit"
+		info.Icon = "file-edit"
+		info.Category = "mutation"
+		info.Subtitle = shortenPath(getString("file_path"))
+	case "glob":
+		info.Title = "Glob"
+		info.Icon = "search"
+		info.Category = "context"
+		info.Subtitle = getString("pattern")
+	case "grep":
+		info.Title = "Search"
+		info.Icon = "search"
+		info.Category = "context"
+		info.Subtitle = getString("pattern")
+	case "execute":
+		info.Title = "Shell"
+		info.Icon = "terminal"
+		info.Category = "execution"
+		info.Subtitle = getString("description")
+		if info.Subtitle == "" {
+			cmd := getString("command")
+			if len(cmd) > 100 {
+				cmd = cmd[:100] + "…"
+			}
+			info.Subtitle = cmd
+		}
+	case "background":
+		info.Title = "Background"
+		info.Icon = "terminal"
+		info.Category = "execution"
+		info.Subtitle = getString("description")
+	case "todowrite":
+		info.Title = "Update Todos"
+		info.Icon = "checklist"
+		info.Category = "mutation"
+	case "todoread":
+		info.Title = "Read Todos"
+		info.Icon = "checklist"
+		info.Category = "context"
+	case "subagent":
+		info.Title = "Subagent"
+		info.Icon = "agent"
+		info.Category = "execution"
+		info.Subtitle = getString("description")
+		if info.Subtitle == "" {
+			info.Subtitle = getString("name")
+		}
+	case "ask_user":
+		info.Title = "Ask User"
+		info.Icon = "question"
+		info.Category = "context"
+		info.Subtitle = getString("question")
+		if len(info.Subtitle) > 60 {
+			info.Subtitle = info.Subtitle[:60] + "…"
+		}
+	default:
+		// MCP or unknown tools
+		info.Title = name
+		info.Icon = "tool"
+		info.Category = ""
+	}
+
+	return info
+}
+
+// shortenPath returns the last 2 path components for display.
+func shortenPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	// Handle both / and \ separators
+	parts := strings.Split(strings.ReplaceAll(path, "\\", "/"), "/")
+	if len(parts) <= 2 {
+		return path
+	}
+	return "…/" + strings.Join(parts[len(parts)-2:], "/")
+}
+
+// cleanToolOutput strips AI-oriented metadata from tool output for UI display.
+// For execute tools: removes STDOUT:/STDERR: prefixes, [Exit code], [Completed], [Hint] lines.
+// Returns empty string if no cleaning is needed (frontend will use raw output).
+func cleanToolOutput(name, output string) string {
+	if name != "execute" {
+		return ""
+	}
+	lines := strings.Split(output, "\n")
+	var clean []string
+	skipPrefixes := true
+	for _, line := range lines {
+		// Skip STDOUT:/STDERR: header lines
+		if skipPrefixes && (line == "STDOUT:" || line == "STDERR:") {
+			continue
+		}
+		skipPrefixes = false
+		// Skip metadata lines at the end
+		if strings.HasPrefix(line, "[Exit code:") ||
+			strings.HasPrefix(line, "[Completed in") ||
+			strings.HasPrefix(line, "[Hint:") {
+			continue
+		}
+		clean = append(clean, line)
+	}
+	// Trim trailing empty lines
+	for len(clean) > 0 && strings.TrimSpace(clean[len(clean)-1]) == "" {
+		clean = clean[:len(clean)-1]
+	}
+	result := strings.Join(clean, "\n")
+	if result == output {
+		return "" // no change, don't send duplicate
+	}
+	return result
 }
 
 // WebToolResultData carries tool completion info.
 type WebToolResultData struct {
-	Name       string `json:"name"`
-	Output     string `json:"output"`
-	Error      string `json:"error,omitempty"`
-	ToolCallID string `json:"tool_call_id,omitempty"`
+	Name          string `json:"name"`
+	Output        string `json:"output"`
+	DisplayOutput string `json:"display_output,omitempty"` // clean output for UI display
+	Error         string `json:"error,omitempty"`
+	ToolCallID    string `json:"tool_call_id,omitempty"`
 }
 
 // WebTokenData carries token usage.
@@ -112,7 +270,12 @@ func (h *WebHandler) OnAgentText(text string) {
 }
 
 func (h *WebHandler) OnToolCall(name, args, toolCallID string) {
-	h.emit("tool_call", WebToolCallData{Name: name, Args: args, ToolCallID: toolCallID})
+	h.emit("tool_call", WebToolCallData{
+		Name:        name,
+		Args:        args,
+		ToolCallID:  toolCallID,
+		DisplayInfo: extractToolDisplayInfo(name, args),
+	})
 }
 
 func (h *WebHandler) OnToolResult(name, output, toolCallID string, err error) {
@@ -120,7 +283,14 @@ func (h *WebHandler) OnToolResult(name, output, toolCallID string, err error) {
 	if err != nil {
 		errMsg = err.Error()
 	}
-	h.emit("tool_result", WebToolResultData{Name: name, Output: output, ToolCallID: toolCallID, Error: errMsg})
+	display := cleanToolOutput(name, output)
+	h.emit("tool_result", WebToolResultData{
+		Name:          name,
+		Output:        output,
+		DisplayOutput: display,
+		ToolCallID:    toolCallID,
+		Error:         errMsg,
+	})
 }
 
 func (h *WebHandler) OnTodoUpdate() {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -85,6 +85,7 @@ type SessionMeta struct {
 	Provider  string `json:"provider"`
 	Model     string `json:"model"`
 	StartTime string `json:"start_time"` // RFC3339
+	Title     string `json:"title,omitempty"`
 }
 
 // sessionIndex is the on-disk structure of session.json.
@@ -110,6 +111,7 @@ type Recorder struct {
 	// resuming is true when loading an existing session via --resume.
 	// In this mode, ensureFile opens the existing file for append instead of creating new.
 	resuming bool
+	title    string
 }
 
 // NewRecorder returns a Recorder that will create the session file only when
@@ -175,8 +177,19 @@ func (r *Recorder) HasRecording() bool {
 }
 
 // RecordUser appends a user message entry.
+// On the first user message, the title is auto-generated from the content.
 func (r *Recorder) RecordUser(content string) {
+	r.mu.Lock()
+	needsTitle := r.file == nil && !r.resuming
+	r.mu.Unlock()
 	_ = r.writeEntry(Entry{Type: EntryUser, Content: content})
+	if needsTitle {
+		title := generateTitle(content)
+		r.mu.Lock()
+		r.title = title
+		r.mu.Unlock()
+		_ = updateIndexTitle(r.project, r.uuid, title)
+	}
 }
 
 // RecordAssistant appends an assistant message entry.
@@ -392,6 +405,59 @@ func addToIndex(project string, meta SessionMeta) error {
 	}
 	// Atomic write: write to temp file then rename to prevent corruption
 	// from concurrent writes or interrupted I/O.
+	tmpPath := indexPath + ".tmp"
+	if err := os.WriteFile(tmpPath, newData, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, indexPath)
+}
+
+// generateTitle creates a human-readable session title from the first user message.
+// It truncates to a reasonable length and strips newlines.
+func generateTitle(content string) string {
+	// Take first line only
+	title := content
+	if idx := strings.IndexAny(title, "\n\r"); idx >= 0 {
+		title = title[:idx]
+	}
+	title = strings.TrimSpace(title)
+	if len(title) == 0 {
+		return "New session"
+	}
+	// Truncate to 80 chars
+	runes := []rune(title)
+	if len(runes) > 80 {
+		title = string(runes[:80]) + "…"
+	}
+	return title
+}
+
+// updateIndexTitle updates the title of a session in the shared index file.
+func updateIndexTitle(project, uuid, title string) error {
+	indexPath, err := config.SessionsIndexPath()
+	if err != nil {
+		return err
+	}
+	data, readErr := os.ReadFile(indexPath)
+	if readErr != nil {
+		return readErr
+	}
+	var idx sessionIndex
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return err
+	}
+	metas := idx.Sessions[project]
+	for i := range metas {
+		if metas[i].UUID == uuid {
+			metas[i].Title = title
+			break
+		}
+	}
+	idx.Sessions[project] = metas
+	newData, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return err
+	}
 	tmpPath := indexPath + ".tmp"
 	if err := os.WriteFile(tmpPath, newData, 0644); err != nil {
 		return err

--- a/internal/tools/execute.go
+++ b/internal/tools/execute.go
@@ -34,9 +34,10 @@ const (
 )
 
 type ExecuteInput struct {
-	Command    string `json:"command"`
-	Timeout    int    `json:"timeout,omitempty"`    // milliseconds
-	Background bool   `json:"background,omitempty"` // run in background
+	Command     string `json:"command"`
+	Timeout     int    `json:"timeout,omitempty"`     // milliseconds
+	Background  bool   `json:"background,omitempty"`  // run in background
+	Description string `json:"description,omitempty"` // short human-readable description
 }
 
 func (e *Env) NewExecuteTool(bm *BackgroundManager) tool.InvokableTool {
@@ -61,6 +62,15 @@ func (e *Env) NewExecuteTool(bm *BackgroundManager) tool.InvokableTool {
 				Type:     schema.Boolean,
 				Desc:     "If true, run the command in the background and return immediately with a task ID. Default is false.",
 				Required: false,
+			},
+			"description": {
+				Type: schema.String,
+				Desc: "Clear, concise description of what this command does in 5-10 words. Examples:\n" +
+					"Input: ls\nOutput: Lists files in current directory\n" +
+					"Input: git status\nOutput: Shows working tree status\n" +
+					"Input: npm install\nOutput: Installs package dependencies\n" +
+					"Input: mkdir foo\nOutput: Creates directory 'foo'",
+				Required: true,
 			},
 		}),
 	}

--- a/internal/tools/execute.go
+++ b/internal/tools/execute.go
@@ -70,7 +70,7 @@ func (e *Env) NewExecuteTool(bm *BackgroundManager) tool.InvokableTool {
 					"Input: git status\nOutput: Shows working tree status\n" +
 					"Input: npm install\nOutput: Installs package dependencies\n" +
 					"Input: mkdir foo\nOutput: Creates directory 'foo'",
-				Required: true,
+				Required: false,
 			},
 		}),
 	}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -58,7 +58,12 @@ func GetApprovalChannel() chan ToolApprovalRequestMsg {
 // --- Messages ---
 
 type AgentTextMsg struct{ Text string }
-type ToolCallMsg struct{ Name, Args string }
+type ToolCallMsg struct {
+	Name     string
+	Args     string
+	Title    string // human-readable tool name (e.g. "Read", "Shell")
+	Subtitle string // context info (file path, description)
+}
 type ToolResultMsg struct {
 	Name, Output string
 	Err          error

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -216,9 +216,17 @@ func (i sessionListItem) Title() string {
 	if len(ts) >= 16 {
 		ts = ts[:16]
 	}
+	if i.meta.Title != "" {
+		return fmt.Sprintf("%s  %s", ts, i.meta.Title)
+	}
 	return fmt.Sprintf("%s  %s / %s", ts, i.meta.Provider, i.meta.Model)
 }
-func (i sessionListItem) Description() string { return i.meta.UUID }
+func (i sessionListItem) Description() string {
+	if i.meta.Title != "" {
+		return fmt.Sprintf("%s / %s  %s", i.meta.Provider, i.meta.Model, i.meta.UUID[:8])
+	}
+	return i.meta.UUID
+}
 func (i sessionListItem) FilterValue() string { return i.meta.StartTime + i.meta.UUID }
 
 // sshAliasItem for the SSH alias picker
@@ -1700,12 +1708,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 		m.thinking = true
 		m.flushText()
 		m.pendingTool = msg.Name
-		argsDisplay := formatToolArgs(msg.Args)
-		// Tool call header with status icon
-		m.lines = append(m.lines, fmt.Sprintf("  %s %s %s",
+		// Use display info if available, fall back to raw args
+		displayLabel := msg.Name
+		if msg.Title != "" {
+			displayLabel = msg.Title
+		}
+		subtitlePart := ""
+		if msg.Subtitle != "" {
+			subtitlePart = " " + toolArgsStyle.Render(msg.Subtitle)
+		} else {
+			argsDisplay := formatToolArgs(msg.Args)
+			if argsDisplay != "" {
+				subtitlePart = " " + toolArgsStyle.Render(argsDisplay)
+			}
+		}
+		m.lines = append(m.lines, fmt.Sprintf("  %s %s%s",
 			toolIconRunning,
-			toolNameStyle.Render(msg.Name),
-			toolArgsStyle.Render(argsDisplay),
+			toolNameStyle.Render(displayLabel),
+			subtitlePart,
 		))
 		m.refreshViewport()
 		cmds = append(cmds, m.spinner.Tick)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -83,6 +83,10 @@ type Server struct {
 	// disabledMCP tracks MCP servers that have been disabled via the UI.
 	disabledMCP map[string]bool
 
+	// sessionSnapshot holds the git tree hash at the start of an agent run,
+	// used to compute session-scoped diffs (agent changes only).
+	sessionSnapshot string
+
 	// wechatClient is the optional WeChat channel client.
 	wechatClient channel.Channel
 
@@ -372,6 +376,10 @@ func (s *Server) submitMessage(message, mode, source string) {
 			s.runCancel = nil
 			s.mu.Unlock()
 		}()
+
+		// Take a git snapshot before the agent run for session diff tracking.
+		s.takeSessionSnapshot()
+
 		resp := runner.Run(runCtx, agent, history, s.eventHandler, s.recorder, s.todoStore, s.tracer, nil)
 		if resp != "" {
 			s.mu.Lock()
@@ -393,6 +401,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 		CreatedAt string `json:"created_at"`
 		Provider  string `json:"provider"`
 		Model     string `json:"model"`
+		Title     string `json:"title,omitempty"`
 	}
 
 	items := make([]sessionItem, 0, len(metas))
@@ -402,6 +411,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 			CreatedAt: m.StartTime,
 			Provider:  m.Provider,
 			Model:     m.Model,
+			Title:     m.Title,
 		})
 	}
 	writeJSON(w, http.StatusOK, items)
@@ -579,15 +589,8 @@ func (s *Server) handleSwitchModel(w http.ResponseWriter, r *http.Request) {
 	s.agent = ag
 	s.providerName = req.Provider
 	s.modelName = req.Model
-	s.history = nil // reset history on model change
+	// Keep history — allow continuing the conversation with a different model.
 	s.mu.Unlock()
-
-	// Reset recorder for new model.
-	if s.recorder != nil {
-		s.recorder.Close()
-	}
-	rec, _ := session.NewRecorder(s.pwd, req.Provider, req.Model)
-	s.recorder = rec
 
 	// Notify clients.
 	s.broker.Broadcast(SSEEvent{Event: "model_changed", Data: map[string]string{
@@ -796,6 +799,12 @@ func (s *Server) handleDiff(w http.ResponseWriter, r *http.Request) {
 		mode = "working"
 	}
 
+	// "session" mode: diff between snapshot taken at agent run start and current state.
+	if mode == "session" {
+		s.handleSessionDiff(w, r)
+		return
+	}
+
 	var args []string
 	switch mode {
 	case "staged":
@@ -910,6 +919,77 @@ func countDiffLines(patch string) (adds, dels int) {
 		}
 	}
 	return
+}
+
+// takeSessionSnapshot records the current git working tree state
+// so that session-scoped diffs can be computed later.
+func (s *Server) takeSessionSnapshot() {
+	// Use "git stash create" to get a tree-ish of the current state without
+	// actually stashing. If there are no changes, use HEAD.
+	cmd := exec.CommandContext(s.ctx, "git", "stash", "create")
+	cmd.Dir = s.pwd
+	out, err := cmd.Output()
+	snapshot := strings.TrimSpace(string(out))
+	if err != nil || snapshot == "" {
+		// No local changes — use HEAD as baseline
+		cmd2 := exec.CommandContext(s.ctx, "git", "rev-parse", "HEAD")
+		cmd2.Dir = s.pwd
+		out2, _ := cmd2.Output()
+		snapshot = strings.TrimSpace(string(out2))
+	}
+	s.mu.Lock()
+	s.sessionSnapshot = snapshot
+	s.mu.Unlock()
+}
+
+// handleSessionDiff computes the diff between the session start snapshot and current state.
+func (s *Server) handleSessionDiff(w http.ResponseWriter, _ *http.Request) {
+	s.mu.RLock()
+	snapshot := s.sessionSnapshot
+	s.mu.RUnlock()
+
+	type diffEntry struct {
+		File      string `json:"file"`
+		Patch     string `json:"patch"`
+		Additions int    `json:"additions"`
+		Deletions int    `json:"deletions"`
+		Status    string `json:"status"`
+	}
+
+	if snapshot == "" {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"mode":    "session",
+			"entries": []diffEntry{},
+		})
+		return
+	}
+
+	// Diff from snapshot to current working tree
+	cmd := exec.CommandContext(s.ctx, "git", "diff", snapshot, "--no-color")
+	cmd.Dir = s.pwd
+	output, _ := cmd.CombinedOutput()
+
+	var entries []diffEntry
+	sections := splitDiffByFile(string(output))
+	for _, sec := range sections {
+		adds, dels := countDiffLines(sec.patch)
+		entries = append(entries, diffEntry{
+			File:      sec.file,
+			Patch:     sec.patch,
+			Additions: adds,
+			Deletions: dels,
+			Status:    sec.status,
+		})
+	}
+
+	if entries == nil {
+		entries = []diffEntry{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"mode":    "session",
+		"entries": entries,
+	})
 }
 
 func (s *Server) handleListMCP(w http.ResponseWriter, r *http.Request) {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -55,8 +55,8 @@ function scrollToBottom(smooth = true) {
 const { connected } = useWebSocket({
   onAgentStart: () => { store.isRunning = true },
   onAgentText: (data) => store.appendAgentText(data.text),
-  onToolCall: (data) => store.addToolCall(data.name, data.args, data.tool_call_id),
-  onToolResult: (data) => store.resolveToolCall(data.name, data.output, data.tool_call_id, data.error),
+  onToolCall: (data) => store.addToolCall(data.name, data.args, data.tool_call_id, data.display_info),
+  onToolResult: (data) => store.resolveToolCall(data.name, data.output, data.tool_call_id, data.error, data.display_output),
   onTokenUpdate: (data) => { store.tokenInfo = data },
   onAgentDone: (data) => store.agentDone(data?.error),
   onTodoUpdate: () => store.fetchTodos(),
@@ -205,7 +205,7 @@ function startResize(e: MouseEvent) {
         <div class="flex items-center gap-2.5 min-w-0">
           <!-- Sidebar toggle -->
           <button
-            class="w-7 h-7 flex items-center justify-center rounded-lg text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+            class="w-7 h-7 flex items-center justify-center rounded text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
             @click="sidebarCollapsed = !sidebarCollapsed"
             title="Toggle sidebar (Ctrl+B)"
           >
@@ -221,7 +221,7 @@ function startResize(e: MouseEvent) {
         </div>
         <div class="flex items-center gap-2">
           <!-- Panel toggles -->
-          <div class="flex items-center gap-0.5 bg-zinc-100 dark:bg-zinc-800/60 rounded-lg p-0.5">
+          <div class="flex items-center gap-0.5 bg-zinc-100 dark:bg-zinc-800/60 rounded p-0.5">
             <button
               class="px-2.5 py-1 text-[11px] font-medium rounded-md cursor-pointer transition-all duration-150"
               :class="bottomPanel === 'terminal'
@@ -263,7 +263,7 @@ function startResize(e: MouseEvent) {
         >
           <!-- Welcome -->
           <div v-if="!store.hasMessages" class="flex flex-col items-center justify-center h-full text-center px-8 animate-fade-in">
-            <div class="w-14 h-14 rounded-2xl bg-gradient-to-br from-emerald-500/20 to-emerald-600/10 dark:from-emerald-400/15 dark:to-emerald-500/5 flex items-center justify-center mb-5 ring-1 ring-emerald-500/20">
+            <div class="w-14 h-14 rounded bg-gradient-to-br from-emerald-500/20 to-emerald-600/10 dark:from-emerald-400/15 dark:to-emerald-500/5 flex items-center justify-center mb-5 ring-1 ring-emerald-500/20">
               <svg class="w-7 h-7 text-emerald-500 dark:text-emerald-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                 <path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round"/>
               </svg>

--- a/web/src/components/ApprovalBanner.vue
+++ b/web/src/components/ApprovalBanner.vue
@@ -18,7 +18,7 @@ function formatArgs(args: string): string {
 </script>
 
 <template>
-  <div class="my-2 rounded-xl border px-4 py-3 flex items-start gap-3 animate-fade-in"
+  <div class="my-2 rounded-md border px-4 py-3 flex items-start gap-3 animate-fade-in"
     :class="approval.resolved
       ? approval.approved
         ? 'border-emerald-200 dark:border-emerald-500/20 bg-emerald-50/50 dark:bg-emerald-500/5'
@@ -32,12 +32,12 @@ function formatArgs(args: string): string {
     </div>
     <div v-if="!approval.resolved" class="flex gap-1.5 shrink-0">
       <button
-        class="px-3.5 py-1.5 text-xs rounded-xl bg-emerald-500 hover:bg-emerald-600 text-white transition-colors cursor-pointer font-medium shadow-sm"
+        class="px-3.5 py-1.5 text-xs rounded-md bg-emerald-500 hover:bg-emerald-600 text-white transition-colors cursor-pointer font-medium shadow-sm"
         @click="store.resolveApproval(approval.id, true)">
         Allow
       </button>
       <button
-        class="px-3.5 py-1.5 text-xs rounded-xl bg-zinc-200 dark:bg-zinc-700 hover:bg-zinc-300 dark:hover:bg-zinc-600 text-zinc-600 dark:text-zinc-300 transition-colors cursor-pointer font-medium"
+        class="px-3.5 py-1.5 text-xs rounded-md bg-zinc-200 dark:bg-zinc-700 hover:bg-zinc-300 dark:hover:bg-zinc-600 text-zinc-600 dark:text-zinc-300 transition-colors cursor-pointer font-medium"
         @click="store.resolveApproval(approval.id, false)">
         Deny
       </button>

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -142,11 +142,11 @@ watch(() => store.isRunning, (running) => {
 <template>
   <div ref="containerRef" class="border-t border-zinc-200 dark:border-zinc-800/80 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-sm px-5 py-3">
     <div class="max-w-3xl mx-auto">
-      <div class="bg-zinc-50 dark:bg-zinc-800/60 border border-zinc-200 dark:border-zinc-700/60 rounded-2xl px-3.5 py-2.5 focus-within:border-emerald-400 dark:focus-within:border-emerald-500/60 focus-within:ring-1 focus-within:ring-emerald-400/20 dark:focus-within:ring-emerald-500/10 transition-all relative">
+      <div class="bg-zinc-50 dark:bg-zinc-800/60 border border-zinc-200 dark:border-zinc-700/60 rounded-md px-3.5 py-2.5 transition-all relative">
         <!-- Slash command menu -->
         <div
           v-if="showSlashMenu && filteredSlashCommands.length > 0"
-          class="absolute bottom-full mb-2 left-0 right-0 z-30 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl shadow-lg dark:shadow-2xl py-1.5 max-h-48 overflow-y-auto"
+          class="absolute bottom-full mb-2 left-0 right-0 z-30 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md shadow-lg dark:shadow-2xl py-1.5 max-h-48 overflow-y-auto"
         >
           <button
             v-for="(cmd, i) in filteredSlashCommands"
@@ -179,7 +179,7 @@ watch(() => store.isRunning, (running) => {
             <!-- Mode selector -->
             <div class="relative">
               <button
-                class="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded-lg transition-colors cursor-pointer"
+                class="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded transition-colors cursor-pointer"
                 :class="store.mode === 'plan'
                   ? 'bg-amber-100 dark:bg-amber-500/15 text-amber-600 dark:text-amber-400'
                   : 'bg-zinc-100 dark:bg-zinc-700/60 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200'"
@@ -190,11 +190,11 @@ watch(() => store.isRunning, (running) => {
                   <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
                 </svg>
               </button>
-              <div v-if="showModePicker" class="absolute bottom-full mb-1 left-0 z-20 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl shadow-lg dark:shadow-2xl py-1 min-w-28">
+              <div v-if="showModePicker" class="absolute bottom-full mb-1 left-0 z-20 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md shadow-lg dark:shadow-2xl py-1 min-w-28">
                 <button
                   v-for="m in modes"
                   :key="m.value"
-                  class="w-full px-3 py-1.5 text-xs cursor-pointer select-none text-left transition-colors rounded-lg"
+                  class="w-full px-3 py-1.5 text-xs cursor-pointer select-none text-left transition-colors rounded"
                   :class="store.mode === m.value
                     ? 'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-500/10'
                     : 'text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700/50 hover:text-zinc-700 dark:hover:text-zinc-200'"
@@ -208,7 +208,7 @@ watch(() => store.isRunning, (running) => {
             <!-- Model selector -->
             <div class="relative">
               <button
-                class="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded-lg bg-zinc-100 dark:bg-zinc-700/60 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 cursor-pointer transition-colors"
+                class="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded bg-zinc-100 dark:bg-zinc-700/60 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 cursor-pointer transition-colors"
                 @click.stop="showModelPicker = !showModelPicker; showModePicker = false"
               >
                 {{ store.modelName || 'model' }}
@@ -218,7 +218,7 @@ watch(() => store.isRunning, (running) => {
               </button>
               <div
                 v-if="showModelPicker"
-                class="absolute bottom-full mb-1 left-0 z-20 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl shadow-lg dark:shadow-2xl py-1.5 max-h-72 overflow-y-auto min-w-56"
+                class="absolute bottom-full mb-1 left-0 z-20 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md shadow-lg dark:shadow-2xl py-1.5 max-h-72 overflow-y-auto min-w-56"
               >
                 <template v-for="p in store.providers" :key="p.id">
                   <div class="px-3 py-1 text-[10px] text-zinc-400 dark:text-zinc-500 uppercase tracking-wider font-semibold sticky top-0 bg-white dark:bg-zinc-800">
@@ -244,7 +244,7 @@ watch(() => store.isRunning, (running) => {
 
             <!-- Auto-approve toggle -->
             <button
-              class="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded-lg transition-colors cursor-pointer"
+              class="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded transition-colors cursor-pointer"
               :class="store.autoApprove
                 ? 'bg-emerald-100 dark:bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-200 dark:hover:bg-emerald-500/25'
                 : 'bg-zinc-100 dark:bg-zinc-700/60 text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-600/60'"
@@ -260,7 +260,7 @@ watch(() => store.isRunning, (running) => {
             <!-- Channel toggle -->
             <button
               v-if="store.channelAvailable"
-              class="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded-lg transition-colors cursor-pointer"
+              class="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded transition-colors cursor-pointer"
               :class="store.channelEnabled
                 ? 'bg-emerald-100 dark:bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-200 dark:hover:bg-emerald-500/25'
                 : 'bg-zinc-100 dark:bg-zinc-700/60 text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-600/60'"
@@ -283,7 +283,7 @@ watch(() => store.isRunning, (running) => {
             <!-- Stop button -->
             <button
               v-if="store.isRunning"
-              class="w-7 h-7 flex items-center justify-center rounded-xl bg-red-500 hover:bg-red-600 text-white transition-colors cursor-pointer shadow-sm"
+              class="w-7 h-7 flex items-center justify-center rounded-md bg-red-500 hover:bg-red-600 text-white transition-colors cursor-pointer shadow-sm"
               title="Stop agent (Esc)"
               @click="store.stopAgent()"
             >
@@ -294,7 +294,7 @@ watch(() => store.isRunning, (running) => {
             <!-- Send button -->
             <button
               v-else
-              class="w-7 h-7 flex items-center justify-center rounded-xl bg-emerald-500 hover:bg-emerald-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-sm"
+              class="w-7 h-7 flex items-center justify-center rounded-md bg-emerald-500 hover:bg-emerald-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-sm"
               :disabled="!input.trim()"
               @click="send"
             >

--- a/web/src/components/ChatMessage.vue
+++ b/web/src/components/ChatMessage.vue
@@ -12,7 +12,7 @@ defineProps<{
     <!-- Role label -->
     <div class="flex items-center gap-2 mb-2">
       <div
-        class="w-5 h-5 rounded-lg flex items-center justify-center text-[9px] font-bold shrink-0"
+        class="w-5 h-5 rounded flex items-center justify-center text-[9px] font-bold shrink-0"
         :class="{
           'bg-emerald-500/15 text-emerald-600 dark:bg-emerald-400/15 dark:text-emerald-400': message.role === 'assistant',
           'bg-zinc-200 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400': message.role === 'user' && message.source !== 'wechat',

--- a/web/src/components/DiffViewer.vue
+++ b/web/src/components/DiffViewer.vue
@@ -4,11 +4,12 @@ import { api } from '@/composables/api'
 import type { DiffEntry } from '@/types/api'
 
 const entries = ref<DiffEntry[]>([])
-const mode = ref<'working' | 'staged' | 'branch'>('working')
+const mode = ref<'working' | 'staged' | 'branch' | 'session'>('session')
 const loading = ref(false)
 const selectedFile = ref<string | null>(null)
 
 const modes = [
+  { value: 'session' as const, label: 'Session' },
   { value: 'working' as const, label: 'Working' },
   { value: 'staged' as const, label: 'Staged' },
   { value: 'branch' as const, label: 'Branch' },
@@ -76,7 +77,7 @@ onMounted(fetchDiff)
           <button
             v-for="m in modes"
             :key="m.value"
-            class="px-1.5 py-0.5 text-[10px] rounded-lg cursor-pointer transition-colors font-medium"
+            class="px-1.5 py-0.5 text-[10px] rounded cursor-pointer transition-colors font-medium"
             :class="mode === m.value
               ? 'bg-emerald-100 dark:bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
               : 'text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700'"

--- a/web/src/components/FileViewer.vue
+++ b/web/src/components/FileViewer.vue
@@ -26,11 +26,11 @@ function highlighted(): string {
 
 <template>
   <div class="fixed inset-0 bg-black/40 dark:bg-black/60 z-50 flex items-center justify-center p-8 backdrop-blur-sm animate-fade-in" @click.self="emit('close')">
-    <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-2xl flex flex-col w-full max-w-5xl max-h-[85vh] overflow-hidden shadow-2xl">
+    <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded flex flex-col w-full max-w-5xl max-h-[85vh] overflow-hidden shadow-2xl">
       <div class="flex items-center justify-between px-4 py-2.5 border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-800/80">
         <span class="font-mono text-xs text-zinc-500 dark:text-zinc-400 truncate">{{ path }}</span>
         <button
-          class="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 cursor-pointer transition-colors font-medium px-2 py-0.5 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700"
+          class="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 cursor-pointer transition-colors font-medium px-2 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700"
           @click="emit('close')">
           Close
         </button>

--- a/web/src/components/MCPPanel.vue
+++ b/web/src/components/MCPPanel.vue
@@ -65,7 +65,7 @@ onMounted(fetchMCP)
       <div
         v-for="(info, name) in servers"
         :key="name"
-        class="flex items-center gap-3 px-3 py-2.5 rounded-xl border border-zinc-200 dark:border-zinc-700/60 bg-white dark:bg-zinc-800/60 hover:border-zinc-300 dark:hover:border-zinc-600 transition-colors"
+        class="flex items-center gap-3 px-3 py-2.5 rounded-md border border-zinc-200 dark:border-zinc-700/60 bg-white dark:bg-zinc-800/60 hover:border-zinc-300 dark:hover:border-zinc-600 transition-colors"
       >
         <span class="text-base">{{ serverIcon(info.type) }}</span>
         <div class="flex-1 min-w-0">

--- a/web/src/components/ProjectSwitcher.vue
+++ b/web/src/components/ProjectSwitcher.vue
@@ -131,7 +131,7 @@ function deleteProject(id: string) {
           leave-from="opacity-100 translate-y-0"
           leave-to="opacity-0 translate-y-2"
         >
-          <DialogPanel class="w-full max-w-lg bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-2xl shadow-2xl overflow-hidden">
+          <DialogPanel class="w-full max-w-lg bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded shadow-2xl overflow-hidden">
             <!-- Header -->
             <div class="px-5 pt-4 pb-2">
               <DialogTitle class="text-sm font-semibold text-zinc-800 dark:text-zinc-100" style="font-family: var(--font-sans)">
@@ -145,12 +145,12 @@ function deleteProject(id: string) {
                 <input
                   v-model="pathInput"
                   type="text"
-                  class="flex-1 px-3 py-1.5 text-sm font-mono rounded-xl border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-200 outline-none focus:border-emerald-400 dark:focus:border-emerald-500/60 transition-colors"
+                  class="flex-1 px-3 py-1.5 text-sm font-mono rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-200 outline-none focus:border-emerald-400 dark:focus:border-emerald-500/60 transition-colors"
                   placeholder="/path/to/folder"
                   @keydown="handlePathKeyDown"
                 />
                 <button
-                  class="px-3 py-1.5 text-xs font-medium bg-emerald-500 hover:bg-emerald-600 text-white rounded-xl cursor-pointer transition-colors"
+                  class="px-3 py-1.5 text-xs font-medium bg-emerald-500 hover:bg-emerald-600 text-white rounded-md cursor-pointer transition-colors"
                   @click="handlePathSubmit"
                 >
                   OK
@@ -163,7 +163,7 @@ function deleteProject(id: string) {
                 </button>
               </div>
 
-              <div class="border border-zinc-200 dark:border-zinc-700 rounded-xl overflow-hidden max-h-80 overflow-y-auto bg-zinc-50 dark:bg-zinc-800/60">
+              <div class="border border-zinc-200 dark:border-zinc-700 rounded-md overflow-hidden max-h-80 overflow-y-auto bg-zinc-50 dark:bg-zinc-800/60">
                 <button
                   v-if="browsePath && browsePath !== '/'"
                   class="w-full flex items-center gap-2 px-3 py-2 text-sm text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-700 cursor-pointer transition-colors border-b border-zinc-100 dark:border-zinc-700/60"
@@ -196,7 +196,7 @@ function deleteProject(id: string) {
                   {{ displayPath }}
                 </div>
                 <button
-                  class="px-4 py-1.5 text-xs font-medium bg-emerald-500 hover:bg-emerald-600 text-white rounded-xl cursor-pointer transition-colors shrink-0"
+                  class="px-4 py-1.5 text-xs font-medium bg-emerald-500 hover:bg-emerald-600 text-white rounded-md cursor-pointer transition-colors shrink-0"
                   @click="selectCurrentPath"
                 >
                   Open Folder
@@ -207,7 +207,7 @@ function deleteProject(id: string) {
             <!-- Project list mode -->
             <div v-else>
               <div v-if="projectStore.switchError" class="px-5 py-2">
-                <div class="text-xs text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20 rounded-xl px-3 py-2">
+                <div class="text-xs text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20 rounded-md px-3 py-2">
                   {{ projectStore.switchError }}
                 </div>
               </div>
@@ -223,14 +223,14 @@ function deleteProject(id: string) {
                 <div
                   v-for="p in projectStore.projects"
                   :key="p.id"
-                  class="group flex items-center gap-2 px-3 py-2.5 rounded-xl cursor-pointer transition-colors"
+                  class="group flex items-center gap-2 px-3 py-2.5 rounded-md cursor-pointer transition-colors"
                   :class="projectStore.activeId === p.id
                     ? 'bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-200 dark:border-emerald-500/20'
                     : 'hover:bg-zinc-50 dark:hover:bg-zinc-800 border border-transparent'"
                   @click="selectProject(p.id)"
                 >
                   <div
-                    class="w-7 h-7 rounded-xl flex items-center justify-center text-xs font-bold shrink-0"
+                    class="w-7 h-7 rounded-md flex items-center justify-center text-xs font-bold shrink-0"
                     :class="projectStore.activeId === p.id
                       ? 'bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-400'
                       : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400'"

--- a/web/src/components/SettingsDialog.vue
+++ b/web/src/components/SettingsDialog.vue
@@ -174,7 +174,7 @@ const tabLabel: Record<string, string> = {
           leave="ease-in duration-100"
           leave-from="opacity-100 translate-y-0"
           leave-to="opacity-0 translate-y-2">
-          <DialogPanel class="w-2xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-2xl shadow-2xl overflow-hidden">
+          <DialogPanel class="w-2xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded shadow-2xl overflow-hidden">
             <div class="px-5 pt-5 pb-3 border-b border-zinc-200 dark:border-zinc-800">
               <DialogTitle class="text-sm font-semibold text-zinc-800 dark:text-zinc-100" style="font-family: var(--font-sans)">Settings</DialogTitle>
             </div>
@@ -267,7 +267,7 @@ const tabLabel: Record<string, string> = {
                     <div
                       v-for="(info, name) in mcpServers"
                       :key="name"
-                      class="flex items-center gap-3 px-3 py-2.5 rounded-xl border border-zinc-200 dark:border-zinc-700/60"
+                      class="flex items-center gap-3 px-3 py-2.5 rounded-md border border-zinc-200 dark:border-zinc-700/60"
                       :class="info.enabled
                         ? 'bg-white dark:bg-zinc-800/60'
                         : 'bg-zinc-50 dark:bg-zinc-800/30 opacity-60'"
@@ -300,7 +300,7 @@ const tabLabel: Record<string, string> = {
 
                   <div class="mb-3">
                     <div class="text-[10px] text-zinc-400 dark:text-zinc-500 mb-1">Current Environment</div>
-                    <div class="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg bg-emerald-50 dark:bg-emerald-500/10 text-xs text-emerald-700 dark:text-emerald-400 font-medium">
+                    <div class="inline-flex items-center gap-1.5 px-2 py-1 rounded bg-emerald-50 dark:bg-emerald-500/10 text-xs text-emerald-700 dark:text-emerald-400 font-medium">
                       <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 dark:bg-emerald-400" />
                       {{ sshCurrent }}
                     </div>
@@ -316,7 +316,7 @@ const tabLabel: Record<string, string> = {
                     <div
                       v-for="alias in sshAliases"
                       :key="alias.name"
-                      class="flex items-center gap-3 px-3 py-2.5 rounded-xl border border-zinc-200 dark:border-zinc-700/60 bg-white dark:bg-zinc-800/60"
+                      class="flex items-center gap-3 px-3 py-2.5 rounded-md border border-zinc-200 dark:border-zinc-700/60 bg-white dark:bg-zinc-800/60"
                     >
                       <span class="text-sm">🖥</span>
                       <div class="flex-1 min-w-0">
@@ -348,7 +348,7 @@ const tabLabel: Record<string, string> = {
                   </div>
 
                   <div v-else class="space-y-4">
-                    <div class="px-4 py-3 rounded-xl border border-zinc-200 dark:border-zinc-700/60 bg-white dark:bg-zinc-800/60">
+                    <div class="px-4 py-3 rounded-md border border-zinc-200 dark:border-zinc-700/60 bg-white dark:bg-zinc-800/60">
                       <div class="flex items-center justify-between mb-3">
                         <div class="flex items-center gap-2">
                           <span class="text-base">💬</span>
@@ -377,7 +377,7 @@ const tabLabel: Record<string, string> = {
                       </div>
 
                       <div v-if="channelQRContent" class="flex flex-col items-center py-3">
-                        <canvas ref="qrCanvas" class="rounded-xl border border-zinc-200 dark:border-zinc-700" />
+                        <canvas ref="qrCanvas" class="rounded-md border border-zinc-200 dark:border-zinc-700" />
                         <div class="text-[10px] text-zinc-400 dark:text-zinc-500 mt-2">Scan with WeChat to connect</div>
                       </div>
 
@@ -385,7 +385,7 @@ const tabLabel: Record<string, string> = {
                         <button
                           v-if="channelState === 'none'"
                           :disabled="channelLoading"
-                          class="flex-1 px-3 py-1.5 text-xs rounded-xl bg-emerald-500 text-white hover:bg-emerald-600 disabled:opacity-50 cursor-pointer transition-colors font-medium"
+                          class="flex-1 px-3 py-1.5 text-xs rounded-md bg-emerald-500 text-white hover:bg-emerald-600 disabled:opacity-50 cursor-pointer transition-colors font-medium"
                           @click="channelLogin"
                         >
                           {{ channelLoading ? 'Loading...' : 'Connect' }}
@@ -393,7 +393,7 @@ const tabLabel: Record<string, string> = {
                         <button
                           v-if="channelState === 'enabled' || channelState === 'disabled'"
                           :disabled="channelLoading"
-                          class="flex-1 px-3 py-1.5 text-xs rounded-xl text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 disabled:opacity-50 cursor-pointer transition-colors font-medium"
+                          class="flex-1 px-3 py-1.5 text-xs rounded-md text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 disabled:opacity-50 cursor-pointer transition-colors font-medium"
                           @click="channelLogout"
                         >
                           Disconnect
@@ -404,7 +404,7 @@ const tabLabel: Record<string, string> = {
                     <!-- Login reminder banner -->
                     <div
                       v-if="channelLoginReminder"
-                      class="px-4 py-3 rounded-xl border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 flex items-start gap-2.5"
+                      class="px-4 py-3 rounded-md border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 flex items-start gap-2.5"
                     >
                       <span class="text-sm shrink-0 mt-0.5">⚠️</span>
                       <div class="flex-1 min-w-0">
@@ -432,10 +432,10 @@ const tabLabel: Record<string, string> = {
                     <div
                       v-for="s in shortcuts"
                       :key="s.keys"
-                      class="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                      class="flex items-center justify-between py-1.5 px-2 rounded hover:bg-zinc-50 dark:hover:bg-zinc-800"
                     >
                       <span class="text-xs text-zinc-600 dark:text-zinc-300">{{ s.desc }}</span>
-                      <kbd class="px-2 py-0.5 text-[10px] font-mono bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-lg text-zinc-500 dark:text-zinc-400">{{ s.keys }}</kbd>
+                      <kbd class="px-2 py-0.5 text-[10px] font-mono bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded text-zinc-500 dark:text-zinc-400">{{ s.keys }}</kbd>
                     </div>
                   </div>
                 </div>

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -108,10 +108,10 @@ function fileIcon(file: FileItem): string {
     <!-- Project header -->
     <div class="px-3.5 pt-4 pb-3">
       <button
-        class="flex items-center gap-2.5 mb-3 w-full text-left cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-xl p-2 -m-0.5 transition-colors group"
+        class="flex items-center gap-2.5 mb-3 w-full text-left cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-md p-2 -m-0.5 transition-colors group"
         @click="emit('openProjects')"
       >
-        <div class="w-8 h-8 rounded-xl bg-gradient-to-br from-emerald-500 to-emerald-600 dark:from-emerald-400 dark:to-emerald-500 text-white flex items-center justify-center text-sm font-bold shadow-sm">
+        <div class="w-8 h-8 rounded-md bg-gradient-to-br from-emerald-500 to-emerald-600 dark:from-emerald-400 dark:to-emerald-500 text-white flex items-center justify-center text-sm font-bold shadow-sm">
           {{ (store.projectName || 'J').charAt(0).toUpperCase() }}
         </div>
         <div class="min-w-0 flex-1">
@@ -123,7 +123,7 @@ function fileIcon(file: FileItem): string {
         </svg>
       </button>
       <button
-        class="w-full py-2 text-xs font-medium rounded-xl border border-zinc-200 dark:border-zinc-700/60 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/60 transition-all cursor-pointer"
+        class="w-full py-2 text-xs font-medium rounded-md border border-zinc-200 dark:border-zinc-700/60 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/60 transition-all cursor-pointer"
         @click="store.newSession()"
       >
         + New conversation
@@ -157,15 +157,15 @@ function fileIcon(file: FileItem): string {
       <div
         v-for="s in store.sessions"
         :key="s.uuid"
-        class="group relative flex items-center gap-2 px-2.5 py-2.5 rounded-xl cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors mb-0.5"
+        class="group relative flex items-center gap-2 px-2.5 py-2.5 rounded-md cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors mb-0.5"
         @click="store.loadSession(s.uuid)"
       >
         <div class="min-w-0 flex-1">
-          <div class="text-xs text-zinc-600 dark:text-zinc-300 truncate font-medium">{{ s.uuid.slice(0, 8) }}…</div>
+          <div class="text-xs text-zinc-600 dark:text-zinc-300 truncate font-medium">{{ s.title || s.uuid.slice(0, 8) + '…' }}</div>
           <div class="text-[10px] text-zinc-400 dark:text-zinc-600 mt-0.5 font-mono">{{ s.model }} · {{ formatDate(s.created_at) }}</div>
         </div>
         <button
-          class="opacity-0 group-hover:opacity-100 shrink-0 w-6 h-6 flex items-center justify-center rounded-lg text-zinc-400 hover:text-red-500 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-all cursor-pointer"
+          class="opacity-0 group-hover:opacity-100 shrink-0 w-6 h-6 flex items-center justify-center rounded text-zinc-400 hover:text-red-500 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-all cursor-pointer"
           @click.stop="toggleContextMenu(s.uuid, $event)"
           title="Delete"
         >
@@ -176,11 +176,11 @@ function fileIcon(file: FileItem): string {
         <!-- Delete confirmation -->
         <div
           v-if="contextMenuId === s.uuid"
-          class="absolute right-0 top-full z-10 mt-1 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl shadow-lg py-1 min-w-[120px]"
+          class="absolute right-0 top-full z-10 mt-1 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md shadow-lg py-1 min-w-[120px]"
           @click.stop
         >
           <button
-            class="w-full px-3 py-1.5 text-xs text-left text-red-500 hover:bg-zinc-50 dark:hover:bg-zinc-700 cursor-pointer rounded-lg mx-0.5"
+            class="w-full px-3 py-1.5 text-xs text-left text-red-500 hover:bg-zinc-50 dark:hover:bg-zinc-700 cursor-pointer rounded mx-0.5"
             style="width: calc(100% - 4px)"
             @click="handleDelete(s.uuid)"
           >
@@ -194,7 +194,7 @@ function fileIcon(file: FileItem): string {
     <div v-if="activeTab === 'files'" class="flex-1 overflow-y-auto px-2 py-2">
       <button
         v-if="currentPath"
-        class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 mb-1 cursor-pointer rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors w-full"
+        class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 mb-1 cursor-pointer rounded hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors w-full"
         @click="goUp"
       >
         <svg class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z" clip-rule="evenodd" /></svg>
@@ -203,7 +203,7 @@ function fileIcon(file: FileItem): string {
       <div
         v-for="file in files"
         :key="file.name"
-        class="flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-xs cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors truncate"
+        class="flex items-center gap-2 px-2.5 py-1.5 rounded text-xs cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors truncate"
         :class="file.is_dir ? 'text-zinc-700 dark:text-zinc-300 font-medium' : 'text-zinc-500 dark:text-zinc-400'"
         @click="handleFileClick(file)"
       >
@@ -220,7 +220,7 @@ function fileIcon(file: FileItem): string {
       <div class="flex items-center gap-1">
         <!-- Theme toggle -->
         <button
-          class="w-7 h-7 flex items-center justify-center rounded-lg text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+          class="w-7 h-7 flex items-center justify-center rounded text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
           @click="emit('toggleTheme')"
           :title="resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'"
         >
@@ -235,7 +235,7 @@ function fileIcon(file: FileItem): string {
         </button>
         <!-- Settings -->
         <button
-          class="w-7 h-7 flex items-center justify-center rounded-lg text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+          class="w-7 h-7 flex items-center justify-center rounded text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
           @click="emit('openSettings')"
           title="Settings (Ctrl+,)"
         >

--- a/web/src/components/ToolCallCard.vue
+++ b/web/src/components/ToolCallCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import type { ToolCall } from '@/types/api'
+import { TOOL_ICONS } from '@/composables/toolInfo'
 
 defineOptions({ name: 'ToolCallCard' })
 
@@ -13,16 +14,133 @@ const expanded = ref(false)
 const isSubagent = computed(() => props.tool.name === 'subagent')
 const subagentExpanded = ref(true)
 
-function formatArgs(args: string): string {
+// Display info: use backend-provided or fall back to name
+const displayTitle = computed(() => props.tool.displayInfo?.title || props.tool.name)
+const displaySubtitle = computed(() => props.tool.displayInfo?.subtitle || '')
+const displayIcon = computed(() => {
+  const iconKey = props.tool.displayInfo?.icon || 'tool'
+  return TOOL_ICONS[iconKey] || '🔧'
+})
+const isContextTool = computed(() => props.tool.displayInfo?.category === 'context')
+
+// Determine render type for expanded content
+const renderType = computed(() => {
+  const name = props.tool.name
+  if (name === 'execute') return 'terminal'
+  if (name === 'read') return 'file-viewer'
+  if (name === 'write') return 'file-viewer'
+  if (name === 'edit' || name === 'multi_edit') return 'diff'
+  return 'generic'
+})
+
+// ─── Terminal renderer helpers ───
+const terminalCommand = computed(() => {
   try {
-    const parsed = JSON.parse(args)
-    return Object.entries(parsed)
-      .map(([k, v]) => `${k}: ${typeof v === 'string' ? v.slice(0, 80) : JSON.stringify(v).slice(0, 80)}`)
-      .join(', ')
-  } catch {
-    return args.slice(0, 120)
+    const parsed = JSON.parse(props.tool.args)
+    return parsed.command || ''
+  } catch { return '' }
+})
+
+// ─── File viewer helpers ───
+const filePath = computed(() => {
+  try {
+    const parsed = JSON.parse(props.tool.args)
+    return parsed.file_path || ''
+  } catch { return '' }
+})
+
+const fileName = computed(() => {
+  if (!filePath.value) return ''
+  const parts = filePath.value.replace(/\\/g, '/').split('/')
+  return parts[parts.length - 1] || ''
+})
+
+const fileDir = computed(() => {
+  if (!filePath.value) return ''
+  const parts = filePath.value.replace(/\\/g, '/').split('/')
+  parts.pop()
+  const dir = parts.join('/')
+  return dir || '/'
+})
+
+const fileContent = computed(() => {
+  const name = props.tool.name
+  if (name === 'write') {
+    try {
+      const parsed = JSON.parse(props.tool.args)
+      return parsed.content || ''
+    } catch { return '' }
   }
-}
+  // For read — output is the file content (with line numbers from the tool)
+  return props.tool.output || ''
+})
+
+const fileLines = computed(() => {
+  if (!fileContent.value) return []
+  const raw = fileContent.value
+  const lines = raw.split('\n')
+  // The read tool outputs lines like "   1│content"
+  // For write tool, content is raw — we add our own line numbers
+  if (props.tool.name === 'read') {
+    return lines.map((line: string) => {
+      const match = line.match(/^\s*(\d+)│(.*)$/)
+      if (match) return { num: parseInt(match[1]), text: match[2] }
+      return { num: 0, text: line }
+    }).filter((_: { num: number; text: string }, i: number, arr: { num: number; text: string }[]) => !(i === arr.length - 1 && _.text === ''))
+  }
+  // Write tool: raw content with line numbers we generate
+  return lines.map((line: string, i: number) => ({ num: i + 1, text: line }))
+})
+
+// ─── Diff renderer helpers ───
+const diffData = computed(() => {
+  try {
+    const parsed = JSON.parse(props.tool.args)
+    const oldStr: string = parsed.old_string || ''
+    const newStr: string = parsed.new_string || ''
+    const isCreate = !oldStr && newStr
+
+    // For multi_edit, try to show edits array
+    if (props.tool.name === 'multi_edit' && parsed.edits) {
+      const edits = parsed.edits as Array<{ old_string: string; new_string: string }>
+      let totalAdd = 0, totalDel = 0
+      const sections: Array<{ type: 'add' | 'del' | 'context'; lines: string[] }> = []
+      for (const edit of edits) {
+        if (edit.old_string) {
+          const lines = edit.old_string.split('\n')
+          totalDel += lines.length
+          sections.push({ type: 'del', lines })
+        }
+        if (edit.new_string) {
+          const lines = edit.new_string.split('\n')
+          totalAdd += lines.length
+          sections.push({ type: 'add', lines })
+        }
+      }
+      return { added: totalAdd, deleted: totalDel, sections, isCreate: false }
+    }
+
+    const addedLines = newStr ? newStr.split('\n') : []
+    const deletedLines = oldStr ? oldStr.split('\n') : []
+
+    const sections: Array<{ type: 'add' | 'del' | 'context'; lines: string[] }> = []
+    if (deletedLines.length && !isCreate) {
+      sections.push({ type: 'del', lines: deletedLines })
+    }
+    if (addedLines.length) {
+      sections.push({ type: 'add', lines: addedLines })
+    }
+
+    return {
+      added: addedLines.length,
+      deleted: isCreate ? 0 : deletedLines.length,
+      sections,
+      isCreate,
+    }
+  } catch {
+    return { added: 0, deleted: 0, sections: [], isCreate: false }
+  }
+})
 
 function subagentName(): string {
   try {
@@ -36,13 +154,24 @@ function subagentName(): string {
 function truncate(text: string, max: number): string {
   return text.length > max ? text.slice(0, max) + `… (${text.length} chars)` : text
 }
+
+function formatArgs(args: string): string {
+  try {
+    const parsed = JSON.parse(args)
+    return Object.entries(parsed)
+      .map(([k, v]) => `${k}: ${typeof v === 'string' ? v.slice(0, 80) : JSON.stringify(v).slice(0, 80)}`)
+      .join(', ')
+  } catch {
+    return args.slice(0, 120)
+  }
+}
 </script>
 
 <template>
   <!-- Subagent card -->
   <div v-if="isSubagent" class="my-2">
     <div
-      class="rounded-xl border overflow-hidden transition-colors"
+      class="rounded-md border overflow-hidden transition-colors"
       :class="tool.status === 'running'
         ? 'border-violet-300 dark:border-violet-500/30 bg-violet-50/30 dark:bg-violet-500/5'
         : 'border-zinc-200 dark:border-zinc-700/60 bg-zinc-50/50 dark:bg-zinc-800/30'"
@@ -111,36 +240,213 @@ function truncate(text: string, max: number): string {
   <!-- Regular tool call -->
   <div v-else class="my-1">
     <button
-      class="w-full flex items-center gap-2 px-3 py-1.5 rounded-xl text-left hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors cursor-pointer"
+      class="tool-trigger w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-left transition-colors cursor-pointer"
+      :class="[
+        expanded
+          ? 'bg-zinc-100 dark:bg-zinc-800/80 border border-zinc-200/80 dark:border-zinc-700/50'
+          : 'hover:bg-zinc-100 dark:hover:bg-zinc-800/60 border border-transparent',
+        tool.status === 'error' ? 'border-red-200/60 dark:border-red-500/20' : ''
+      ]"
       @click="expanded = !expanded"
     >
-      <span class="text-[10px]" :class="{
-        'text-zinc-400 dark:text-zinc-500 animate-pulse': tool.status === 'running',
-        'text-emerald-600 dark:text-emerald-400': tool.status === 'done',
+      <!-- Status indicator -->
+      <span class="text-[11px] shrink-0" :class="{
+        'animate-pulse': tool.status === 'running',
+      }">{{ displayIcon }}</span>
+
+      <!-- Tool title -->
+      <span class="text-xs font-medium" :class="{
+        'text-zinc-500 dark:text-zinc-400': tool.status !== 'error',
         'text-red-500 dark:text-red-400': tool.status === 'error',
       }">
-        <template v-if="tool.status === 'running'">●</template>
-        <template v-else-if="tool.status === 'done'">✓</template>
-        <template v-else>✗</template>
+        <template v-if="tool.status === 'running'">
+          <span class="inline-flex items-center gap-1">
+            {{ displayTitle }}
+            <span class="text-[10px] text-zinc-400 dark:text-zinc-500 animate-pulse">…</span>
+          </span>
+        </template>
+        <template v-else>
+          {{ displayTitle }}
+        </template>
       </span>
-      <span class="font-mono text-xs text-zinc-500 dark:text-zinc-400">{{ tool.name }}</span>
-      <span v-if="tool.status === 'running'" class="text-[10px] text-zinc-400 dark:text-zinc-500 animate-pulse">running</span>
+
+      <!-- Subtitle: file path, command, pattern, etc. -->
+      <span
+        v-if="displaySubtitle && tool.status !== 'running'"
+        class="text-xs font-mono truncate min-w-0 flex-1"
+        :class="isContextTool
+          ? 'text-zinc-400 dark:text-zinc-500'
+          : 'text-emerald-600/80 dark:text-emerald-400/70'"
+      >{{ displaySubtitle }}</span>
+
+      <!-- Diff stats badge for edit tools -->
+      <span
+        v-if="renderType === 'diff' && diffData.added + diffData.deleted > 0 && tool.status !== 'running'"
+        class="text-[10px] font-mono tabular-nums shrink-0"
+      >
+        <span v-if="diffData.added" class="text-emerald-600 dark:text-emerald-400">+{{ diffData.added }}</span>
+        <span v-if="diffData.added && diffData.deleted" class="text-zinc-400 dark:text-zinc-500 mx-0.5">/</span>
+        <span v-if="diffData.deleted" class="text-red-500 dark:text-red-400">-{{ diffData.deleted }}</span>
+      </span>
+
+      <!-- Error badge -->
+      <span
+        v-if="tool.status === 'error'"
+        class="text-[9px] font-semibold uppercase tracking-wider text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-500/10 px-1.5 py-0.5 rounded-md"
+      >error</span>
+
+      <!-- Expand arrow -->
       <svg
-        class="w-3 h-3 text-zinc-400 dark:text-zinc-500 ml-auto transition-transform"
+        class="w-3 h-3 text-zinc-400 dark:text-zinc-500 ml-auto transition-transform shrink-0"
         :class="{ 'rotate-180': expanded }"
         viewBox="0 0 20 20" fill="currentColor"
       >
         <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
       </svg>
     </button>
-    <div v-if="expanded" class="ml-5 pl-3 border-l border-zinc-200 dark:border-zinc-700/60 text-xs font-mono text-zinc-500 dark:text-zinc-400 py-1.5 max-h-48 overflow-y-auto">
-      <div class="mb-1">
-        <span class="text-zinc-400 dark:text-zinc-500">args:</span> {{ formatArgs(tool.args) }}
+
+    <!-- ═══════ Expanded: Terminal (execute) ═══════ -->
+    <div
+      v-if="expanded && renderType === 'terminal'"
+      class="mt-1 rounded border overflow-hidden"
+      :class="tool.status === 'error'
+        ? 'border-red-300/60 dark:border-red-500/30'
+        : 'border-zinc-200 dark:border-zinc-700/60'"
+    >
+      <!-- Terminal header -->
+      <div class="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-100 dark:bg-zinc-800/80 border-b border-zinc-200 dark:border-zinc-700/60">
+        <span class="w-2 h-2 rounded-full bg-red-400/80"></span>
+        <span class="w-2 h-2 rounded-full bg-yellow-400/80"></span>
+        <span class="w-2 h-2 rounded-full bg-green-400/80"></span>
+        <span class="text-[10px] text-zinc-400 dark:text-zinc-500 ml-1 font-mono">terminal</span>
       </div>
-      <div v-if="tool.output" class="whitespace-pre-wrap text-zinc-500 dark:text-zinc-400">
-        {{ truncate(tool.output, 500) }}
+      <!-- Terminal body -->
+      <div class="bg-zinc-950 dark:bg-[#0d1117] px-3 py-2 font-mono text-xs max-h-72 overflow-y-auto">
+        <div class="text-emerald-400 dark:text-emerald-400">
+          <span class="text-zinc-500 select-none">$ </span>
+          <span class="text-zinc-200">{{ terminalCommand }}</span>
+        </div>
+        <div v-if="tool.displayOutput || tool.output" class="text-zinc-400 mt-1 whitespace-pre-wrap break-all">{{ truncate(tool.displayOutput || tool.output || '', 2000) }}</div>
+        <div v-if="tool.error" class="text-red-400 mt-1 whitespace-pre-wrap">{{ tool.error }}</div>
+        <div v-if="tool.status === 'running'" class="text-zinc-500 mt-1 animate-pulse">running…</div>
       </div>
-      <div v-if="tool.error" class="text-red-500 dark:text-red-400 whitespace-pre-wrap">{{ tool.error }}</div>
+    </div>
+
+    <!-- ═══════ Expanded: File Viewer (read/write) ═══════ -->
+    <div
+      v-if="expanded && renderType === 'file-viewer'"
+      class="mt-1 rounded border overflow-hidden"
+      :class="tool.status === 'error'
+        ? 'border-red-300/60 dark:border-red-500/30'
+        : 'border-zinc-200 dark:border-zinc-700/60'"
+    >
+      <!-- File header -->
+      <div class="flex items-center gap-2 px-3 py-1.5 bg-zinc-50 dark:bg-zinc-800/80 border-b border-zinc-200 dark:border-zinc-700/60">
+        <span class="text-[11px]">{{ tool.name === 'write' ? '✏️' : '📄' }}</span>
+        <span class="text-[10px] text-zinc-400 dark:text-zinc-500 font-mono truncate">{{ fileDir }}/</span>
+        <span class="text-xs text-zinc-700 dark:text-zinc-300 font-mono font-medium">{{ fileName }}</span>
+      </div>
+      <!-- File body -->
+      <div class="bg-white dark:bg-[#0d1117] max-h-72 overflow-y-auto">
+        <table v-if="fileLines.length" class="w-full text-xs font-mono border-collapse">
+          <tr v-for="line in fileLines" :key="line.num" class="hover:bg-zinc-100/50 dark:hover:bg-zinc-800/30">
+            <td class="text-right select-none text-zinc-300 dark:text-zinc-600 pr-3 pl-2 py-0 w-1 align-top whitespace-nowrap">{{ line.num }}</td>
+            <td class="text-zinc-700 dark:text-zinc-300 pr-3 py-0 whitespace-pre-wrap break-all">{{ line.text }}</td>
+          </tr>
+        </table>
+        <div v-else-if="tool.error" class="px-3 py-2 text-xs text-red-500 dark:text-red-400 font-mono whitespace-pre-wrap">{{ tool.error }}</div>
+        <div v-else-if="tool.status === 'running'" class="px-3 py-3 text-xs text-zinc-400 dark:text-zinc-500 animate-pulse">Loading…</div>
+        <div v-else class="px-3 py-2 text-xs text-zinc-400 dark:text-zinc-500 italic">No content</div>
+      </div>
+    </div>
+
+    <!-- ═══════ Expanded: Diff Viewer (edit/multi_edit) ═══════ -->
+    <div
+      v-if="expanded && renderType === 'diff'"
+      class="mt-1 rounded border overflow-hidden"
+      :class="tool.status === 'error'
+        ? 'border-red-300/60 dark:border-red-500/30'
+        : 'border-zinc-200 dark:border-zinc-700/60'"
+    >
+      <!-- Diff header -->
+      <div class="flex items-center gap-2 px-3 py-1.5 bg-zinc-50 dark:bg-zinc-800/80 border-b border-zinc-200 dark:border-zinc-700/60">
+        <span class="text-[11px]">✏️</span>
+        <span class="text-[10px] text-zinc-400 dark:text-zinc-500 font-mono truncate">{{ fileDir }}/</span>
+        <span class="text-xs text-zinc-700 dark:text-zinc-300 font-mono font-medium">{{ fileName }}</span>
+        <span class="ml-auto text-[10px] font-mono tabular-nums shrink-0">
+          <span v-if="diffData.added" class="text-emerald-600 dark:text-emerald-400">+{{ diffData.added }}</span>
+          <span v-if="diffData.added && diffData.deleted" class="text-zinc-400 dark:text-zinc-500 mx-0.5">/</span>
+          <span v-if="diffData.deleted" class="text-red-500 dark:text-red-400">-{{ diffData.deleted }}</span>
+          <span v-if="diffData.isCreate" class="text-emerald-600 dark:text-emerald-400 italic">new file</span>
+        </span>
+      </div>
+      <!-- Diff body -->
+      <div class="bg-white dark:bg-[#0d1117] max-h-72 overflow-y-auto">
+        <table v-if="diffData.sections.length" class="w-full text-xs font-mono border-collapse">
+          <template v-for="(section, si) in diffData.sections" :key="si">
+            <tr
+              v-for="(line, li) in section.lines"
+              :key="`${si}-${li}`"
+              :class="{
+                'bg-red-50/80 dark:bg-red-500/10': section.type === 'del',
+                'bg-emerald-50/80 dark:bg-emerald-500/10': section.type === 'add',
+              }"
+            >
+              <td class="text-right select-none pr-2 pl-2 py-0 w-1 align-top whitespace-nowrap"
+                :class="{
+                  'text-red-300 dark:text-red-500/60': section.type === 'del',
+                  'text-emerald-300 dark:text-emerald-500/60': section.type === 'add',
+                  'text-zinc-300 dark:text-zinc-600': section.type === 'context',
+                }"
+              >{{ li + 1 }}</td>
+              <td class="px-1 py-0 w-4 select-none font-bold"
+                :class="{
+                  'text-red-400 dark:text-red-400': section.type === 'del',
+                  'text-emerald-500 dark:text-emerald-400': section.type === 'add',
+                }"
+              >{{ section.type === 'del' ? '-' : section.type === 'add' ? '+' : ' ' }}</td>
+              <td class="pr-3 py-0 whitespace-pre-wrap break-all"
+                :class="{
+                  'text-red-700 dark:text-red-300': section.type === 'del',
+                  'text-emerald-700 dark:text-emerald-300': section.type === 'add',
+                  'text-zinc-700 dark:text-zinc-300': section.type === 'context',
+                }"
+              >{{ line }}</td>
+            </tr>
+          </template>
+        </table>
+        <div v-else-if="tool.error" class="px-3 py-2 text-xs text-red-500 dark:text-red-400 font-mono whitespace-pre-wrap">{{ tool.error }}</div>
+        <div v-else-if="tool.status === 'running'" class="px-3 py-3 text-xs text-zinc-400 dark:text-zinc-500 animate-pulse">Applying…</div>
+        <div v-else class="px-3 py-2 text-xs text-zinc-400 dark:text-zinc-500 italic">No changes</div>
+      </div>
+      <!-- Diff result -->
+      <div v-if="tool.output && !tool.error" class="px-3 py-1.5 border-t border-zinc-200/60 dark:border-zinc-700/40 bg-zinc-50/50 dark:bg-zinc-800/40">
+        <div class="text-[10px] text-zinc-400 dark:text-zinc-500 font-mono">{{ truncate(tool.output, 200) }}</div>
+      </div>
+    </div>
+
+    <!-- ═══════ Expanded: Generic fallback ═══════ -->
+    <div
+      v-if="expanded && renderType === 'generic'"
+      class="ml-3 mt-0.5 pl-3 border-l-2 text-xs font-mono py-2 max-h-64 overflow-y-auto transition-all"
+      :class="tool.status === 'error'
+        ? 'border-red-300 dark:border-red-500/30'
+        : 'border-zinc-200 dark:border-zinc-700/60'"
+    >
+      <div class="mb-1.5">
+        <span class="text-[10px] text-zinc-400 dark:text-zinc-500 uppercase tracking-wider">args</span>
+        <div class="text-zinc-500 dark:text-zinc-400 mt-0.5">{{ formatArgs(tool.args) }}</div>
+      </div>
+      <div v-if="tool.output" class="mt-2">
+        <span class="text-[10px] text-zinc-400 dark:text-zinc-500 uppercase tracking-wider">output</span>
+        <div class="text-zinc-500 dark:text-zinc-400 whitespace-pre-wrap mt-0.5">
+          {{ truncate(tool.output, 500) }}
+        </div>
+      </div>
+      <div v-if="tool.error" class="mt-2">
+        <span class="text-[10px] text-red-400 dark:text-red-500 uppercase tracking-wider">error</span>
+        <div class="text-red-500 dark:text-red-400 whitespace-pre-wrap mt-0.5">{{ tool.error }}</div>
+      </div>
     </div>
   </div>
 </template>

--- a/web/src/composables/toolInfo.ts
+++ b/web/src/composables/toolInfo.ts
@@ -1,0 +1,82 @@
+// Tool display information utilities for client-side rendering.
+// Used when replaying sessions (where the backend display_info is not available).
+
+import type { ToolDisplayInfo } from '@/types/api'
+
+/** Extract the last 2 path components for compact display. */
+function shortenPath(path: string): string {
+  if (!path) return ''
+  const parts = path.replace(/\\/g, '/').split('/')
+  if (parts.length <= 2) return path
+  return '…/' + parts.slice(-2).join('/')
+}
+
+/**
+ * Extract display metadata from a tool name and its JSON args.
+ * Mirrors the backend extractToolDisplayInfo function for session replay.
+ */
+export function extractToolDisplayInfo(name: string, argsJSON: string): ToolDisplayInfo {
+  let args: Record<string, unknown> = {}
+  try {
+    args = JSON.parse(argsJSON) || {}
+  } catch {
+    // ignore parse errors
+  }
+
+  const getString = (key: string): string => {
+    const v = args[key]
+    return typeof v === 'string' ? v : ''
+  }
+
+  switch (name) {
+    case 'read':
+      return { title: 'Read', icon: 'file', category: 'context', subtitle: shortenPath(getString('file_path')) }
+    case 'write':
+      return { title: 'Write', icon: 'file-edit', category: 'mutation', subtitle: shortenPath(getString('file_path')) }
+    case 'edit':
+      return { title: 'Edit', icon: 'file-edit', category: 'mutation', subtitle: shortenPath(getString('file_path')) }
+    case 'multi_edit':
+      return { title: 'Multi Edit', icon: 'file-edit', category: 'mutation', subtitle: shortenPath(getString('file_path')) }
+    case 'glob':
+      return { title: 'Glob', icon: 'search', category: 'context', subtitle: getString('pattern') }
+    case 'grep':
+      return { title: 'Search', icon: 'search', category: 'context', subtitle: getString('pattern') }
+    case 'execute': {
+      let subtitle = getString('description')
+      if (!subtitle) {
+        const cmd = getString('command')
+        subtitle = cmd.length > 100 ? cmd.slice(0, 100) + '…' : cmd
+      }
+      return { title: 'Shell', icon: 'terminal', category: 'execution', subtitle }
+    }
+    case 'background':
+      return { title: 'Background', icon: 'terminal', category: 'execution', subtitle: getString('description') }
+    case 'todowrite':
+      return { title: 'Update Todos', icon: 'checklist', category: 'mutation' }
+    case 'todoread':
+      return { title: 'Read Todos', icon: 'checklist', category: 'context' }
+    case 'subagent': {
+      const subtitle = getString('description') || getString('name')
+      return { title: 'Subagent', icon: 'agent', category: 'execution', subtitle }
+    }
+    case 'ask_user': {
+      let subtitle = getString('question')
+      if (subtitle.length > 60) subtitle = subtitle.slice(0, 60) + '…'
+      return { title: 'Ask User', icon: 'question', category: 'context', subtitle }
+    }
+    default:
+      return { title: name, icon: 'tool', category: '' }
+  }
+}
+
+/** Map tool icon identifiers to SVG symbols or emoji for display. */
+export const TOOL_ICONS: Record<string, string> = {
+  file: '📄',
+  'file-edit': '✏️',
+  search: '🔍',
+  terminal: '💻',
+  checklist: '☑️',
+  agent: '🤖',
+  question: '❓',
+  tool: '🔧',
+}

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -10,8 +10,10 @@ import type {
   SessionItem,
   AgentMode,
   ProviderInfo,
+  ToolDisplayInfo,
 } from '@/types/api'
 import { api } from '@/composables/api'
+import { extractToolDisplayInfo } from '@/composables/toolInfo'
 
 let _seqId = 0
 function nextSeqId() {
@@ -99,7 +101,7 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  function addToolCall(name: string, args: string, toolCallID?: string) {
+  function addToolCall(name: string, args: string, toolCallID?: string, displayInfo?: ToolDisplayInfo) {
     // Flush current streaming — new text after tool will get a fresh message
     streamingText = ''
     streamingMsgId = ''
@@ -111,11 +113,12 @@ export const useChatStore = defineStore('chat', () => {
       args,
       status: 'running',
       timestamp: Date.now(),
+      displayInfo,
     }
     timeline.value.push({ kind: 'tool', data: tc, seq: nextSeqId() })
   }
 
-  function resolveToolCall(name: string, output: string, toolCallID?: string, error?: string) {
+  function resolveToolCall(name: string, output: string, toolCallID?: string, error?: string, displayOutput?: string) {
     // Prefer matching by backend tool_call_id (exact, unambiguous).
     // Fall back to name-based scan for older events without an ID.
     for (let i = timeline.value.length - 1; i >= 0; i--) {
@@ -127,6 +130,7 @@ export const useChatStore = defineStore('chat', () => {
         const nameMatch = !toolCallID && tc.name === name
         if (idMatch || nameMatch) {
           tc.output = output
+          tc.displayOutput = displayOutput || undefined
           tc.error = error
           tc.status = error ? 'error' : 'done'
           break
@@ -154,6 +158,7 @@ export const useChatStore = defineStore('chat', () => {
             args: detail,
             status: 'running',
             timestamp: Date.now(),
+            displayInfo: extractToolDisplayInfo(toolName, detail),
           })
         } else if (event === 'tool_result') {
           // Resolve the most recent running child with this toolName
@@ -307,7 +312,6 @@ export const useChatStore = defineStore('chat', () => {
       await api.switchModel(provider, model)
       providerName.value = provider
       modelName.value = model
-      clearChat()
     } catch (err: unknown) {
       addMessage('system', `Failed to switch model: ${err instanceof Error ? err.message : String(err)}`)
     }
@@ -397,6 +401,7 @@ export const useChatStore = defineStore('chat', () => {
             args: e.args || '',
             status: 'running',
             timestamp: e.timestamp ? new Date(e.timestamp).getTime() : Date.now(),
+            displayInfo: extractToolDisplayInfo(e.name, e.args || ''),
           }
           timeline.value.push({ kind: 'tool', data: tc, seq: nextSeqId() })
           if (e.tool_call_id) {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -50,8 +50,7 @@ html {
 
 /* ─── Focus ring ─── */
 *:focus-visible {
-  outline: 2px solid oklch(0.696 0.17 162.48 / 0.5);
-  outline-offset: 2px;
+  outline: none;
 }
 
 /* ─── Prose overrides for chat messages ─── */
@@ -125,3 +124,40 @@ html {
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
+/* ─── Tool Card Refinements ─── */
+
+/* Smooth expand/collapse transition */
+.tool-trigger {
+  transition: background-color 150ms var(--ease-out),
+              border-color 150ms var(--ease-out);
+}
+
+/* Context tool group: collapsed summary of read-only tools */
+.tool-context-group {
+  border-radius: var(--radius-lg);
+  border: 1px solid;
+  padding: 0.25rem 0.5rem;
+  margin: 0.25rem 0;
+}
+.dark .tool-context-group {
+  border-color: #27272a80;
+  background: #18181b40;
+}
+:root:not(.dark) .tool-context-group {
+  border-color: #e4e4e760;
+  background: #f4f4f540;
+}
+
+/* Diff change bars — colored blocks showing additions/deletions */
+.diff-bar-add {
+  background: #34d399;
+}
+.diff-bar-del {
+  background: #f87171;
+}
+.diff-bar-empty {
+  background: #3f3f46;
+}
+:root:not(.dark) .diff-bar-empty {
+  background: #d4d4d8;
+}

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -6,15 +6,15 @@
 
 :root {
   /* ─── Fonts ─── */
-  --font-sans: 'Outfit', ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
   /* ─── Radii ─── */
-  --radius-sm: 0.375rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
-  --radius-xl: 1rem;
-  --radius-2xl: 1.25rem;
+  --radius-sm: 0.125rem;
+  --radius-md: 0.1875rem;
+  --radius-lg: 0.25rem;
+  --radius-xl: 0.375rem;
+  --radius-2xl: 0.5rem;
   --radius-pill: 9999px;
 
   /* ─── Shadows (dark mode defaults) ─── */

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -23,6 +23,7 @@ export interface SessionItem {
   created_at: string
   provider: string
   model: string
+  title?: string
 }
 
 export interface SessionEntry {
@@ -163,11 +164,20 @@ export interface ToolCallData {
   name: string
   args: string
   tool_call_id?: string
+  display_info?: ToolDisplayInfo
+}
+
+export interface ToolDisplayInfo {
+  title: string
+  subtitle?: string
+  icon?: string
+  category?: string // 'context' | 'mutation' | 'execution'
 }
 
 export interface ToolResultData {
   name: string
   output: string
+  display_output?: string  // clean output for UI display (no metadata)
   error?: string
   tool_call_id?: string
 }
@@ -209,9 +219,12 @@ export interface ToolCall {
   name: string
   args: string
   output?: string
+  displayOutput?: string  // clean output for UI display
   error?: string
   status: 'running' | 'done' | 'error'
   timestamp: number
+  /** Display metadata extracted from tool args */
+  displayInfo?: ToolDisplayInfo
   /** For subagent tools: nested tool calls from within the subagent */
   children?: ToolCall[]
 }


### PR DESCRIPTION
## Summary

Comprehensive refinement of tool display, session management, and UI aesthetics for the web frontend and TUI.

### Tool Display Improvements
- **Specialized renderers**: Terminal-style for execute, file viewer for read/write, GitHub-style diff for edit/multi_edit
- **Execute tool `description` param**: LLM now provides a short human-readable description — mirrors opencode bash tool design
- **Display output**: New `display_output` field strips AI metadata (`STDOUT:`, `[Completed in Xs]`, `[Hint: ...]`) from tool output for clean UI rendering
- **Subagent child tools**: Child tool calls inside subagents now render with full displayInfo
- **Tool info composable**: `toolInfo.ts` with `extractToolDisplayInfo()` and `TOOL_ICONS`

### Session UX
- **Auto-generated titles**: Session title extracted from first user message
- **Session-scoped diff tracking**: Git snapshot before agent run enables "Session" mode in DiffViewer
- **TUI resume shows title**: Session picker displays title when available
- **Model switching preserves conversation**: Switching models no longer clears chat history

### UI Polish
- **GitHub system fonts**: system font stack matching GitHub
- **Minimal border-radius**: Reduced all radii globally
- **No focus ring**: Removed focus highlight on input box

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session titles auto-generated from your first message
  * Tool calls now include display metadata (title, icon, subtitle, category)
  * Session-scoped diff view to track git changes during a session
  * Richer tool-result views for command execution, file ops, and edits
  * Model switching preserves conversation history

* **Improvements**
  * Tool output cleaned and formatted for clearer UI presentation
  * Tool call timeline enriched for better context

* **Style**
  * Reduced border radii, font stack updates, and refined focus/rounded styles across the UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->