### PR TITLE
fix(tui): store raw assistant text for Ctrl+Y copy

### DIFF
--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"charm.land/lipgloss/v2"
+	"charm.land/glamour/v2"
 )
 
 func formatToolArgs(argsJSON string) string {
@@ -66,12 +67,12 @@ func truncate(s string, maxLen int) string {
 }
 
 // formatToolResult returns styled output lines depending on the tool name.
-func formatToolResult(toolName, output string, termWidth int) []string {
-	return formatToolResultBody(toolName, output, nil, termWidth)
+func formatToolResult(toolName, output string, termWidth int, expanded bool, mdRenderer *glamour.TermRenderer) []string {
+	return formatToolResultBody(toolName, output, nil, termWidth, expanded, mdRenderer)
 }
 
 // formatToolResultBody returns styled output lines for a tool result with optional error.
-func formatToolResultBody(toolName, output string, err error, termWidth int) []string {
+func formatToolResultBody(toolName, output string, err error, termWidth int, expanded bool, mdRenderer *glamour.TermRenderer) []string {
 	if err != nil {
 		errText := truncate(sanitize(err.Error()), maxToolOutputLen)
 		return []string{
@@ -87,7 +88,7 @@ func formatToolResultBody(toolName, output string, err error, termWidth int) []s
 	case "edit":
 		return formatEditOutput(output, termWidth)
 	case "subagent":
-		return formatSubagentOutput(output, termWidth)
+		return formatSubagentOutput(output, termWidth, expanded, mdRenderer)
 	case "todowrite":
 		return formatTodoWriteOutput(output)
 	default:
@@ -215,17 +216,52 @@ func formatEditOutput(output string, termWidth int) []string {
 	return result
 }
 
-// formatSubagentOutput shows the first few lines of subagent output with left border.
-func formatSubagentOutput(output string, termWidth int) []string {
-	const tailLines = 8
-	rawLines := strings.Split(strings.TrimRight(output, "\n"), "\n")
-
-	shown := rawLines
-	hidden := 0
-	if len(rawLines) > tailLines {
-		shown = rawLines[:tailLines]
-		hidden = len(rawLines) - tailLines
+// formatSubagentOutput renders subagent output with markdown support.
+// When collapsed, it shows a limited number of lines with a hint to expand.
+// When expanded, it shows the full rendered markdown output.
+func formatSubagentOutput(output string, termWidth int, expanded bool, mdRenderer *glamour.TermRenderer) []string {
+	output = strings.TrimRight(output, "\n")
+	if output == "" {
+		return nil
 	}
+
+	// Render markdown via glamour if available.
+	rendered := output
+	if mdRenderer != nil {
+		if md, err := mdRenderer.Render(output); err == nil {
+			rendered = strings.TrimRight(md, "\n")
+		}
+	}
+
+	const collapsedLines = 12
+	rawLines := strings.Split(rendered, "\n")
+
+	boxWidth := termWidth - 8
+	if boxWidth < 30 {
+		boxWidth = 30
+	}
+
+	if expanded || len(rawLines) <= collapsedLines {
+		// Show all content.
+		var boxContent strings.Builder
+		for i, line := range rawLines {
+			boxContent.WriteString(line)
+			if i < len(rawLines)-1 {
+				boxContent.WriteString("\n")
+			}
+		}
+		if expanded && len(rawLines) > collapsedLines {
+			boxContent.WriteString("\n")
+			boxContent.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Italic(true).
+				Render("▲ ctrl+e 收起"))
+		}
+		box := subagentBodyStyle.Width(boxWidth).Render(boxContent.String())
+		return []string{box}
+	}
+
+	// Collapsed: show limited lines.
+	shown := rawLines[:collapsedLines]
+	hidden := len(rawLines) - collapsedLines
 
 	var boxContent strings.Builder
 	for i, line := range shown {
@@ -234,18 +270,11 @@ func formatSubagentOutput(output string, termWidth int) []string {
 			boxContent.WriteString("\n")
 		}
 	}
-	if hidden > 0 {
-		boxContent.WriteString("\n")
-		boxContent.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Italic(true).
-			Render(fmt.Sprintf("… %d more lines", hidden)))
-	}
+	boxContent.WriteString("\n")
+	boxContent.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Italic(true).
+		Render(fmt.Sprintf("… %d more lines (ctrl+e 展开)", hidden)))
 
-	boxWidth := termWidth - 8
-	if boxWidth < 30 {
-		boxWidth = 30
-	}
-
-	box := toolBodyStyle.Width(boxWidth).Render(boxContent.String())
+	box := subagentBodyStyle.Width(boxWidth).Render(boxContent.String())
 	return []string{box}
 }
 

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -253,7 +253,7 @@ func formatSubagentOutput(output string, termWidth int, expanded bool, mdRendere
 		if expanded && len(rawLines) > collapsedLines {
 			boxContent.WriteString("\n")
 			boxContent.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Italic(true).
-				Render("▲ ctrl+e 收起"))
+				Render("▲ ctrl+e collapse"))
 		}
 		box := subagentBodyStyle.Width(boxWidth).Render(boxContent.String())
 		return []string{box}
@@ -272,7 +272,7 @@ func formatSubagentOutput(output string, termWidth int, expanded bool, mdRendere
 	}
 	boxContent.WriteString("\n")
 	boxContent.WriteString(lipgloss.NewStyle().Foreground(colorMuted).Italic(true).
-		Render(fmt.Sprintf("… %d more lines (ctrl+e 展开)", hidden)))
+		Render(fmt.Sprintf("… %d more lines (ctrl+e expand)", hidden)))
 
 	box := subagentBodyStyle.Width(boxWidth).Render(boxContent.String())
 	return []string{box}

--- a/internal/tui/pickers.go
+++ b/internal/tui/pickers.go
@@ -613,6 +613,7 @@ func (m Model) helpPanelView() string {
 	left = append(left, renderEntry("Ctrl+P", "Agent ↔ Plan mode"))
 	left = append(left, renderEntry("Ctrl+A", "Ask ↔ Auto approve"))
 	left = append(left, renderEntry("Ctrl+Y", "Copy last response"))
+	left = append(left, renderEntry("Ctrl+E", "Expand subagent output"))
 	left = append(left, renderEntry("Escape", "Cancel / Back"))
 	left = append(left, "")
 	left = append(left, sectionStyle.Render("Navigation"))

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -153,6 +153,12 @@ var (
 			PaddingLeft(1).
 			MarginLeft(3)
 
+	// --- Subagent output body style (indented with left border, purple accent) ---
+	subagentBodyStyle = lipgloss.NewStyle().
+					Border(lipgloss.Border{Left: "│"}).
+					BorderForeground(lipgloss.Color("99")).
+					PaddingLeft(1).
+					MarginLeft(3)
 	// --- Button styles for dialogs ---
 	buttonFocusStyle = lipgloss.NewStyle().
 				Bold(true).

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -193,9 +193,10 @@ type contentLine struct {
 // toolResultData stores the raw data for a tool result, allowing
 // re-rendering with the current terminal width on resize.
 type toolResultData struct {
-	name   string
-	output string
-	err    error // non-nil for error results
+	name     string
+	output   string
+	err      error // non-nil for error results
+	expanded bool  // true when subagent output is expanded (full markdown)
 }
 
 // textLine creates a plain text content line.
@@ -210,9 +211,9 @@ func toolResultContentLine(name, output string, err error) contentLine {
 
 // render returns the rendered string for this content line, using the
 // given width for tool result boxes. Plain text lines are returned as-is.
-func (cl contentLine) render(width int) string {
+func (cl contentLine) render(width int, mdRenderer *glamour.TermRenderer) string {
 	if cl.tool != nil {
-		lines := formatToolResultBody(cl.tool.name, cl.tool.output, cl.tool.err, width)
+		lines := formatToolResultBody(cl.tool.name, cl.tool.output, cl.tool.err, width, cl.tool.expanded, mdRenderer)
 		return strings.Join(lines, "\n")
 	}
 	return cl.text
@@ -1460,6 +1461,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 					m.refreshViewport()
 					return m, tea.Batch(cmds...)
 				}
+			case "ctrl+e":
+				// Toggle expand/collapse of subagent output near viewport top
+				m.toggleSubagentExpand()
+				return m, tea.Batch(cmds...)
 			case "ctrl+y":
 				// Copy last assistant message to clipboard
 				text := m.getLastAssistantText()
@@ -1799,9 +1804,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 						toolErrorStyle.Render("✗ Subagent Error:"),
 						toolResultStyle.Render(truncate(sanitize(e.Error), maxToolOutputLen)))))
 				} else {
-					m.lines = append(m.lines, textLine(fmt.Sprintf("   %s %s",
-						toolSuccessStyle.Render("✓ Subagent Done:"),
-						toolResultStyle.Render(truncate(sanitize(e.Output), maxToolOutputLen)))))
+					m.lines = append(m.lines, textLine(fmt.Sprintf("   %s",
+						toolSuccessStyle.Render("✓ Subagent Done"))))
+					m.lines = append(m.lines, toolResultContentLine("subagent", sanitize(e.Output), nil))
 				}
 			case string(session.EntryPlanUpdate):
 				statusIcon := "📝"
@@ -2105,9 +2110,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 				toolErrorStyle.Render("✗ Subagent Error:"),
 				toolResultStyle.Render(truncate(sanitize(msg.Err.Error()), maxToolOutputLen)))))
 		} else {
-			m.lines = append(m.lines, textLine(fmt.Sprintf("   %s %s",
-				toolSuccessStyle.Render("✓ Subagent Done:"),
-				toolResultStyle.Render(truncate(sanitize(msg.Result), maxToolOutputLen)))))
+			m.lines = append(m.lines, textLine(fmt.Sprintf("   %s",
+				toolSuccessStyle.Render("✓ Subagent Done"))))
 		}
 		m.refreshViewport()
 		cmds = append(cmds, m.spinner.Tick)
