### PR TITLE
fix(session): make /resume consistent with --resume CLI flag

### DIFF
--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -442,6 +442,7 @@ func (s *interactiveState) handleResume(uuid string) {
 	st := session.ReconstructState(entries)
 	s.history = st.History
 	s.approvalState.SetSessionApproval(false)
+	s.rec.SetUUID(uuid)
 	s.p.Send(tui.SessionResumedMsg{UUID: uuid, Entries: tui.ConvertSessionEntries(entries)})
 
 	if st.Plan != nil {


### PR DESCRIPTION
## Problem

The `/resume` command inside an interactive session only restored history messages to memory but kept the session recorder pointing at the **current** session UUID. This caused new messages to be written to a **new** session file instead of appending to the resumed (old) session file.

Meanwhile, the `--resume <UUID>` CLI flag correctly called `rec.SetUUID(uuid)` to switch the recorder to the old session.

This inconsistency meant:
- `jcode --resume <UUID>` → correctly appends to old session file ✅
- `/resume <UUID>` inside a session → writes to a new session file ❌

## Fix

Add `s.rec.SetUUID(uuid)` in `handleResume()` so that the recorder switches to the old session UUID, matching the behavior of the `--resume` CLI flag path.

## Changes

- `internal/command/interactive.go`: Add `s.rec.SetUUID(uuid)` call after restoring session state in `handleResume()`

## Testing

- Build passes: `go build ./cmd/jcode/` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where resumed sessions were not properly tracked, ensuring session continuity and operations are correctly maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->