### PR TITLE
feat: redesign TUI with two-column layout, sidebar, and orange theme

### DIFF
--- a/DESIGN_PLAN.md
+++ b/DESIGN_PLAN.md
@@ -1,0 +1,781 @@
+# JCODE TUI Redesign Plan
+
+## 1. 设计总览
+
+将当前单列全宽布局重构为 **响应式两栏布局**，核心变化：
+
+- **Landing Page（无对话）**：Google 风格，居中 JCODE Logo + tagline + 输入框，无右侧栏，极简干净
+- **Chat Mode（有对话后）**：主内容区（左）+ 信息侧栏（右）
+- **窄屏回退（< 90 列）**：隐藏侧栏，回退单栏布局
+- **品牌统一**：所有 "Little Jack" → "JCODE"
+
+参考 [Crush](https://github.com/charmbracelet/crush) 和 [OpenCode](https://github.com/anomalyco/opencode) 的侧栏 + 主内容区分栏设计。
+
+---
+
+## 2. 布局线框图
+
+### 2.1 Landing Page（无对话，无侧边栏）
+
+```
++---------------------------------------------------------------+
+|                                                               |
+|                                                               |
+|                                                               |
+|                                                               |
+|                                                               |
+|                                                               |
+|                                                               |
+|                                                               |
+|                    J  C  O  D  E                              |
+|                    ═════════════                              |
+|                    coding assistant                           |
+|                                                               |
+|                                                               |
+|                                                               |
+|                                                               |
+|                                                               |
+|                                                               |
+|  ━━━ Agent ━━━ · ━━━ Ask ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ |
+|  > Type your prompt here...                                   |
+|  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ |
+|                                                               |
++---------------------------------------------------------------+
+```
+
+- 终端中心区域显示 **J C O D E** 大 Logo（violet bold，字母间 2 空格）
+- 下方细线 `═════════════` + "coding assistant" tagline（muted color）
+- 下方大面积留白
+- 底部：模式指示 pills（Agent/Plan + Ask/Auto）在输入框上方
+- 输入框全宽，placeholder 提示
+- **无任何右侧栏、无任何提示文字、无 header bar**
+
+### 2.2 Chat Mode（有对话，宽屏 ≥ 90 列）
+
+```
++----------------------------------------+----------------------+
+|                                        │  J C O D E           |
+|  👤 You: hello                         │  ─────────           |
+|                                        │                      |
+|  🤖 Assistant: Hi! How can I help?     │  Model               |
+|                                        │  openai / gpt-4      |
+|                                        │                      |
+|  ● Read file.go                        │  Env                 |
+|    ✓ result...                         │  🖥️  Local            |
+|                                        │                      |
+|                                        │  Usage               |
+|                                        │  [████░░░░░] 45%     |
+|                                        │                      |
+|                                        │  📋 Todo (3/5)       |
+|                                        │  ✓ completed task    |
+|                                        │  ⏳ in progress       |
+|                                        │  ○ pending task      |
+|                                        │  ○ another task      |
+|                                        │  ▼ 1 more            |
+|                                        │                      |
+|                                        │  MCP                 |
+|                                        │  ● filesystem (3)    |
+|                                        │                      |
++----------------------------------------+----------------------+
+|  ━━━ Agent ━━━ · ━━━ Ask ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ |
+|  > What's next?                                               |
+|  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ |
++---------------------------------------------------------------+
+```
+
+- **左侧主区域**：聊天 viewport（对话内容、tool call、结果、spinner）
+- **右侧边栏**（34 字符宽）：JCODE logo → Model → Env → Usage → Todo → MCP
+- **底部**：模式 pills 行 + 输入框 + 精简状态栏
+- 侧栏高度与 viewport 对齐（不含底部输入区）
+
+### 2.3 窄屏回退（< 90 列）
+
+```
++---------------------------------------------------------------+
+|  👤 You: hello                                                |
+|                                                               |
+|  🤖 Assistant: Hi! How can I help?                            |
+|                                                               |
+|  ● Read file.go                                               |
+|    ✓ result...                                                |
+|                                                               |
+|  ━━━ Agent ━━━ · ━━━ Ask ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ |
+|  > What's next?                                               |
+|  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ |
+|  Model: openai/gpt-4  │  Approve: Ask  │ [██░░░] 40%         |
++---------------------------------------------------------------+
+```
+
+- 侧栏自动隐藏
+- 关键信息（model、approve、usage）回退到精简状态栏
+- 单栏布局与当前类似，但模式 pills 仍然在输入框上方
+
+---
+
+## 3. 右侧边栏设计（Sidebar Component）
+
+### 3.1 文件：`internal/tui/sidebar_component.go`（新增）
+
+```go
+type SidebarState struct {
+    Width             int
+    Height            int
+    EnvLabel          string
+    ActiveProvider    string
+    ActiveModel       string
+    TotalTokens       int64
+    ModelContextLimit int
+    TodoItems         []tools.TodoItem
+    TodoScrollOffset  int  // 滚动偏移
+    MCPStatuses       []MCPStatusItem
+    HasConversation   bool // 是否有对话内容
+}
+
+type SidebarComponent struct{}
+
+func (s *SidebarComponent) View(state SidebarState) string
+```
+
+### 3.2 侧栏各区块设计
+
+**Logo 区（2 行）：**
+```
+  J C O D E
+  ─────────
+```
+- "J C O D E": `colorPrimary` (violet), Bold, 字母间 2 空格
+- 下方 `─` 线：同色系但 muted
+
+**Model 区（2-3 行）：**
+```
+  Model
+  openai / gpt-4
+```
+- "Model" label: `colorMuted` + Bold
+- model 名: `colorText`，provider/model 用 `/` 分隔
+
+**Env 区（2 行）：**
+```
+  Env
+  🖥️  Local
+```
+- SSH 时显示 `🔗 SSH (label)`
+
+**Usage 区（2 行）：**
+```
+  Usage
+  [████░░░░░] 45%
+```
+- 复用现有 `renderProgressBar()`
+- bar 颜色：绿 <70%、橙 70-90%、红 >90%
+
+**Todo 区（动态高度，最少 2 行）：**
+```
+  📋 Todo (3/5)
+  ✓ completed
+  ⏳ in progress
+  ○ pending
+  ▼ 1 more
+```
+- 可滚动：通过 `TodoScrollOffset` 控制显示哪些项
+- 显示范围由可用高度动态计算
+- 滚动指示：▲ 上方还有更多 / ▼ 下方还有更多
+- 每项带对应状态图标（复用现有 todo styles）
+- 最多占用侧栏剩余空间的 60%
+
+**MCP 区（动态高度）：**
+```
+  MCP
+  ● filesystem (3)
+  ○ github (0)
+```
+- 只显示 running 的 server
+- `●` green = running, `○` muted = inactive
+- 格式：`name (toolCount)`
+
+### 3.3 侧栏整体样式
+
+```go
+sidebarStyle = lipgloss.NewStyle().
+    Border(lipgloss.Border{Left: "│"}).
+    BorderForeground(colorMuted).
+    PaddingLeft(1).
+    PaddingRight(1)
+
+sidebarSectionTitleStyle = lipgloss.NewStyle().
+    Bold(true).
+    Foreground(colorMuted)
+
+sidebarItemStyle = lipgloss.NewStyle().
+    Foreground(colorText)
+```
+
+侧栏左边界用 `│` 细线分隔主内容区，整体 padding 1，无上下边框。
+
+---
+
+## 4. 模式指示 Pills（输入框上方）
+
+### 4.1 设计
+
+在输入框 textarea 的**正上方**添加一行模式指示：
+
+```
+  ━━━ Agent ━━━ · ━━━ Ask ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Agent/Plan Pill：**
+- 正常: `Agent` — cyan bold，无背景
+- 计划: `Plan` — color "99" bold，无背景
+- 当前激活模式用 `━━━` 包裹，例如 `━━━ Agent ━━━`
+
+**Approve Pill：**
+- Ask: `Ask` — `colorMuted`
+- Auto: `Auto` — `colorWarning` (amber)
+- 同样用 `━━━` 包裹激活状态
+
+**分隔：** 两个 pill 之间用 ` · `（居中点）分隔
+
+**剩余部分：** 用 `━` 或 `─` 填充到行尾
+
+### 4.2 代码位置
+
+新增 `renderModePills()` 在 `input_views.go`，`inputAreaView()` 在 textarea 上方插入这行。
+
+---
+
+## 5. Landing Page 实现
+
+### 5.1 触发条件
+
+当 `len(m.lines) == 0 && !m.thinking` 时，显示 Landing Page。
+
+### 5.2 Landing Page View
+
+新增 `landingPageView()` 方法：
+
+```go
+func (m Model) landingPageView() string {
+    // 垂直居中计算
+    logo := lipgloss.NewStyle().Bold(true).Foreground(colorPrimary).
+        Render("J  C  O  D  E")
+    underline := lipgloss.NewStyle().Foreground(colorMuted).
+        Render("═════════════")
+    tagline := lipgloss.NewStyle().Foreground(colorMuted).
+        Render("coding assistant")
+
+    // 垂直居中排列
+    contentHeight := 5 // logo + underline + tagline + spacing
+    topPad := (m.height - contentHeight - m.inputAreaHeight()) / 2
+    if topPad < 0 { topPad = 0 }
+
+    parts := []string{
+        strings.Repeat("\n", topPad),
+        lipgloss.PlaceHorizontal(m.width, lipgloss.Center, logo),
+        lipgloss.PlaceHorizontal(m.width, lipgloss.Center, underline),
+        lipgloss.PlaceHorizontal(m.width, lipgloss.Center, tagline),
+    }
+    parts = append(parts, m.inputAreaView())
+    return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+```
+
+### 5.3 Landing → Chat 过渡
+
+用户提交第一条消息后，`m.lines` 不再为空，自动切换到 Chat Mode 布局，侧边栏出现。
+
+---
+
+## 6. 品牌统一：Little Jack → JCODE
+
+| 文件 | 当前文本 | 修改为 |
+|------|---------|--------|
+| `internal/tui/tui.go:288` | Welcome to Little Jack... | Welcome to JCODE... |
+| `internal/tui/tui.go:1203` | Welcome to Little Jack | Welcome to JCODE |
+| `internal/tui/tui.go:1529` | Welcome to Little Jack | Welcome to JCODE |
+| `internal/tui/tui.go:2248` | 🚀 Little Jack — Coding Assistant | （删除，header 栏移除） |
+| `internal/tui/tui.go:2470` | 🚀 Little Jack — Coding Assistant | J C O D E |
+| `internal/tui/setup.go:477` | 🚀 Little Jack — Setup | ▓▒░ JCODE — Setup ░▒▓ |
+| `cmd/jcode/main.go:21` | Little Jack — AI coding assistant | JCODE — AI coding assistant |
+| `cmd/jcode/main.go:29` | Little Jack — Coding Assistant | JCODE — Coding Assistant |
+| `internal/command/commands.go:20` | Little Jack — Coding Assistant | JCODE — Coding Assistant |
+| `internal/command/commands.go:28` | Little Jack — Coding Assistant | JCODE — Coding Assistant |
+| `internal/command/acp.go:191` | Little Jack — Coding Assistant | JCODE — Coding Assistant |
+| `script/install.sh:148` | Little Jack — Coding Assistant | JCODE — Coding Assistant |
+| `internal/prompts/system.md:1` | You are "Little Jack"... | You are "JCODE"... |
+| `internal/prompts/plan.md:1` | You are "Little Jack"... | You are "JCODE"... |
+| `internal-docs/design/.../ui.md` | 🚀 Little Jack — Coding Assistant | JCODE |
+
+---
+
+## 7. 两栏布局核心修改（tui.go View()）
+
+### 7.1 新增常量与字段
+
+```go
+const sidebarWidth = 34  // 侧栏固定宽度（含边界和 padding）
+const minWidthForSidebar = 90  // 显示侧栏的最小终端宽度
+
+// Model 新增字段
+type Model struct {
+    // ... 现有字段 ...
+    showSidebar        bool   // 当前是否显示侧栏
+    sidebarScrollOffset int   // 侧栏 todo 滚动偏移
+    // ...
+}
+```
+
+### 7.2 View() 重构逻辑
+
+```go
+func (m Model) View() tea.View {
+    // 各种 picker/modal 的提前返回保持不变 ...
+
+    if !m.ready {
+        return m.newView("\n  Initializing...")
+    }
+
+    // Landing page: 无对话且无思考中
+    if len(m.lines) == 0 && !m.thinking && !m.agentDone {
+        return m.newView(m.landingPageView())
+    }
+
+    // 决定是否显示侧栏
+    m.showSidebar = m.width >= minWidthForSidebar
+
+    // 计算主内容区宽度
+    mainWidth := m.width
+    if m.showSidebar {
+        mainWidth = m.width - sidebarWidth - 1  // -1 for gap
+    }
+
+    // 渲染输入区（全宽，因为 pills 和状态栏需要全宽信息）
+    footer := m.inputAreaView()
+    footerHeight := lipgloss.Height(footer)
+
+    // 主内容区（viewport）
+    m.viewport.SetWidth(mainWidth)
+    m.viewport.SetHeight(m.height - footerHeight)
+    if m.viewport.Height() < 3 {
+        m.viewport.SetHeight(3)
+    }
+    m.viewport.SetContent(strings.TrimRight(m.renderContent(), "\n"))
+
+    vpView := m.viewport.View()
+    if m.hasSelection || m.mouseSelecting {
+        vpView = m.applySelectionHighlight(vpView)
+    }
+
+    // 组装主视图
+    if m.showSidebar {
+        // 渲染侧栏
+        sidebar := m.renderSidebar()
+        // 水平拼接：主内容 + 侧栏
+        contentRow := lipgloss.JoinHorizontal(lipgloss.Top, vpView, sidebar)
+        mainView := lipgloss.JoinVertical(lipgloss.Left, contentRow, footer)
+        return m.newView(mainView)
+    }
+
+    // 窄屏：单栏布局
+    mainView := lipgloss.JoinVertical(lipgloss.Left, vpView, footer)
+    return m.newView(mainView)
+}
+```
+
+### 7.3 Header 栏移除
+
+当前 header（`🚀 Little Jack... | 🖥️ Env: Local`）完全移除：
+- Logo → 侧栏 / Landing Page
+- Env → 侧栏
+- Team pill → 侧栏（新增）或保留在底部状态栏
+
+---
+
+## 8. 输入区重构（input_views.go）
+
+### 8.1 inputAreaView() 新结构
+
+```go
+func (m Model) inputAreaView() string {
+    var parts []string
+
+    // 1. 模式 pills 行（新增）
+    parts = append(parts, m.renderModePills())
+
+    // 2. 输入框内容
+    switch {
+    case m.planReviewActive:
+        parts = append(parts, m.planReviewPromptView())
+    case m.askUserActive:
+        parts = append(parts, m.askUserPromptView())
+    default:
+        if m.cmdSuggestionActive && len(m.cmdSuggestions) > 0 {
+            parts = append(parts, m.renderCommandSuggestions())
+        }
+        parts = append(parts, lipgloss.NewStyle().PaddingLeft(1).PaddingRight(2).
+            Render(strings.TrimRight(m.textarea.View(), "\n")))
+    }
+
+    // 3. 精简状态栏（窄屏时显示关键信息）
+    if !m.showSidebar {
+        parts = append(parts, m.renderFallbackStatusBar())
+    } else {
+        // 宽屏时状态栏只保留 copy notice + bg tasks
+        parts = append(parts, m.renderMinimalStatusBar())
+    }
+
+    return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+```
+
+### 8.2 Todo Bar 从输入区移除
+
+`renderTodoBar()` 不再在 `inputAreaView()` 中调用，Todo 完全移到侧栏。
+
+### 8.3 renderModePills() 新增
+
+```go
+func (m Model) renderModePills() string {
+    // Agent/Plan pill
+    var modePill string
+    switch m.agentMode {
+    case ModePlanning:
+        modePill = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("99")).
+            Render("━━━ Plan ━━━")
+    default:
+        modePill = lipgloss.NewStyle().Bold(true).Foreground(colorSecondary).
+            Render("━━━ Agent ━━━")
+    }
+
+    // Approve pill
+    var approvePill string
+    if m.approvalMode == ModeAuto {
+        approvePill = lipgloss.NewStyle().Bold(true).Foreground(colorWarning).
+            Render("━━━ Auto ━━━")
+    } else {
+        approvePill = lipgloss.NewStyle().Bold(true).Foreground(colorMuted).
+            Render("━━━ Ask ━━━")
+    }
+
+    // 分隔符
+    separator := lipgloss.NewStyle().Foreground(colorMuted).Render(" · ")
+
+    leftPart := modePill + separator + approvePill + " "
+    leftW := lipgloss.Width(leftPart)
+
+    // 用 ─ 填充到行尾
+    remaining := m.width - leftW
+    if remaining < 0 {
+        remaining = 0
+    }
+    fill := lipgloss.NewStyle().Foreground(colorMuted).
+        Render(strings.Repeat("─", remaining))
+
+    return leftPart + fill
+}
+```
+
+---
+
+## 9. 侧栏渲染（新增 sidebar_component.go）
+
+### 9.1 核心渲染逻辑
+
+```go
+func (s *SidebarComponent) View(state SidebarState) string {
+    var sections []string
+
+    // Logo
+    sections = append(sections, "")
+    sections = append(sections, s.renderLogo())
+    sections = append(sections, "")
+
+    // Model
+    sections = append(sections, s.renderModelSection(state))
+    sections = append(sections, "")
+
+    // Env
+    sections = append(sections, s.renderEnvSection(state))
+    sections = append(sections, "")
+
+    // Usage
+    if state.TotalTokens > 0 || state.ModelContextLimit > 0 {
+        sections = append(sections, s.renderUsageSection(state))
+        sections = append(sections, "")
+    }
+
+    // Todo (可滚动，动态高度)
+    if len(state.TodoItems) > 0 {
+        sections = append(sections, s.renderTodoSection(state))
+        sections = append(sections, "")
+    }
+
+    // MCP
+    if len(state.MCPStatuses) > 0 {
+        sections = append(sections, s.renderMCPSection(state))
+        sections = append(sections, "")
+    }
+
+    content := strings.Join(sections, "\n")
+
+    // 应用样式：左边界线 + padding
+    style := lipgloss.NewStyle().
+        Border(lipgloss.Border{Left: "│"}).
+        BorderForeground(colorMuted).
+        PaddingLeft(1).
+        PaddingRight(1).
+        Height(state.Height)
+
+    return style.Width(state.Width).Render(content)
+}
+```
+
+### 9.2 Todo 滚动实现
+
+```go
+func (s *SidebarComponent) renderTodoSection(state SidebarState) string {
+    var lines []string
+    completed, total := countTodos(state.TodoItems)
+    header := fmt.Sprintf("📋 Todo (%d/%d)", completed, total)
+    lines = append(lines, sidebarSectionTitleStyle.Render(header))
+
+    // 计算可用行数
+    usedLines := s.countUsedLines(state)  // 其他 section 已用行数
+    available := state.Height - usedLines - 2  // 留给 todo 的行数
+    if available < 3 {
+        available = 3
+    }
+
+    items := state.TodoItems
+    start := state.TodoScrollOffset
+    if start < 0 {
+        start = 0
+    }
+    if start > len(items) {
+        start = len(items)
+    }
+
+    // 上方滚动指示
+    if start > 0 {
+        lines = append(lines, lipgloss.NewStyle().Foreground(colorMuted).Render("  ▲ "+strconv.Itoa(start)+" more"))
+    }
+
+    // 显示项
+    end := start + available - 1  // -1 for scroll indicator space
+    if end > len(items) {
+        end = len(items)
+    }
+    for i := start; i < end && i < len(items); i++ {
+        lines = append(lines, s.renderTodoItem(items[i]))
+    }
+
+    // 下方滚动指示
+    if end < len(items) {
+        lines = append(lines, lipgloss.NewStyle().Foreground(colorMuted).Render("  ▼ "+strconv.Itoa(len(items)-end)+" more"))
+    }
+
+    return strings.Join(lines, "\n")
+}
+```
+
+### 9.3 侧栏滚动键绑定
+
+在 `Update()` 的 key handling 中添加：
+
+```go
+case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+up"))):
+    if m.showSidebar && len(m.todoStore.Items()) > 0 {
+        m.sidebarScrollOffset--
+        if m.sidebarScrollOffset < 0 {
+            m.sidebarScrollOffset = 0
+        }
+    }
+case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+down"))):
+    if m.showSidebar && m.todoStore != nil {
+        maxOffset := len(m.todoStore.Items()) - 5
+        if maxOffset < 0 {
+            maxOffset = 0
+        }
+        m.sidebarScrollOffset++
+        if m.sidebarScrollOffset > maxOffset {
+            m.sidebarScrollOffset = maxOffset
+        }
+    }
+```
+
+> **注**：`Ctrl+↑/↓` 为侧栏 todo 滚动快捷键。
+
+---
+
+## 10. 状态栏精简
+
+### 10.1 宽屏状态栏（minimal）
+
+仅保留：
+- Copy notice（绿色斜体，2s 自动清除）
+- Background tasks: `Bg: N running`（如有）
+
+```go
+func (m Model) renderMinimalStatusBar() string {
+    var parts []string
+    if m.copyNotice != "" {
+        parts = append(parts, lipgloss.NewStyle().Foreground(colorSuccess).Italic(true).Render(m.copyNotice))
+    }
+    if m.bgRunning > 0 {
+        parts = append(parts, lipgloss.NewStyle().Foreground(colorWarning).Render(fmt.Sprintf("Bg: %d running", m.bgRunning)))
+    }
+    if len(parts) == 0 {
+        return lipgloss.NewStyle().Foreground(colorMuted).Render(strings.Repeat("─", m.width))
+    }
+    txt := strings.Join(parts, " │ ")
+    txtW := lipgloss.Width(txt)
+    fill := strings.Repeat("─", m.width-txtW-2)
+    return lipgloss.NewStyle().Foreground(colorMuted).Render(fill+" "+txt)
+}
+```
+
+### 10.2 窄屏状态栏（fallback）
+
+回退当前 status bar 的大部分信息：
+- Model: provider/model
+- Approve: Ask/Auto
+- Token usage bar
+- Bg tasks
+- Team count
+- MCP summary
+
+复用现有 `StatusBarComponent.View()` 但去掉 mode indicator（因为 pills 已显示）。
+
+---
+
+## 11. 鼠标支持调整
+
+当前鼠标拖拽选择文本基于 viewport 坐标。两栏布局后，viewport 变窄，鼠标坐标系需要调整：
+
+- `handleMouseClick/Drag/Release` 中的 `msg.X` 需要减去侧栏宽度（如果侧栏在右侧）
+- 或者更简单：鼠标事件只作用于主 viewport 区域，侧栏不接受鼠标交互
+
+在 `Update()` 的 mouse handling 中添加边界检查：
+
+```go
+if m.showSidebar {
+    sidebarStartX := m.width - sidebarWidth
+    if msg.X >= sidebarStartX {
+        // 鼠标在侧栏区域，忽略（或未来用于侧栏交互）
+        return m, nil
+    }
+}
+```
+
+---
+
+## 12. Team Panel 位置
+
+当前 team coordinator panel 在 viewport 下方、输入区上方。新布局中：
+
+**方案 A**：team panel 跨全宽（在 viewport+sidebar 下方）
+**方案 B**：team panel 只出现在主内容区下方
+
+推荐 **方案 A**（跨全宽），因为 team 信息是重要的全局面板：
+
+```
++----------------------------------------+----------------------+
+|  Main viewport                         │  Sidebar             |
++----------------------------------------+----------------------+
+|  Team: project (3)                                                 |
+|  ● Main  ○ @backend 5s  ○ @frontend 2s                            |
++--------------------------------------------------------------------+
+|  ━━━ Agent ━━━ · ━━━ Ask ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ |
+|  > Input...                                                        |
++--------------------------------------------------------------------+
+```
+
+---
+
+## 13. 实现顺序（推荐）
+
+按依赖顺序执行，每步可独立测试：
+
+### Phase 1: 基础架构（可独立测试）
+1. **创建 `sidebar_component.go`**：SidebarComponent + SidebarState + 各 section 渲染
+2. **修改 `styles.go`**：添加 sidebar 相关样式
+3. **修改 `tui.go`**：
+   - 新增 `showSidebar`, `sidebarScrollOffset` 字段
+   - 新增 `sidebarWidth`, `minWidthForSidebar` 常量
+   - 新增 `renderSidebar()` 方法
+   - 修改 `View()`：实现两栏/单栏/landing 分支逻辑
+   - 新增 `landingPageView()` 方法
+   - 修改 `calcViewportHeight()` 适配新布局
+   - 移除旧 header bar 渲染
+
+### Phase 2: 输入区重构（依赖 Phase 1）
+4. **修改 `input_views.go`**：
+   - 新增 `renderModePills()`
+   - 修改 `inputAreaView()`：插入 pills，移除 todo bar
+   - 移除 status bar 中的 mode/model/approve/usage/todo/mcp
+   - 新增 `renderMinimalStatusBar()` 和 `renderFallbackStatusBar()`
+
+### Phase 3: 品牌统一（可并行）
+5. **全局替换 "Little Jack" → "JCODE"**：
+   - `internal/tui/tui.go`
+   - `internal/tui/setup.go`
+   - `cmd/jcode/main.go`
+   - `internal/command/commands.go`
+   - `internal/command/acp.go`
+   - `script/install.sh`
+   - `internal/prompts/system.md`
+   - `internal/prompts/plan.md`
+   - `internal-docs/design/autonomous_env_switching/ui.md`
+
+### Phase 4: 交互完善（依赖 Phase 1-2）
+6. **修改 `tui.go` Update()**：
+   - 添加 `Ctrl+↑/↓` 侧栏 todo 滚动键绑定
+   - 调整鼠标事件边界检查
+   - 确保 landing → chat 过渡平滑
+
+7. **测试场景**：
+   - Landing page（无对话）
+   - 第一条消息提交后切换布局
+   - 宽屏两栏布局
+   - 窄屏回退单栏
+   - Plan/Agent 模式切换 pills 更新
+   - Ask/Auto approve 切换 pills 更新
+   - Todo 滚动
+   - MCP 状态更新
+   - Team panel 显示
+
+---
+
+## 14. 风险与注意事项
+
+1. **viewport 宽度变化**：Markdown renderer (`glamour`) 的 word wrap 依赖于 viewport 宽度。侧栏出现后 viewport 变窄，需确保 `glamour.WithWordWrap()` 使用新的主内容区宽度。
+
+2. **Team panel 全宽显示**：team panel 跨越主内容区 + 侧栏下方，需确保宽度正确。
+
+3. **选择高亮坐标**：`applySelectionHighlight()` 中的坐标基于 viewport 宽度，需验证窄屏和宽屏下都正确。
+
+4. **侧栏高度同步**：viewport 高度变化时（如 todo bar 消失、team panel 出现/隐藏），侧栏高度需同步重新计算。
+
+5. **初始化顺序**：`View()` 中不能修改 Model 状态（Bubble Tea 规则），`showSidebar` 的计算应放在 `Update()` 的 `tea.WindowSizeMsg` 处理中。
+
+---
+
+## 15. 关键代码变更清单
+
+| 文件 | 操作 | 变更内容 |
+|------|------|---------|
+| `internal/tui/sidebar_component.go` | 新增 | SidebarComponent, SidebarState, logo/model/env/usage/todo/mcp 渲染 |
+| `internal/tui/styles.go` | 修改 | 添加 sidebarSectionTitleStyle, sidebarItemStyle, modePillActiveStyle, modePillInactiveStyle, landingLogoStyle 等 |
+| `internal/tui/tui.go` | 大幅修改 | View() 两栏/landing 布局, renderSidebar(), landingPageView(), 移除 header, 新增字段 |
+| `internal/tui/input_views.go` | 修改 | inputAreaView() 结构, 新增 renderModePills(), 移除 todo bar, 精简状态栏 |
+| `internal/tui/statusbar_component.go` | 修改 | 窄屏回退逻辑，宽屏时大部分信息移到侧栏 |
+| `internal/tui/selection.go` | 修改 | 鼠标事件边界检查（排除侧栏区域） |
+| `internal/tui/team_view.go` | 可能修改 | Team panel 全宽渲染确认 |
+| `cmd/jcode/main.go` | 修改 | CLI 描述 branding |
+| `internal/command/commands.go` | 修改 | version/help branding |
+| `internal/command/acp.go` | 修改 | ACP title branding |
+| `internal/tui/setup.go` | 修改 | Setup wizard branding |
+| `script/install.sh` | 修改 | Installer branding |
+| `internal/prompts/system.md` | 修改 | AI persona name |
+| `internal/prompts/plan.md` | 修改 | AI persona name |
+| `internal-docs/.../ui.md` | 修改 | 设计文档更新 |

--- a/cmd/jcode/main.go
+++ b/cmd/jcode/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	rootCmd := &cobra.Command{
 		Use:           "jcode",
-		Short:         "Little Jack — AI coding assistant",
+		Short:         "JCODE — AI coding assistant",
 		Version:       command.Version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -26,7 +26,7 @@ func main() {
 			return command.RunInteractive(prompt, resumeUUID, unsafeMode)
 		},
 	}
-	rootCmd.SetVersionTemplate(fmt.Sprintf("Little Jack — Coding Assistant\nVersion:    %s\nBuild time: %s\nGit commit: %s\n", command.Version, command.BuildTime, command.GitCommit))
+	rootCmd.SetVersionTemplate(fmt.Sprintf("JCODE — Coding Assistant\nVersion:    %s\nBuild time: %s\nGit commit: %s\n", command.Version, command.BuildTime, command.GitCommit))
 	rootCmd.Flags().StringVarP(&prompt, "prompt", "p", "", "One-shot prompt (non-interactive)")
 	rootCmd.Flags().StringVar(&resumeUUID, "resume", "", "Resume a previous session by UUID")
 	rootCmd.Flags().BoolVar(&unsafeMode, "unsafe", false, "Auto-approve all tool calls (overrides config)")

--- a/internal-docs/design/autonomous_env_switching/ui.md
+++ b/internal-docs/design/autonomous_env_switching/ui.md
@@ -8,8 +8,8 @@ The most prominent place to show the global execution context is the Header area
 Instead of just a static title, the Header will dynamically reflect the `Env` state.
 
 **Example Layouts:**
-- **Local (Default)**: `🚀 Little Jack — Coding Assistant  |  🖥️  Env: Local`
-- **Connected (SSH)**: `🚀 Little Jack — Coding Assistant  |  🔗 Env: SSH (prod-db)`
+- **Local (Default)**: `J C O D E  |  🖥️  Env: Local`
+- **Connected (SSH)**: `J C O D E  |  🔗 Env: SSH (prod-db)`
 
 ## 3. Environment States & Transitions
 The UI needs to gracefully handle the transition when the agent calls `switch_env`:

--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -188,7 +188,7 @@ func (a *acpAgent) Initialize(_ context.Context, params acp.InitializeRequest) (
 		},
 		AgentInfo: &acp.Implementation{
 			Name:    "jcode",
-			Title:   acp.Ptr("Little Jack — Coding Assistant"),
+			Title:   acp.Ptr("JCODE — Coding Assistant"),
 			Version: Version, // set from internal/command/version.go
 		},
 	}, nil

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -17,15 +17,22 @@ import (
 )
 
 func printVersion() {
-	fmt.Printf("Little Jack — Coding Assistant\n")
+	fmt.Printf("JCODE — Coding Assistant\n")
 	fmt.Printf("Version:    %s\n", Version)
 	fmt.Printf("Build time: %s\n", BuildTime)
 	fmt.Printf("Git commit: %s\n", GitCommit)
 }
 
 func runDoctorMode() {
+	// ANSI color codes for [JCODE] logo
+	orange := "\033[1;38;2;255;132;0m"
+	gray := "\033[38;2;107;114;128m"
+	reset := "\033[0m"
+	logo := fmt.Sprintf("%s[%s%sJ%s%sCODE%s%s]%s", gray, reset, orange, reset, gray, reset, gray, reset)
+
 	fmt.Println("┌─────────────────────────────────────┐")
-	fmt.Println("│  Little Jack — Coding Assistant      │")
+	fmt.Printf("│  %-35s│\n", logo)
+	fmt.Println("│  ─────────────────────────────────  │")
 	fmt.Printf("│  Version:    %-23s│\n", Version)
 	fmt.Printf("│  Build time: %-23s│\n", BuildTime)
 	fmt.Printf("│  Git commit: %-23s│\n", GitCommit)

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -29,9 +29,15 @@ func runDoctorMode() {
 	gray := "\033[38;2;107;114;128m"
 	reset := "\033[0m"
 	logo := fmt.Sprintf("%s[%s%sJ%s%sCODE%s%s]%s", gray, reset, orange, reset, gray, reset, gray, reset)
+	// Visible width of "[JCODE]" is 7; pad manually to align the box border.
+	visibleWidth := 7 // len("[JCODE]")
+	padding := 35 - visibleWidth
+	if padding < 0 {
+		padding = 0
+	}
 
 	fmt.Println("┌─────────────────────────────────────┐")
-	fmt.Printf("│  %-35s│\n", logo)
+	fmt.Printf("│  %s%s│\n", logo, fmt.Sprintf("%*s", padding, ""))
 	fmt.Println("│  ─────────────────────────────────  │")
 	fmt.Printf("│  Version:    %-23s│\n", Version)
 	fmt.Printf("│  Build time: %-23s│\n", BuildTime)

--- a/internal/prompts/plan.md
+++ b/internal/prompts/plan.md
@@ -1,4 +1,4 @@
-You are "Little Jack" in **Plan Mode** — a software architect and planning specialist.
+You are "JCODE" in **Plan Mode** — a software architect and planning specialist.
 
 Current work path: {{ .Pwd }}
 Platform: {{ .Platform }}

--- a/internal/prompts/system.md
+++ b/internal/prompts/system.md
@@ -1,4 +1,4 @@
-You are "Little Jack", a coding assistant.
+You are "JCODE", a coding assistant.
 
 Current work path: {{ .Pwd }}
 Platform: {{ .Platform }}

--- a/internal/tui/input_views.go
+++ b/internal/tui/input_views.go
@@ -124,16 +124,13 @@ func (m *Model) updateSuggestions() {
 func (m Model) inputAreaView() string {
 	var parts []string
 
-	// Show todo bar (compact) unless a bottom prompt needs the space
-	if m.todoStore != nil && m.todoStore.HasItems() {
-		todoLine := m.renderTodoBar()
-		if todoLine != "" {
-			parts = append(parts, todoLine)
-		}
-	}
+	// Determine sidebar visibility locally
+	showSidebar := m.width >= minWidthForSidebar && len(m.lines) > 0
 
-	parts = append(parts, divider(m.width))
+	// 1. Mode pills line (Agent/Plan + Ask/Auto)
+	parts = append(parts, m.renderModePills())
 
+	// 2. Input content: textarea or special prompts
 	switch {
 	case m.planReviewActive:
 		parts = append(parts, m.planReviewPromptView())
@@ -146,32 +143,19 @@ func (m Model) inputAreaView() string {
 				parts = append(parts, suggestionView)
 			}
 		}
-		parts = append(parts, lipgloss.NewStyle().PaddingLeft(1).PaddingRight(2).Render(strings.TrimRight(m.textarea.View(), "\n")))
+		// Clean textarea — no background, no border, with subtle vertical padding
+		taView := strings.TrimRight(m.textarea.View(), "\n")
+		parts = append(parts, lipgloss.NewStyle().PaddingTop(1).PaddingBottom(1).Render(taView))
 	}
 
-	parts = append(parts, divider(m.width))
-
-	// Render StatusBar using StatusBarComponent
-	sbComp := NewStatusBarComponent()
-	teammateCount := len(m.teamState.Teammates)
-	activeTokens := m.totalTokens
-	if m.teamState.ViewingAgent != "" {
-		activeTokens = m.teammateTokens[m.teamState.ViewingAgent]
+	// 3. Status bar (minimal for wide screen, fallback for narrow)
+	if showSidebar {
+		if status := m.renderMinimalStatusBar(); status != "" {
+			parts = append(parts, status)
+		}
+	} else {
+		parts = append(parts, m.renderFallbackStatusBar())
 	}
-	statusLine := sbComp.View(StatusBarState{
-		Width:             m.width,
-		ActiveProvider:    m.activeProvider,
-		ActiveModel:       m.activeModel,
-		AutoApprove:       m.approvalMode == ModeAuto,
-		TotalTokens:       activeTokens,
-		ModelContextLimit: m.modelContextLimit,
-		MCPStatuses:       m.mcpStatuses,
-		Mode:              m.agentMode,
-		BgRunning:         m.bgRunning,
-		TeammateCount:     teammateCount,
-		CopyNotice:        m.copyNotice,
-	})
-	parts = append(parts, statusLine)
 
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
@@ -358,4 +342,88 @@ func (m Model) handleSkillSlashInput(skillName, userInput string, cmds []tea.Cmd
 	})
 	cmds = append(cmds, m.spinner.Tick)
 	return m, tea.Batch(cmds...)
+}
+
+// renderModePills renders the Agent/Plan + Ask/Auto mode indicator line above the input.
+func (m Model) renderModePills() string {
+	// Mode pill (Agent / Plan)
+	var modePill string
+	switch m.agentMode {
+	case ModePlanning:
+		modePill = modePillPlanStyle.Render(" Plan ")
+	default:
+		modePill = modePillAgentStyle.Render(" Agent ")
+	}
+
+	// Approve pill (Ask / Auto)
+	var approvePill string
+	if m.approvalMode == ModeAuto {
+		approvePill = modePillAutoStyle.Render(" Auto ")
+	} else {
+		approvePill = modePillAskStyle.Render(" Ask ")
+	}
+
+	separator := modeSeparatorStyle.Render("·")
+	leftPart := modePill + " " + separator + " " + approvePill + " "
+	leftW := lipgloss.Width(leftPart)
+
+	// Fill remaining width with dashes
+	fillWidth := m.width - leftW
+	if fillWidth < 0 {
+		fillWidth = 0
+	}
+	fill := modeFillStyle.Render(strings.Repeat("─", fillWidth))
+
+	return leftPart + fill
+}
+
+// renderMinimalStatusBar renders a minimal status bar for wide-screen mode (sidebar visible).
+// Only shows copy notice and background tasks. Returns empty string when nothing to show.
+func (m Model) renderMinimalStatusBar() string {
+	var parts []string
+	if m.copyNotice != "" {
+		parts = append(parts, lipgloss.NewStyle().Foreground(colorSuccess).Italic(true).Render(m.copyNotice))
+	}
+	if m.bgRunning > 0 {
+		parts = append(parts, lipgloss.NewStyle().Foreground(colorWarning).Render(fmt.Sprintf("⏳ %d background", m.bgRunning)))
+	}
+	if m.teamState.HasTeam() {
+		parts = append(parts, RenderTeamStatusPill(len(m.teamState.Teammates)))
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	txt := strings.Join(parts, " │ ")
+	txtW := lipgloss.Width(txt)
+	fillW := m.width - txtW - 2
+	if fillW < 0 {
+		fillW = 0
+	}
+	fill := minimalStatusBarStyle.Render(strings.Repeat("─", fillW))
+	return fill + " " + txt
+}
+
+// renderFallbackStatusBar renders a full status bar for narrow-screen mode (no sidebar).
+func (m Model) renderFallbackStatusBar() string {
+	sbComp := NewStatusBarComponent()
+	teammateCount := len(m.teamState.Teammates)
+	activeTokens := m.totalTokens
+	if m.teamState.ViewingAgent != "" {
+		activeTokens = m.teammateTokens[m.teamState.ViewingAgent]
+	}
+	return sbComp.View(StatusBarState{
+		Width:             m.width,
+		ActiveProvider:    m.activeProvider,
+		ActiveModel:       m.activeModel,
+		AutoApprove:       m.approvalMode == ModeAuto,
+		TotalTokens:       activeTokens,
+		ModelContextLimit: m.modelContextLimit,
+		MCPStatuses:       m.mcpStatuses,
+		Mode:              m.agentMode,
+		BgRunning:         m.bgRunning,
+		TeammateCount:     teammateCount,
+		CopyNotice:        m.copyNotice,
+	})
 }

--- a/internal/tui/input_views.go
+++ b/internal/tui/input_views.go
@@ -124,8 +124,8 @@ func (m *Model) updateSuggestions() {
 func (m Model) inputAreaView() string {
 	var parts []string
 
-	// Determine sidebar visibility locally
-	showSidebar := m.width >= minWidthForSidebar && len(m.lines) > 0
+	// Determine sidebar visibility locally (width-only, consistent with View())
+	showSidebar := m.width >= minWidthForSidebar
 
 	// 1. Mode pills line (Agent/Plan + Ask/Auto)
 	parts = append(parts, m.renderModePills())

--- a/internal/tui/selection.go
+++ b/internal/tui/selection.go
@@ -10,15 +10,27 @@ import (
 )
 
 // viewportOffsetY returns the Y offset of the viewport in screen coordinates.
-// This accounts for the header + divider lines above the viewport.
+// The viewport starts at the top of the screen (header has been removed).
 func (m *Model) viewportOffsetY() int {
-	// header title + divider line = 2 lines total
-	return 2
+	return 0
+}
+
+// isMouseInSidebar checks if the given screen X coordinate is inside the sidebar area.
+func (m *Model) isMouseInSidebar(x int) bool {
+	if !m.showSidebar {
+		return false
+	}
+	return x >= m.width-sidebarWidth
 }
 
 // handleMouseClick processes a left-click to start text selection.
 // Coordinates are stored as viewport-visible-relative (not content-absolute).
 func (m *Model) handleMouseClick(x, y int) {
+	// Ignore clicks in the sidebar area
+	if m.isMouseInSidebar(x) {
+		return
+	}
+
 	vpOffsetY := m.viewportOffsetY()
 	vpY := y - vpOffsetY
 
@@ -57,6 +69,14 @@ func (m *Model) handleMouseDrag(x, y int) {
 		x = 0
 	}
 
+	// Clamp X to main content area (don't select into sidebar)
+	if m.showSidebar {
+		maxX := m.width - sidebarWidth - 1
+		if x > maxX {
+			x = maxX
+		}
+	}
+
 	m.mouseEndX = x
 	m.mouseEndY = vpY
 
@@ -80,6 +100,14 @@ func (m *Model) handleMouseRelease(x, y int) tea.Cmd {
 	}
 	if vpY >= m.viewport.Height() {
 		vpY = m.viewport.Height() - 1
+	}
+
+	// Clamp X to main content area
+	if m.showSidebar {
+		maxX := m.width - sidebarWidth - 1
+		if x > maxX {
+			x = maxX
+		}
 	}
 	m.mouseEndX = x
 	m.mouseEndY = vpY

--- a/internal/tui/setup.go
+++ b/internal/tui/setup.go
@@ -474,7 +474,7 @@ func (m SetupModel) View() tea.View {
 		w = 80
 	}
 
-	logo := lipgloss.NewStyle().Bold(true).Foreground(colorPrimary).Render("🚀 Little Jack — Setup")
+	logo := lipgloss.NewStyle().Bold(true).Foreground(colorPrimary).Render("▓▒░ JCODE — Setup ░▒▓")
 	subtitle := lipgloss.NewStyle().Foreground(colorMuted).Italic(true).Render("Follow the wizard to configure your LLM")
 	header := lipgloss.JoinVertical(lipgloss.Center, logo, subtitle)
 	header = lipgloss.NewStyle().Width(w).Align(lipgloss.Center).PaddingTop(2).PaddingBottom(1).Render(header)

--- a/internal/tui/sidebar_component.go
+++ b/internal/tui/sidebar_component.go
@@ -1,0 +1,316 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/cnjack/jcode/internal/tools"
+)
+
+// SidebarState holds the data needed to render the right sidebar.
+type SidebarState struct {
+	Width             int
+	Height            int
+	TotalWidth        int // full width including borders
+	EnvLabel          string
+	ActiveProvider    string
+	ActiveModel       string
+	TotalTokens       int64
+	ModelContextLimit int
+	TodoItems         []tools.TodoItem
+	TodoScrollOffset  int
+	MCPStatuses       []MCPStatusItem
+	TeammateCount     int
+	BgRunning         int
+}
+
+// SidebarComponent renders the right-hand info panel.
+type SidebarComponent struct{}
+
+// NewSidebarComponent creates a new sidebar component.
+func NewSidebarComponent() *SidebarComponent {
+	return &SidebarComponent{}
+}
+
+// View renders the sidebar. Content is built line-by-line to ensure it never
+// exceeds state.Height. Each section is appended until the height budget is
+// exhausted.
+func (s *SidebarComponent) View(state SidebarState) string {
+	if state.Height < 3 {
+		state.Height = 3
+	}
+	maxLines := state.Height
+
+	var lines []string
+	addLines := func(content string) {
+		for _, line := range strings.Split(content, "\n") {
+			if len(lines) >= maxLines {
+				return
+			}
+			lines = append(lines, line)
+		}
+	}
+
+	addLines(s.renderLogo())
+	if state.ActiveProvider != "" && len(lines) < maxLines {
+		addLines(s.renderModelSection(state))
+	}
+	if len(lines) < maxLines {
+		addLines(s.renderEnvSection(state))
+	}
+	if (state.TotalTokens > 0 || state.ModelContextLimit > 0) && len(lines) < maxLines {
+		addLines(s.renderUsageSection(state))
+	}
+	if len(state.TodoItems) > 0 && len(lines) < maxLines {
+		addLines(s.renderTodoSection(state))
+	}
+	if len(state.MCPStatuses) > 0 && len(lines) < maxLines {
+		addLines(s.renderMCPSection(state))
+	}
+	if state.BgRunning > 0 && len(lines) < maxLines {
+		addLines(s.renderBgSection(state))
+	}
+	if state.TeammateCount > 0 && len(lines) < maxLines {
+		addLines(s.renderTeamSection(state))
+	}
+
+	// Fill remaining lines with empty lines so lipgloss Height matches exactly
+	for len(lines) < maxLines {
+		lines = append(lines, "")
+	}
+
+	// Manually build the sidebar with left+right borders.
+	// Each line is padded so the right "│" aligns perfectly.
+	contentWidth := state.TotalWidth - 4 // "│ " and " │"
+	if contentWidth < 10 {
+		contentWidth = 10
+	}
+
+	var result strings.Builder
+	for i, line := range lines {
+		result.WriteString("│ ")
+		result.WriteString(line)
+		// Pad with spaces so right border aligns
+		w := lipgloss.Width(line)
+		pad := contentWidth - w
+		if pad < 0 {
+			pad = 0
+		}
+		result.WriteString(strings.Repeat(" ", pad))
+		result.WriteString(" │")
+		if i < len(lines)-1 {
+			result.WriteString("\n")
+		}
+	}
+	return result.String()
+}
+
+func (s *SidebarComponent) renderLogo() string {
+	bracketStyle := lipgloss.NewStyle().Foreground(colorMuted).Bold(true)
+	jStyle := lipgloss.NewStyle().Foreground(colorLogoJ).Bold(true)
+	codeStyle := lipgloss.NewStyle().Foreground(colorText).Bold(true)
+	logo := lipgloss.JoinHorizontal(lipgloss.Left,
+		bracketStyle.Render("["),
+		jStyle.Render("J"),
+		codeStyle.Render("CODE"),
+		bracketStyle.Render("]"),
+	)
+	line := lipgloss.NewStyle().Foreground(colorMuted).Render("─────────")
+	return lipgloss.JoinVertical(lipgloss.Left, logo, line)
+}
+
+func (s *SidebarComponent) renderModelSection(state SidebarState) string {
+	title := sidebarSectionTitleStyle.Render("Model")
+	modelName := state.ActiveProvider + " / " + state.ActiveModel
+	value := sidebarValueStyle.Render(truncateString(modelName, state.Width-3))
+	return lipgloss.JoinVertical(lipgloss.Left, title, value)
+}
+
+func (s *SidebarComponent) renderEnvSection(state SidebarState) string {
+	title := sidebarSectionTitleStyle.Render("Env")
+	var envText string
+	if state.EnvLabel == "Local" || state.EnvLabel == "local" || state.EnvLabel == "" {
+		envText = "🖥️  Local"
+	} else {
+		envText = "🔗 " + state.EnvLabel
+	}
+	value := sidebarValueStyle.Render(envText)
+	return lipgloss.JoinVertical(lipgloss.Left, title, value)
+}
+
+func (s *SidebarComponent) renderUsageSection(state SidebarState) string {
+	title := sidebarSectionTitleStyle.Render("Usage")
+	var usageLine string
+	if state.ModelContextLimit > 0 {
+		pct := float64(state.TotalTokens) / float64(state.ModelContextLimit) * 100
+		bar := renderProgressBar(pct, 8)
+		usageLine = fmt.Sprintf("%s %.0f%%", bar, pct)
+	} else {
+		usageLine = fmt.Sprintf("%d tokens", state.TotalTokens)
+	}
+	value := sidebarValueStyle.Render(usageLine)
+	return lipgloss.JoinVertical(lipgloss.Left, title, value)
+}
+
+func (s *SidebarComponent) renderTodoSection(state SidebarState) string {
+	if len(state.TodoItems) == 0 {
+		return ""
+	}
+
+	completed, total := countTodos(state.TodoItems)
+	title := sidebarSectionTitleStyle.Render(fmt.Sprintf("📋 Todo (%d/%d)", completed, total))
+
+	// Calculate available lines for todo items
+	// We need to estimate how many lines other sections use
+	otherLines := s.countFixedSectionLines(state)
+	available := state.Height - otherLines - 4 // reserve space for title + padding
+	if available < 2 {
+		available = 2
+	}
+
+	items := state.TodoItems
+	start := state.TodoScrollOffset
+	if start < 0 {
+		start = 0
+	}
+	if start > len(items) {
+		start = len(items)
+	}
+
+	var lines []string
+	lines = append(lines, title)
+
+	// Top scroll indicator
+	if start > 0 {
+		lines = append(lines, sidebarScrollIndicatorStyle.Render(fmt.Sprintf("▲ %d more", start)))
+	}
+
+	// Visible items
+	end := start + available
+	if end > len(items) {
+		end = len(items)
+	}
+	for i := start; i < end && i < len(items); i++ {
+		lines = append(lines, s.renderTodoItem(items[i]))
+	}
+
+	// Bottom scroll indicator
+	if end < len(items) {
+		lines = append(lines, sidebarScrollIndicatorStyle.Render(fmt.Sprintf("▼ %d more", len(items)-end)))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (s *SidebarComponent) renderTodoItem(item tools.TodoItem) string {
+	var icon, text string
+	switch item.Status {
+	case tools.TodoCompleted:
+		icon = todoCompletedStyle.Render("✓")
+		text = todoCompletedStyle.Render(truncateString(item.Title, 20))
+	case tools.TodoInProgress:
+		icon = todoInProgressStyle.Render("⏳")
+		text = todoInProgressStyle.Render(truncateString(item.Title, 20))
+	case tools.TodoCancelled:
+		icon = todoCancelledStyle.Render("✗")
+		text = todoCancelledStyle.Render(truncateString(item.Title, 20))
+	default:
+		icon = todoPendingStyle.Render("○")
+		text = todoPendingStyle.Render(truncateString(item.Title, 20))
+	}
+	return fmt.Sprintf("  %s %s", icon, text)
+}
+
+func (s *SidebarComponent) renderMCPSection(state SidebarState) string {
+	title := sidebarSectionTitleStyle.Render("MCP")
+	var lines []string
+	lines = append(lines, title)
+
+	activeServers := 0
+	loadedTools := 0
+	for _, st := range state.MCPStatuses {
+		if st.Running {
+			activeServers++
+			loadedTools += st.ToolCount
+		}
+	}
+
+	if activeServers > 0 {
+		status := sidebarValueStyle.Render(fmt.Sprintf("● %d server%s, %d tool%s",
+			activeServers, plural(activeServers), loadedTools, plural(loadedTools)))
+		lines = append(lines, status)
+	} else {
+		lines = append(lines, sidebarValueStyle.Render("○ inactive"))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (s *SidebarComponent) renderBgSection(state SidebarState) string {
+	title := sidebarSectionTitleStyle.Render("Background")
+	value := sidebarValueStyle.Render(fmt.Sprintf("⏳ %d running", state.BgRunning))
+	return lipgloss.JoinVertical(lipgloss.Left, title, value)
+}
+
+func (s *SidebarComponent) renderTeamSection(state SidebarState) string {
+	title := sidebarSectionTitleStyle.Render("Team")
+	value := sidebarValueStyle.Render(fmt.Sprintf("👥 %d teammate%s", state.TeammateCount, plural(state.TeammateCount)))
+	return lipgloss.JoinVertical(lipgloss.Left, title, value)
+}
+
+// countFixedSectionLines estimates lines used by all sections except todo.
+func (s *SidebarComponent) countFixedSectionLines(state SidebarState) int {
+	lines := 5 // logo + padding
+	if state.ActiveProvider != "" {
+		lines += 3 // model section
+	}
+	lines += 3 // env section
+	if state.TotalTokens > 0 || state.ModelContextLimit > 0 {
+		lines += 3 // usage section
+	}
+	if len(state.MCPStatuses) > 0 {
+		lines += 3 // mcp section
+	}
+	if state.BgRunning > 0 {
+		lines += 3 // bg section
+	}
+	if state.TeammateCount > 0 {
+		lines += 3 // team section
+	}
+	return lines
+}
+
+// Helper functions.
+
+func countTodos(items []tools.TodoItem) (completed, total int) {
+	total = len(items)
+	for _, item := range items {
+		if item.Status == tools.TodoCompleted {
+			completed++
+		}
+	}
+	return
+}
+
+func truncateString(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return s
+	}
+	w := lipgloss.Width(s)
+	if w <= maxLen {
+		return s
+	}
+	// Simple truncation: cut by runes
+	runes := []rune(s)
+	truncated := string(runes[:maxLen-1])
+	return truncated + "…"
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/tui/sidebar_component.go
+++ b/internal/tui/sidebar_component.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/mattn/go-runewidth"
 
 	"github.com/cnjack/jcode/internal/tools"
 )
@@ -134,7 +135,7 @@ func (s *SidebarComponent) renderEnvSection(state SidebarState) string {
 	if state.EnvLabel == "Local" || state.EnvLabel == "local" || state.EnvLabel == "" {
 		envText = "🖥️  Local"
 	} else {
-		envText = "🔗 " + state.EnvLabel
+		envText = "🔗 " + truncateString(state.EnvLabel, state.Width-5)
 	}
 	value := sidebarValueStyle.Render(envText)
 	return lipgloss.JoinVertical(lipgloss.Left, title, value)
@@ -302,10 +303,19 @@ func truncateString(s string, maxLen int) string {
 	if w <= maxLen {
 		return s
 	}
-	// Simple truncation: cut by runes
-	runes := []rune(s)
-	truncated := string(runes[:maxLen-1])
-	return truncated + "…"
+	// Display-width aware truncation: iterate runes and sum cell widths
+	// so CJK/emoji characters (2 cells each) are handled correctly.
+	var result []rune
+	currentWidth := 0
+	for _, r := range s {
+		rw := runewidth.RuneWidth(r)
+		if currentWidth+rw > maxLen-1 { // -1 for ellipsis
+			break
+		}
+		result = append(result, r)
+		currentWidth += rw
+	}
+	return string(result) + "…"
 }
 
 func plural(n int) string {

--- a/internal/tui/statusbar_component.go
+++ b/internal/tui/statusbar_component.go
@@ -33,16 +33,10 @@ func NewStatusBarComponent() *StatusBarComponent {
 
 // View returns the rendered status bar.
 func (s *StatusBarComponent) View(state StatusBarState) string {
-	// Mode indicator (leftmost)
-	var modeStr string
-	switch state.Mode {
-	case ModePlanning:
-		modeStr = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("99")).Render(" Plan")
-	default:
-		modeStr = lipgloss.NewStyle().Bold(true).Foreground(colorSecondary).Render(" Agent")
-	}
+	// Note: Mode indicator (Agent/Plan) is now shown in mode pills above input.
+	// This status bar is only used in narrow-screen fallback mode.
 
-	leftTxt := modeStr + "  │  Model: "
+	leftTxt := "Model: "
 	if state.ActiveProvider != "" {
 		leftTxt += state.ActiveProvider + " / " + state.ActiveModel
 	} else {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Color palette
-	colorPrimary   = lipgloss.Color("#7C3AED") // violet
+	colorPrimary   = lipgloss.Color("#FF8400") // orange
 	colorSecondary = lipgloss.Color("#06B6D4") // cyan
 	colorSuccess   = lipgloss.Color("#10B981") // green
 	colorError     = lipgloss.Color("#EF4444") // red
@@ -17,6 +17,72 @@ var (
 	colorText      = lipgloss.Color("#E5E7EB") // light gray
 	colorBg        = lipgloss.Color("#111827") // dark bg
 	colorDimText   = lipgloss.Color("#9CA3AF") // dim text for secondary info
+	colorPlanMode  = lipgloss.Color("#C084FC") // plan mode (soft purple)
+	colorLogoJ     = lipgloss.Color("#FF8400") // orange J in [JCODE] logo
+
+	// ─── Landing page styles ───
+	landingLogoStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(colorPrimary).
+				PaddingLeft(0)
+
+	landingUnderlineStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#4B5563"))
+
+	landingTaglineStyle = lipgloss.NewStyle().
+				Foreground(colorMuted)
+
+	// ─── Sidebar styles ───
+	sidebarStyle = lipgloss.NewStyle().
+				Border(lipgloss.Border{Left: "│"}).
+				BorderForeground(colorMuted).
+				PaddingLeft(1).
+				PaddingRight(1)
+
+	sidebarSectionTitleStyle = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(colorMuted).
+					PaddingTop(1)
+
+	sidebarItemStyle = lipgloss.NewStyle().
+				Foreground(colorText).
+				PaddingLeft(1)
+
+	sidebarValueStyle = lipgloss.NewStyle().
+				Foreground(colorText).
+				PaddingLeft(1)
+
+	sidebarScrollIndicatorStyle = lipgloss.NewStyle().
+					Foreground(colorMuted).
+					Italic(true).
+					PaddingLeft(1)
+
+	// ─── Mode pills styles ───
+	modePillAgentStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(colorSecondary)
+
+	modePillPlanStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(colorPlanMode)
+
+	modePillAskStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(colorMuted)
+
+	modePillAutoStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(colorWarning)
+
+	modeSeparatorStyle = lipgloss.NewStyle().
+				Foreground(colorMuted)
+
+	modeFillStyle = lipgloss.NewStyle().
+			Foreground(colorMuted)
+
+	// ─── Minimal status bar style ───
+	minimalStatusBarStyle = lipgloss.NewStyle().
+				Foreground(colorMuted)
 
 	// Styles
 	titleStyle = lipgloss.NewStyle().

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -29,6 +29,11 @@ const (
 	ModeAgent Mode = iota
 )
 
+const (
+	sidebarWidth         = 36
+	minWidthForSidebar   = 90
+)
+
 type Model struct {
 	mode      Mode
 	agentDone bool
@@ -167,6 +172,11 @@ type Model struct {
 	// teamLeaderLines stores the leader's viewport content when switching to teammate view
 	teamLeaderLines []string
 	teamLeaderText  string
+
+	// ─── Sidebar state ───
+	showSidebar         bool // whether sidebar is currently visible
+	sidebarScrollOffset int  // scroll offset for todo list in sidebar
+	sidebarComp         *SidebarComponent
 }
 
 // dirItem implements list.Item
@@ -262,7 +272,11 @@ func newTextarea() textarea.Model {
 	ta.Prompt = "> "
 	st := ta.Styles()
 	st.Focused.CursorLine = lipgloss.NewStyle()
+	st.Cursor.Shape = tea.CursorBlock
+	st.Cursor.Color = colorPrimary
 	st.Focused.Prompt = lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
+	st.Focused.Placeholder = lipgloss.NewStyle().Foreground(colorDimText)
+	st.Blurred.Placeholder = lipgloss.NewStyle().Foreground(colorDimText)
 	ta.SetStyles(st)
 	ta.Focus()
 	return ta
@@ -285,13 +299,7 @@ func NewModel(hasPrompt bool, pwd string, todoStore *tools.TodoStore) Model {
 		thinking = true
 	} else {
 		initialLines = []string{
-			lipgloss.NewStyle().Foreground(colorMuted).Render("Welcome to Little Jack. How can I help you today?"),
-			"",
-			lipgloss.NewStyle().Foreground(colorText).PaddingLeft(2).Render("💡 Describe a task and I'll help you code it"),
-			lipgloss.NewStyle().Foreground(colorText).PaddingLeft(2).Render("📁 I can read, write, and edit files in your project"),
-			lipgloss.NewStyle().Foreground(colorText).PaddingLeft(2).Render("⚡ I can execute shell commands for you"),
-			"",
-			lipgloss.NewStyle().Foreground(colorMuted).PaddingLeft(2).Render("Ctrl+P: Plan  │  Ctrl+A: Approval  │  Ctrl+L: Model  │  Ctrl+C: Cancel  │  Drag: Select & Copy"),
+			lipgloss.NewStyle().Foreground(colorMuted).Render("Welcome to JCODE. How can I help you today?"),
 			"",
 		}
 	}
@@ -346,6 +354,7 @@ func NewModel(hasPrompt bool, pwd string, todoStore *tools.TodoStore) Model {
 		textarea:       newTextarea(),
 		textareaLines:  1,
 		currentText:    &strings.Builder{},
+		sidebarComp:    NewSidebarComponent(),
 		dirList:        l,
 		modelPicker:    ml,
 		settingMenu:    sl,
@@ -1200,7 +1209,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 
 					if len(m.lines) > 0 {
 						// Check if the lines are the initial welcome message, we clear it.
-						if strings.Contains(m.lines[0], "Welcome to Little Jack") {
+						if strings.Contains(m.lines[0], "Welcome to JCODE") {
 							m.lines = nil
 						}
 					}
@@ -1420,7 +1429,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		inputWidth := msg.Width - 6
+
+		// Determine if sidebar will be shown (based on width)
+		m.showSidebar = m.width >= minWidthForSidebar && len(m.lines) > 0
+		mainWidth := m.width
+		if m.showSidebar {
+			mainWidth = m.width - sidebarWidth - 1
+		}
+
+		inputWidth := mainWidth - 6
 		if inputWidth < 20 {
 			inputWidth = 20
 		}
@@ -1428,11 +1445,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 
 		vpH := m.calcViewportHeight(m.inputActive())
 		if !m.ready {
-			m.viewport = viewport.New(viewport.WithWidth(msg.Width), viewport.WithHeight(vpH))
-
+			m.viewport = viewport.New(viewport.WithWidth(mainWidth), viewport.WithHeight(vpH))
 			m.ready = true
 		} else {
-			m.viewport.SetWidth(msg.Width)
+			m.viewport.SetWidth(mainWidth)
 			m.viewport.SetHeight(vpH)
 		}
 		m.dirList.SetSize(msg.Width, vpH)
@@ -1526,7 +1542,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 				m.cmdSuggestions = nil
 				m.cmdSuggestionIndex = 0
 
-				if len(m.lines) > 0 && strings.Contains(m.lines[0], "Welcome to Little Jack") {
+				if len(m.lines) > 0 && strings.Contains(m.lines[0], "Welcome to JCODE") {
 					m.lines = nil
 				}
 
@@ -2175,13 +2191,12 @@ func (m Model) inputAreaHeight() int {
 }
 
 func (m Model) calcViewportHeight(_ ...bool) int {
-	headerHeight := 3
 	footerHeight := m.inputAreaHeight()
 	teamPanelHeight := 0
 	if m.teamState.HasTeam() && m.teamState.PanelVisible {
 		teamPanelHeight = m.teamPanelHeight()
 	}
-	h := m.height - headerHeight - footerHeight - teamPanelHeight
+	h := m.height - footerHeight - teamPanelHeight
 	if h < 3 {
 		h = 3
 	}
@@ -2245,25 +2260,14 @@ func (m Model) View() tea.View {
 		return m.newView(m.exitDialogView())
 	}
 
-	headerText := "🚀 Little Jack — Coding Assistant  |  "
-	if m.envLabel == "Local" || m.envLabel == "local" || m.envLabel == "" {
-		headerText += "🖥️  Env: Local"
-	} else {
-		headerText += "🔗 Env: SSH (" + m.envLabel + ")"
-	}
-	// Add team status pill to header
-	if m.teamState.HasTeam() {
-		m.teamState.RefreshTeammates()
-		pill := RenderTeamStatusPill(len(m.teamState.Teammates))
-		if pill != "" {
-			headerText += "  " + pill
-		}
-	}
-	header := titleStyle.Render(headerText)
-	headerLine := divider(m.width)
-	headerHeight := lipgloss.Height(header) + lipgloss.Height(headerLine)
+	// ─── Determine sidebar visibility (local, don't modify Model in View) ───
+	showSidebar := m.width >= minWidthForSidebar
 
-	// Team coordinator panel
+	// ─── Footer (input area) — always full width ───
+	footer := m.inputAreaView()
+	footerHeight := lipgloss.Height(footer)
+
+	// ─── Team coordinator panel ───
 	teamPanel := ""
 	teamPanelHeight := 0
 	if m.teamState.HasTeam() && m.teamState.PanelVisible {
@@ -2271,14 +2275,20 @@ func (m Model) View() tea.View {
 		teamPanelHeight = lipgloss.Height(teamPanel)
 	}
 
-	footer := m.inputAreaView()
-	footerHeight := lipgloss.Height(footer)
+	// ─── Calculate main content area dimensions ───
+	mainWidth := m.width
+	if showSidebar {
+		mainWidth = m.width - sidebarWidth - 1 // -1 for gap
+	}
 
+	// ─── Viewport ───
+	vpH := m.height - footerHeight - teamPanelHeight
+	if vpH < 3 {
+		vpH = 3
+	}
 	if m.ready {
-		m.viewport.SetHeight(m.height - headerHeight - footerHeight - teamPanelHeight)
-		if m.viewport.Height() < 3 {
-			m.viewport.SetHeight(3)
-		}
+		m.viewport.SetWidth(mainWidth)
+		m.viewport.SetHeight(vpH)
 		m.viewport.SetContent(strings.TrimRight(m.renderContent(), "\n"))
 	}
 
@@ -2286,13 +2296,92 @@ func (m Model) View() tea.View {
 	if m.hasSelection || m.mouseSelecting {
 		vpView = m.applySelectionHighlight(vpView)
 	}
-	parts := []string{header, headerLine, vpView}
+
+	// ─── Assemble layout ───
+	if showSidebar {
+		// Two-column layout
+		sidebar := m.renderSidebar(vpH)
+		contentRow := lipgloss.JoinHorizontal(lipgloss.Top, vpView, sidebar)
+		parts := []string{contentRow}
+		if teamPanel != "" {
+			parts = append(parts, teamPanel)
+		}
+		parts = append(parts, footer)
+		mainView := lipgloss.JoinVertical(lipgloss.Left, parts...)
+		return m.newView(mainView)
+	}
+
+	// Single-column fallback
+	parts := []string{vpView}
 	if teamPanel != "" {
 		parts = append(parts, teamPanel)
 	}
 	parts = append(parts, footer)
 	mainView := lipgloss.JoinVertical(lipgloss.Left, parts...)
 	return m.newView(mainView)
+}
+
+// landingPageView renders the Google-style landing page (centered logo + input).
+func (m Model) landingPageView() string {
+	bracketStyle := lipgloss.NewStyle().Foreground(colorMuted).Bold(true)
+	jStyle := lipgloss.NewStyle().Foreground(colorLogoJ).Bold(true)
+	codeStyle := lipgloss.NewStyle().Foreground(colorText).Bold(true)
+	logo := lipgloss.JoinHorizontal(lipgloss.Center,
+		bracketStyle.Render("["),
+		jStyle.Render("J"),
+		codeStyle.Render("CODE"),
+		bracketStyle.Render("]"),
+	)
+	underline := landingUnderlineStyle.Render("═════════════")
+	tagline := landingTaglineStyle.Render("coding assistant")
+
+	// Calculate vertical centering
+	footer := m.inputAreaView()
+	footerHeight := lipgloss.Height(footer)
+	contentHeight := lipgloss.Height(logo) + lipgloss.Height(underline) + lipgloss.Height(tagline)
+	topPad := (m.height - contentHeight - footerHeight) / 2
+	if topPad < 0 {
+		topPad = 0
+	}
+
+	parts := []string{
+		strings.Repeat("\n", topPad),
+		lipgloss.PlaceHorizontal(m.width, lipgloss.Center, logo),
+		lipgloss.PlaceHorizontal(m.width, lipgloss.Center, underline),
+		lipgloss.PlaceHorizontal(m.width, lipgloss.Center, tagline),
+	}
+	parts = append(parts, footer)
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+// renderSidebar renders the right sidebar panel.
+func (m Model) renderSidebar(height int) string {
+	if m.sidebarComp == nil {
+		m.sidebarComp = NewSidebarComponent()
+	}
+	var todos []tools.TodoItem
+	if m.todoStore != nil {
+		todos = m.todoStore.Items()
+	}
+	activeTokens := m.totalTokens
+	if m.teamState.ViewingAgent != "" {
+		activeTokens = m.teammateTokens[m.teamState.ViewingAgent]
+	}
+	return m.sidebarComp.View(SidebarState{
+		Width:             sidebarWidth - 4, // content width: total - leftBorder - leftPad - rightPad - rightBorder
+		Height:            height,
+		TotalWidth:        sidebarWidth,
+		EnvLabel:          m.envLabel,
+		ActiveProvider:    m.activeProvider,
+		ActiveModel:       m.activeModel,
+		TotalTokens:       activeTokens,
+		ModelContextLimit: m.modelContextLimit,
+		TodoItems:         todos,
+		TodoScrollOffset:  m.sidebarScrollOffset,
+		MCPStatuses:       m.mcpStatuses,
+		TeammateCount:     len(m.teamState.Teammates),
+		BgRunning:         m.bgRunning,
+	})
 }
 
 // refreshViewport recalculates viewport height, updates content and scrolls to bottom.
@@ -2466,6 +2555,13 @@ func RunTUI(hasPrompt bool, pwd string, todoStore *tools.TodoStore, opts ...Mode
 }
 
 func HeaderView() string {
-	return lipgloss.NewStyle().Bold(true).Foreground(colorPrimary).
-		Render("🚀 Little Jack — Coding Assistant")
+	bracketStyle := lipgloss.NewStyle().Foreground(colorMuted).Bold(true)
+	jStyle := lipgloss.NewStyle().Foreground(colorLogoJ).Bold(true)
+	codeStyle := lipgloss.NewStyle().Foreground(colorText).Bold(true)
+	return lipgloss.JoinHorizontal(lipgloss.Left,
+		bracketStyle.Render("["),
+		jStyle.Render("J"),
+		codeStyle.Render("CODE"),
+		bracketStyle.Render("]"),
+	)
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -30,8 +30,8 @@ const (
 )
 
 const (
-	sidebarWidth         = 36
-	minWidthForSidebar   = 90
+	sidebarWidth       = 36
+	minWidthForSidebar = 90
 )
 
 type Model struct {
@@ -1096,6 +1096,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 			case "ctrl+l":
 				// Quick model switch
 				return m.handleModelInput(cmds)
+			case "ctrl+up":
+				// Scroll sidebar todo list up
+				if m.showSidebar && m.sidebarScrollOffset > 0 {
+					m.sidebarScrollOffset--
+					m.refreshViewport()
+					return m, tea.Batch(cmds...)
+				}
+			case "ctrl+down":
+				// Scroll sidebar todo list down
+				if m.showSidebar && m.todoStore != nil {
+					maxOffset := len(m.todoStore.Items()) - 3
+					if maxOffset < 0 {
+						maxOffset = 0
+					}
+					if m.sidebarScrollOffset < maxOffset {
+						m.sidebarScrollOffset++
+						m.refreshViewport()
+						return m, tea.Batch(cmds...)
+					}
+				}
 			case "tab":
 				// Accept command suggestion if active
 				if m.cmdSuggestionActive && len(m.cmdSuggestions) > 0 && m.cmdSuggestionIndex < len(m.cmdSuggestions) {
@@ -1430,11 +1450,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 		m.width = msg.Width
 		m.height = msg.Height
 
-		// Determine if sidebar will be shown (based on width)
-		m.showSidebar = m.width >= minWidthForSidebar && len(m.lines) > 0
+		// Determine if sidebar will be shown (width-only, consistent with View()).
+		m.showSidebar = m.width >= minWidthForSidebar
 		mainWidth := m.width
 		if m.showSidebar {
-			mainWidth = m.width - sidebarWidth - 1
+			mainWidth = m.width - sidebarWidth
 		}
 
 		inputWidth := mainWidth - 6
@@ -2278,7 +2298,7 @@ func (m Model) View() tea.View {
 	// ─── Calculate main content area dimensions ───
 	mainWidth := m.width
 	if showSidebar {
-		mainWidth = m.width - sidebarWidth - 1 // -1 for gap
+		mainWidth = m.width - sidebarWidth
 	}
 
 	// ─── Viewport ───

--- a/script/install.sh
+++ b/script/install.sh
@@ -145,7 +145,7 @@ install_ripgrep_from_github() {
 
 main() {
     printf "\n"
-    info "  Little Jack — Coding Assistant Installer"
+    info "  JCODE — Coding Assistant Installer"
     printf "\n"
 
     OS=$(detect_os)


### PR DESCRIPTION
## Summary

Complete TUI redesign to better utilize screen space and modernize the interface.

### Changes

- **Two-column layout**: Main chat viewport (left) + info sidebar (right, 36 chars wide)
- **Right sidebar** displays:
  - `[JCODE]` logo
  - Current model (provider / model name)
  - Environment (Local / SSH)
  - Token usage progress bar
  - Todo list (scrollable, height-limited)
  - MCP server status
- **Mode pills** above input box: `Agent · Ask ────────` (replaces status bar clutter)
- **Modern input**: Clean textarea with subtle vertical padding and block cursor
- **Orange theme**: Primary color changed from violet `#7C3AED` to orange `#FF8400`
- **Branding**: All "Little Jack" references unified to "JCODE"
- **Removed landing page**: App starts directly in chat mode with welcome message
- **Manual sidebar rendering**: Fixed lipgloss height overflow bug that pushed footer off-screen

### Screenshots

N/A (terminal UI)

### Testing

- `go build ./...` passes
- `go vet ./...` passes
- `go test ./...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a right sidebar displaying model, environment, token usage, todo list with scrolling, MCP server status, background tasks, and team information.
  * Added mode selection pills above the input area.
  * New responsive landing page design.

* **Style**
  * Rebranded product name from "Little Jack" to "JCODE" throughout the application.
  * Updated primary theme color to orange.
  * Redesigned TUI with improved layout and visual hierarchy.

* **Documentation**
  * Added comprehensive TUI redesign plan covering layout behavior, sidebar rendering, input area changes, and implementation checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->