@@ -2230,7 +2234,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 						toolResultStyle.Render(truncate(sanitize(msg.ToolErr), maxToolOutputLen))))
 			} else {
 				m.teamState.AppendTeammateLine(msg.AgentID,
-					formatToolResult(msg.ToolName, sanitize(msg.Content), m.contentWidth())...)
+					formatToolResult(msg.ToolName, sanitize(msg.Content), m.contentWidth(), false, nil)...)
 			}
 		case "assistant":
 			m.teamState.FlushTeammateText(msg.AgentID)
@@ -2602,6 +2606,88 @@ func (m *Model) refreshViewport() {
 
 // --- Helpers ---
 
+// maxRenderedLines estimates the number of rendered lines for a tool result.
+// This is used to map viewport scroll position back to content line indices.
+func maxRenderedLines(tool *toolResultData, termWidth int) int {
+	if tool == nil {
+		return 1
+	}
+	output := tool.output
+	if tool.err != nil {
+		output = tool.err.Error()
+	}
+	output = strings.TrimRight(output, "\n")
+	if output == "" {
+		return 1
+	}
+	lines := strings.Count(output, "\n") + 1
+
+	// Account for word-wrapping: estimate based on width.
+	boxWidth := termWidth - 12 // account for border + margin + padding
+	if boxWidth < 20 {
+		boxWidth = 20
+	}
+	wrapped := 0
+	for _, line := range strings.Split(output, "\n") {
+		if len(line) > boxWidth {
+			wrapped += (len(line) / boxWidth)
+		}
+	}
+	return lines + wrapped
+}
+
+// toggleSubagentExpand finds the nearest subagent tool result to the viewport
+// top and toggles its expanded state. It searches from the viewport top line
+// downward to find the first subagent tool result.
+func (m *Model) toggleSubagentExpand() {
+	if !m.ready || len(m.lines) == 0 {
+		return
+	}
+
+	// Estimate which content line index corresponds to the viewport top.
+	// Each content line produces one or more rendered lines. For tool results,
+	// the rendered output can be multi-line. We estimate by counting newlines
+	// in the text content and using a simple heuristic for tool results.
+	topRenderedLine := m.viewport.YOffset()
+	lineCount := 0
+	startIdx := 0
+	for i, cl := range m.lines {
+		var n int
+		if cl.tool != nil {
+			// Tool results are multi-line boxes; estimate conservatively.
+			n = maxRenderedLines(cl.tool, m.contentWidth())
+		} else {
+			n = strings.Count(cl.text, "\n") + 1
+		}
+		if lineCount+n > topRenderedLine {
+			startIdx = i
+			break
+		}
+		lineCount += n
+		if i == len(m.lines)-1 {
+			startIdx = i
+		}
+	}
+
+	// Search from viewport top downward.
+	for i := startIdx; i < len(m.lines); i++ {
+		if m.lines[i].tool != nil && m.lines[i].tool.name == "subagent" {
+			m.lines[i].tool.expanded = !m.lines[i].tool.expanded
+			m.refreshViewport()
+			return
+		}
+	}
+
+	// If not found forward, search from beginning to viewport top.
+	for i := 0; i < startIdx; i++ {
+		if m.lines[i].tool != nil && m.lines[i].tool.name == "subagent" {
+			m.lines[i].tool.expanded = !m.lines[i].tool.expanded
+			m.refreshViewport()
+			return
+		}
+	}
+}
+
 // replaceLastToolIcon replaces the status icon on the last tool call line.
 func (m *Model) replaceLastToolIcon(newIcon string) {
 	for i := len(m.lines) - 1; i >= 0; i-- {
@@ -2695,7 +2781,7 @@ func (m *Model) renderContent() string {
 	width := m.contentWidth()
 	var sb strings.Builder
 	for _, line := range m.lines {
-		sb.WriteString(line.render(width))
+		sb.WriteString(line.render(width, m.mdRenderer))
 		sb.WriteString("\n")
 	}
 	if m.currentText.Len() > 0 {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -123,6 +123,11 @@ type Model struct {
 	agentMode AgentMode
 	bgRunning int // count of running background tasks
 
+	// lastAssistantRawText stores the raw (unrendered) text of the last
+	// assistant response, used by Ctrl+Y to copy to clipboard without
+	// picking up structural elements like dividers.
+	lastAssistantRawText string
+
 	// Plan review state
 	planReviewActive   bool
 	planReviewTitle    string
@@ -1467,7 +1472,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 				return m, tea.Batch(cmds...)
 			case "ctrl+y":
 				// Copy last assistant message to clipboard
-				text := m.getLastAssistantText()
+				text := m.currentText.String()
+				if text == "" {
+					text = m.lastAssistantRawText
+				}
 				if text != "" {
 					cmds = append(cmds, tea.SetClipboard(text))
 				}
@@ -1766,6 +1774,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 				m.lines = append(m.lines, textLine(userPromptStyle.Render("> "+displayContent)))
 			case string(session.EntryAssistant):
 				if e.Content != "" {
+					m.lastAssistantRawText = e.Content
 					rendered := e.Content
 					if m.mdRenderer != nil {
 						if md, err := m.mdRenderer.Render(e.Content); err == nil {
@@ -2703,46 +2712,13 @@ func (m *Model) replaceLastToolIcon(newIcon string) {
 	}
 }
 
-// getLastAssistantText extracts the last assistant response text from lines.
-func (m *Model) getLastAssistantText() string {
-	// If we have streaming text, that's the latest
-	if m.currentText.Len() > 0 {
-		return m.currentText.String()
-	}
-	// Scan backwards from the end, collecting text until we hit a boundary
-	// (user prompt, tool call, or other structural marker)
-	var textLines []string
-	for i := len(m.lines) - 1; i >= 0; i-- {
-		line := m.lines[i]
-		// Stop at user prompt (contains orange background ANSI), tool icons, or other boundaries
-		if strings.Contains(line.text, toolIconRunning) ||
-			strings.Contains(line.text, toolIconSuccess) ||
-			strings.Contains(line.text, toolIconError) ||
-			strings.Contains(line.text, "Session resumed:") ||
-			strings.Contains(line.text, "Subagent:") {
-			break
-		}
-		// Detect user prompt line (rendered with background color via userPromptStyle)
-		if strings.Contains(line.text, "\x1b[") && strings.Contains(line.text, "> ") && strings.Contains(line.text, "48;2;") {
-			break
-		}
-		if line.text != "" {
-			textLines = append(textLines, line.text)
-		}
-	}
-	// Reverse since we scanned backwards
-	for i, j := 0, len(textLines)-1; i < j; i, j = i+1, j-1 {
-		textLines[i], textLines[j] = textLines[j], textLines[i]
-	}
-	return ansi.Strip(strings.Join(textLines, "\n"))
-}
-
 func (m *Model) flushText() {
 	text := m.currentText.String()
 	if text == "" {
 		return
 	}
 	m.currentText.Reset()
+	m.lastAssistantRawText = text
 	rendered := text
 	if m.mdRenderer != nil {
 		if md, err := m.mdRenderer.Render(text); err == nil {


### PR DESCRIPTION
## Summary

Previously `Ctrl+Y` copied the last assistant response by reverse-scanning `m.lines` and stripping ANSI codes. This included structural divider lines (`── ◇ model via provider ──`) in the clipboard output.

## Changes

- Add `lastAssistantRawText` field to the TUI Model struct
- Store the raw markdown text in `flushText()` before rendering
- Store the raw text during session resume (`SessionResumedMsg` / `EntryAssistant`)
- Simplify `Ctrl+Y` handler to read directly from the variable
- Remove `getLastAssistantText()` and `isDividerLine()` — no more reverse line scanning

## Test Plan

- [ ] Run an agent query, wait for completion, press `Ctrl+Y` — clipboard should contain only the assistant markdown, no divider
- [ ] Resume a session, then press `Ctrl+Y` — clipboard should contain the last assistant response from the resumed session
- [ ] Press `Ctrl+Y` during streaming — should copy the current streaming text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Ctrl+E keyboard shortcut to toggle expanded/collapsed view of subagent outputs
  * Subagent outputs now render with markdown formatting for improved readability
  * Collapsible subagent sections display helpful control hints and line counts

* **Improvements**
  * Ctrl+Y now reliably copies the raw assistant response text

* **Style**
  * Applied new purple-accented border styling to subagent output sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->