### PR TITLE
feat: add multimodal image support for web and ACP transports

### DIFF
--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -174,11 +174,28 @@ func (a *acpAgent) broadcastSlashCommands(sessionID acp.SessionId, sess *acpSess
 func (a *acpAgent) Initialize(_ context.Context, params acp.InitializeRequest) (acp.InitializeResponse, error) {
 	config.Logger().Printf("[acp] Initialize: client=%v, protocol=%d",
 		params.ClientInfo, params.ProtocolVersion)
+
+	// Check if the configured model supports image input.
+	imageSupport := false
+	if cfg, err := config.LoadConfig(); err == nil {
+		providerName, modelName := cfg.GetProviderModel()
+		registry := internalmodel.NewModelRegistry()
+		if _, m, ok := registry.LookupModel(providerName, modelName); ok && m != nil && m.Modalities != nil {
+			for _, mod := range m.Modalities.Input {
+				if mod == "image" {
+					imageSupport = true
+					break
+				}
+			}
+		}
+	}
+
 	return acp.InitializeResponse{
 		ProtocolVersion: acp.ProtocolVersionNumber,
 		AgentCapabilities: acp.AgentCapabilities{
 			PromptCapabilities: acp.PromptCapabilities{
 				EmbeddedContext: true,
+				Image:           imageSupport,
 			},
 			LoadSession: true,
 			SessionCapabilities: acp.SessionCapabilities{
@@ -412,11 +429,24 @@ func (a *acpAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Pr
 		return acp.PromptResponse{}, fmt.Errorf("unknown session: %s", params.SessionId)
 	}
 
-	// Extract text from prompt content blocks.
+	// Extract text and images from prompt content blocks.
 	var userText strings.Builder
+	var imageParts []schema.MessageInputPart
 	for _, block := range params.Prompt {
 		if block.Text != nil {
 			userText.WriteString(block.Text.Text)
+		}
+		if block.Image != nil && block.Image.Data != "" {
+			data := block.Image.Data
+			imageParts = append(imageParts, schema.MessageInputPart{
+				Type: schema.ChatMessagePartTypeImageURL,
+				Image: &schema.MessageInputImage{
+					MessagePartCommon: schema.MessagePartCommon{
+						MIMEType:   block.Image.MimeType,
+						Base64Data: &data,
+					},
+				},
+			})
 		}
 		if block.ResourceLink != nil {
 			fmt.Fprintf(&userText, "\n[Resource: %s (%s)]", block.ResourceLink.Name, block.ResourceLink.Uri)
@@ -424,7 +454,7 @@ func (a *acpAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Pr
 	}
 
 	prompt := userText.String()
-	if prompt == "" {
+	if prompt == "" && len(imageParts) == 0 {
 		return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
 	}
 
@@ -448,9 +478,38 @@ func (a *acpAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Pr
 
 	sess.mu.Lock()
 	if sess.rec != nil {
-		sess.rec.RecordUser(prompt)
+		var entryImages []session.EntryImage
+		for _, p := range imageParts {
+			if p.Image != nil && p.Image.Base64Data != nil {
+				entryImages = append(entryImages, session.EntryImage{
+					MimeType: p.Image.MIMEType,
+					Data:     *p.Image.Base64Data,
+				})
+			}
+		}
+		sess.rec.RecordUser(prompt, entryImages...)
 	}
-	sess.history = append(sess.history, schema.UserMessage(prompt))
+
+	// Build user message — include images as multimodal content if provided.
+	var userMsg *schema.Message
+	if len(imageParts) > 0 {
+		parts := make([]schema.MessageInputPart, 0, len(imageParts)+1)
+		if prompt != "" {
+			parts = append(parts, schema.MessageInputPart{
+				Type: schema.ChatMessagePartTypeText,
+				Text: prompt,
+			})
+		}
+		parts = append(parts, imageParts...)
+		userMsg = &schema.Message{
+			Role:                  schema.User,
+			Content:               prompt,
+			UserInputMultiContent: parts,
+		}
+	} else {
+		userMsg = schema.UserMessage(prompt)
+	}
+	sess.history = append(sess.history, userMsg)
 
 	// Create a cancellable context for this prompt turn.
 	promptCtx, cancel := context.WithCancel(ctx)

--- a/internal/model/chatmodel.go
+++ b/internal/model/chatmodel.go
@@ -292,6 +292,38 @@ func toOpenAIMessage(msg *schema.Message) openai.ChatCompletionMessage {
 	if len(msg.ToolCalls) > 0 {
 		m.ToolCalls = toOpenAIToolCalls(msg.ToolCalls)
 	}
+	// Convert multimodal content (text + images) to OpenAI MultiContent format.
+	if len(msg.UserInputMultiContent) > 0 {
+		m.Content = ""
+		parts := make([]openai.ChatMessagePart, 0, len(msg.UserInputMultiContent))
+		for _, p := range msg.UserInputMultiContent {
+			switch p.Type {
+			case schema.ChatMessagePartTypeText:
+				parts = append(parts, openai.ChatMessagePart{
+					Type: openai.ChatMessagePartTypeText,
+					Text: p.Text,
+				})
+			case schema.ChatMessagePartTypeImageURL:
+				if p.Image != nil {
+					var url string
+					if p.Image.Base64Data != nil && *p.Image.Base64Data != "" {
+						url = "data:" + p.Image.MIMEType + ";base64," + *p.Image.Base64Data
+					} else if p.Image.URL != nil {
+						url = *p.Image.URL
+					}
+					if url != "" {
+						parts = append(parts, openai.ChatMessagePart{
+							Type: openai.ChatMessagePartTypeImageURL,
+							ImageURL: &openai.ChatMessageImageURL{
+								URL: url,
+							},
+						})
+					}
+				}
+			}
+		}
+		m.MultiContent = parts
+	}
 	return m
 }
 

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -7,6 +7,38 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
+// entryToUserMessage converts a session Entry into a schema.Message,
+// restoring multimodal content (images) when present.
+func entryToUserMessage(e Entry) *schema.Message {
+	if len(e.Images) == 0 {
+		return schema.UserMessage(e.Content)
+	}
+	parts := make([]schema.MessageInputPart, 0, len(e.Images)+1)
+	if e.Content != "" {
+		parts = append(parts, schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeText,
+			Text: e.Content,
+		})
+	}
+	for _, img := range e.Images {
+		data := img.Data
+		parts = append(parts, schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeImageURL,
+			Image: &schema.MessageInputImage{
+				MessagePartCommon: schema.MessagePartCommon{
+					MIMEType:   img.MimeType,
+					Base64Data: &data,
+				},
+			},
+		})
+	}
+	return &schema.Message{
+		Role:                  schema.User,
+		Content:               e.Content,
+		UserInputMultiContent: parts,
+	}
+}
+
 // ReconstructHistory converts a slice of recorded session entries back into
 // LLM history messages suitable for resuming a conversation.
 // It reconstructs tool call and tool result messages so that resumed sessions
@@ -16,7 +48,7 @@ func ReconstructHistory(entries []Entry) []adk.Message {
 	for _, e := range entries {
 		switch e.Type {
 		case EntryUser:
-			msgs = append(msgs, schema.UserMessage(e.Content))
+			msgs = append(msgs, entryToUserMessage(e))
 		case EntryAssistant:
 			if e.Content != "" {
 				msgs = append(msgs, &schema.Message{Role: schema.Assistant, Content: e.Content})
@@ -73,7 +105,7 @@ func ReconstructState(entries []Entry) *SessionState {
 	for _, e := range entries {
 		switch e.Type {
 		case EntryUser:
-			msgs = append(msgs, schema.UserMessage(e.Content))
+			msgs = append(msgs, entryToUserMessage(e))
 
 		case EntryAssistant:
 			if e.Content != "" {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -42,6 +42,12 @@ type TodoSnapshotItem struct {
 	Status string `json:"status"`
 }
 
+// EntryImage stores a single image attached to a user message.
+type EntryImage struct {
+	MimeType string `json:"media_type"`
+	Data     string `json:"data"` // base64-encoded
+}
+
 // Entry is one line of the JSONL session file.
 type Entry struct {
 	Type       EntryType `json:"type"`
@@ -56,6 +62,9 @@ type Entry struct {
 	Error      string    `json:"error,omitempty"`        // tool error
 	ToolCallID string    `json:"tool_call_id,omitempty"` // links tool_call ↔ tool_result
 	Timestamp  string    `json:"timestamp"`
+
+	// Images attached to a user message.
+	Images []EntryImage `json:"images,omitempty"`
 
 	// plan_update fields
 	PlanStatus  string `json:"plan_status,omitempty"`
@@ -178,11 +187,12 @@ func (r *Recorder) HasRecording() bool {
 
 // RecordUser appends a user message entry.
 // On the first user message, the title is auto-generated from the content.
-func (r *Recorder) RecordUser(content string) {
+// Optional images are persisted alongside the text so they survive session restore.
+func (r *Recorder) RecordUser(content string, images ...EntryImage) {
 	r.mu.Lock()
 	needsTitle := r.file == nil && !r.resuming
 	r.mu.Unlock()
-	_ = r.writeEntry(Entry{Type: EntryUser, Content: content})
+	_ = r.writeEntry(Entry{Type: EntryUser, Content: content, Images: images})
 	if needsTitle {
 		title := generateTitle(content)
 		r.mu.Lock()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -319,6 +319,23 @@ func (s *Server) forwardEvents() {
 
 // --- API Handlers ---
 
+// currentModelSupportsImage checks if the currently selected model supports image input.
+func (s *Server) currentModelSupportsImage() bool {
+	if s.registry == nil {
+		return false
+	}
+	_, m, ok := s.registry.LookupModel(s.providerName, s.modelName)
+	if !ok || m == nil || m.Modalities == nil {
+		return false
+	}
+	for _, mod := range m.Modalities.Input {
+		if mod == "image" {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	sessionID := ""
@@ -343,14 +360,15 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"status":     "ok",
-		"version":    "0.2.0",
-		"pwd":        s.pwd,
-		"provider":   s.providerName,
-		"model":      s.modelName,
-		"mode":       s.mode,
-		"session_id": sessionID,
-		"running":    s.running.Load(),
+		"status":        "ok",
+		"version":       "0.2.0",
+		"pwd":           s.pwd,
+		"provider":      s.providerName,
+		"model":         s.modelName,
+		"mode":          s.mode,
+		"session_id":    sessionID,
+		"running":       s.running.Load(),
+		"image_support": s.currentModelSupportsImage(),
 	})
 }
 
@@ -389,11 +407,12 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	// running is now true; submitMessage will proceed without re-setting it.
 
 	var req struct {
-		Message   string `json:"message"`
-		Mode      string `json:"mode,omitempty"`       // "build" or "plan"
-		SessionID string `json:"session_id,omitempty"` // optional: continue existing session
+		Message   string      `json:"message"`
+		Images    []chatImage `json:"images,omitempty"`     // optional: base64-encoded images
+		Mode      string      `json:"mode,omitempty"`       // "build" or "plan"
+		SessionID string      `json:"session_id,omitempty"` // optional: continue existing session
 	}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, 20<<20)).Decode(&req); err != nil {
 		s.running.Store(false)
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return
@@ -409,8 +428,14 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		mode = s.mode
 	}
 
-	sessionID := s.submitMessage(req.Message, mode, "", req.SessionID)
+	sessionID := s.submitMessage(req.Message, mode, "", req.SessionID, req.Images)
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "processing", "session_id": sessionID})
+}
+
+// chatImage represents a base64-encoded image in a chat request.
+type chatImage struct {
+	Data     string `json:"data"`       // base64 data (without data: prefix)
+	MimeType string `json:"media_type"` // e.g. "image/png", "image/jpeg"
 }
 
 // SubmitMessage submits a message for agent processing from an external source
@@ -419,7 +444,7 @@ func (s *Server) SubmitMessage(message, source string) bool {
 	if !s.running.CompareAndSwap(false, true) {
 		return false
 	}
-	s.submitMessage(message, s.mode, source, "")
+	s.submitMessage(message, s.mode, source, "", nil)
 	return true
 }
 
@@ -428,9 +453,10 @@ func (s *Server) SubmitMessage(message, source string) bool {
 // sessionID is an optional session identifier from the client to ensure
 // continuity — if the current recorder has a different UUID, resume the
 // correct session instead of creating a new one.
+// images is an optional list of base64-encoded images to include in the message.
 // The caller must have already set s.running to true (via CompareAndSwap).
 // Returns the session_id of the recorder used.
-func (s *Server) submitMessage(message, mode, source, sessionID string) string {
+func (s *Server) submitMessage(message, mode, source, sessionID string, images []chatImage) string {
 	// Apply mode prefix if plan mode requested.
 	agentMsg := message
 	if mode == "plan" {
@@ -469,11 +495,47 @@ func (s *Server) submitMessage(message, mode, source, sessionID string) string {
 
 	// Record user message.
 	if recorder != nil {
-		recorder.RecordUser(agentMsg)
+		var entryImages []session.EntryImage
+		for _, img := range images {
+			entryImages = append(entryImages, session.EntryImage{
+				MimeType: img.MimeType,
+				Data:     img.Data,
+			})
+		}
+		recorder.RecordUser(agentMsg, entryImages...)
+	}
+
+	// Build the user message — include images as multimodal content if provided.
+	var userMsg *schema.Message
+	if len(images) > 0 {
+		parts := make([]schema.MessageInputPart, 0, len(images)+1)
+		parts = append(parts, schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeText,
+			Text: agentMsg,
+		})
+		for _, img := range images {
+			data := img.Data
+			parts = append(parts, schema.MessageInputPart{
+				Type: schema.ChatMessagePartTypeImageURL,
+				Image: &schema.MessageInputImage{
+					MessagePartCommon: schema.MessagePartCommon{
+						MIMEType:   img.MimeType,
+						Base64Data: &data,
+					},
+				},
+			})
+		}
+		userMsg = &schema.Message{
+			Role:                  schema.User,
+			Content:               agentMsg,
+			UserInputMultiContent: parts,
+		}
+	} else {
+		userMsg = schema.UserMessage(agentMsg)
 	}
 
 	s.mu.Lock()
-	s.history = append(s.history, schema.UserMessage(agentMsg))
+	s.history = append(s.history, userMsg)
 	history := make([]adk.Message, len(s.history))
 	copy(history, s.history)
 	agent := s.agent
@@ -681,6 +743,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		Recommended    bool   `json:"recommended,omitempty"`
 		DefaultEnabled bool   `json:"default_enabled,omitempty"`
 		Enabled        bool   `json:"enabled"`
+		ImageSupport   bool   `json:"image_support,omitempty"`
 	}
 	type providerInfo struct {
 		ID     string      `json:"id"`
@@ -708,10 +771,20 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			}
 			ref := config.ModelRef{Provider: rp.ID, Model: m.ID}
 			enabled := modelState.IsModelEnabled(ref, m.DefaultEnabled)
+			imageSupport := false
+			if m.Modalities != nil {
+				for _, mod := range m.Modalities.Input {
+					if mod == "image" {
+						imageSupport = true
+						break
+					}
+				}
+			}
 			pi.Models = append(pi.Models, modelInfo{
 				ID: m.ID, Name: m.Name, ToolCall: m.ToolCall, ContextLimit: ctx,
 				Reasoning: m.Reasoning, Recommended: m.Recommended,
 				DefaultEnabled: m.DefaultEnabled, Enabled: enabled,
+				ImageSupport: imageSupport,
 			})
 		}
 		result = append(result, pi)

--- a/script/generate_models.go
+++ b/script/generate_models.go
@@ -41,6 +41,8 @@ var wantedProviders = []string{
 	"tencent-coding-plan",
 	"zai",
 	"zai-coding-plan",
+	"xiaomi",
+	"xiaomi-token-plan-cn",
 	// Cloud/local
 	"ollama-cloud",
 }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -277,6 +277,7 @@ function startResize(e: MouseEvent) {
               :class="store.isRunning ? 'bg-amber-400 animate-pulse' : store.wsConnected ? 'bg-emerald-400' : 'bg-zinc-400 dark:bg-zinc-600'"
             />
             {{ store.isRunning ? 'Working…' : store.wsConnected ? 'Ready' : 'Offline' }}
+            <span v-if="store.serverVersion" class="text-[10px] text-zinc-300 dark:text-zinc-600">v{{ store.serverVersion }}</span>
           </div>
         </div>
       </header>

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -2,7 +2,7 @@
 import { ref, nextTick, watch, computed, onMounted, onUnmounted } from 'vue'
 import { useChatStore } from '@/stores/chat'
 import { api } from '@/composables/api'
-import type { SkillInfo } from '@/types/api'
+import type { SkillInfo, ChatImage } from '@/types/api'
 
 const store = useChatStore()
 const input = ref('')
@@ -17,6 +17,11 @@ const skills = ref<SkillInfo[]>([])
 const showSlashMenu = ref(false)
 const slashFilter = ref('')
 const selectedSlashIdx = ref(0)
+
+// Image attachment state
+const pendingImages = ref<ChatImage[]>([])
+const pendingImagePreviews = ref<string[]>([])
+const fileInput = ref<HTMLInputElement | null>(null)
 
 const modes = [
   { value: 'agent' as const, label: 'Agent', icon: '🔥' },
@@ -116,6 +121,28 @@ function handleKeyDown(e: KeyboardEvent) {
   }
 }
 
+function handlePaste(e: ClipboardEvent) {
+  if (!store.imageSupport) return
+  const items = e.clipboardData?.items
+  if (!items) return
+  for (const item of Array.from(items)) {
+    if (!item.type.startsWith('image/')) continue
+    e.preventDefault()
+    const file = item.getAsFile()
+    if (!file) continue
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      const commaIdx = result.indexOf(',')
+      if (commaIdx < 0) return
+      const base64Data = result.substring(commaIdx + 1)
+      pendingImages.value.push({ data: base64Data, media_type: file.type })
+      pendingImagePreviews.value.push(result)
+    }
+    reader.readAsDataURL(file)
+  }
+}
+
 function handleInput() {
   autoResize()
   const text = input.value
@@ -136,17 +163,52 @@ function applySlashCommand(skill: SkillInfo) {
 
 async function send() {
   const text = input.value.trim()
-  if (!text || store.isRunning) return
+  if ((!text && pendingImages.value.length === 0) || store.isRunning) return
+  const images = pendingImages.value.length > 0 ? [...pendingImages.value] : undefined
   input.value = ''
+  pendingImages.value = []
+  pendingImagePreviews.value = []
   showSlashMenu.value = false
   await nextTick()
   autoResize()
-  store.sendMessage(text)
+  store.sendMessage(text || '(see attached images)', images)
 }
 
 function selectModel(provider: string, model: string) {
   showModelPicker.value = false
   store.switchModel(provider, model)
+}
+
+function triggerImageUpload() {
+  fileInput.value?.click()
+}
+
+function handleImageSelect(e: Event) {
+  const target = e.target as HTMLInputElement
+  const files = target.files
+  if (!files) return
+  for (const file of Array.from(files)) {
+    if (!file.type.startsWith('image/')) continue
+    if (file.size > 10 * 1024 * 1024) continue // 10MB limit
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      // result is "data:<media_type>;base64,<data>"
+      const commaIdx = result.indexOf(',')
+      if (commaIdx < 0) return
+      const base64Data = result.substring(commaIdx + 1)
+      pendingImages.value.push({ data: base64Data, media_type: file.type })
+      pendingImagePreviews.value.push(result)
+    }
+    reader.readAsDataURL(file)
+  }
+  // Reset input so the same file can be re-selected
+  target.value = ''
+}
+
+function removeImage(index: number) {
+  pendingImages.value.splice(index, 1)
+  pendingImagePreviews.value.splice(index, 1)
 }
 
 function selectMode(mode: 'agent' | 'plan') {
@@ -229,6 +291,17 @@ watch(() => store.isRunning, (running) => {
           </button>
         </div>
 
+        <!-- Image previews -->
+        <div v-if="pendingImagePreviews.length > 0" class="flex flex-wrap gap-2 mb-2">
+          <div v-for="(preview, i) in pendingImagePreviews" :key="i" class="relative group">
+            <img :src="preview" class="w-16 h-16 object-cover rounded border border-zinc-200 dark:border-zinc-700" />
+            <button
+              class="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-red-500 text-white text-[9px] flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+              @click="removeImage(i)"
+            >✕</button>
+          </div>
+        </div>
+
         <textarea
           ref="textarea"
           v-model="input"
@@ -238,10 +311,40 @@ watch(() => store.isRunning, (running) => {
           class="w-full bg-transparent text-zinc-800 dark:text-zinc-100 text-sm resize-none outline-none placeholder-zinc-400 dark:placeholder-zinc-500 min-h-6 max-h-40 leading-relaxed disabled:opacity-50"
           @keydown="handleKeyDown"
           @input="handleInput"
+          @paste="handlePaste"
+        />
+
+        <!-- Hidden file input for image upload -->
+        <input
+          ref="fileInput"
+          type="file"
+          accept="image/*"
+          multiple
+          class="hidden"
+          @change="handleImageSelect"
         />
         <!-- Toolbar row -->
         <div class="flex items-center justify-between mt-1.5 pt-1.5 border-t border-zinc-200/60 dark:border-zinc-700/40">
           <div class="flex items-center gap-1.5">
+            <!-- Image attach "+" button -->
+            <button
+              class="w-6 h-6 flex items-center justify-center rounded border transition-colors shrink-0"
+              :class="[
+                store.imageSupport ? 'cursor-pointer' : 'cursor-not-allowed opacity-40',
+                pendingImages.length > 0
+                  ? 'border-blue-400 dark:border-blue-500 bg-blue-50 dark:bg-blue-500/15 text-blue-600 dark:text-blue-400'
+                  : 'border-zinc-300 dark:border-zinc-600 text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 hover:border-zinc-400 dark:hover:border-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-700/60'
+              ]"
+              :title="!store.imageSupport ? 'Current model does not support images' : pendingImages.length > 0 ? `${pendingImages.length} image(s) attached — click to add more` : 'Attach images'"
+              :disabled="!store.imageSupport"
+              @click="store.imageSupport && triggerImageUpload()"
+            >
+              <svg v-if="pendingImages.length === 0" class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" />
+              </svg>
+              <span v-else class="text-[10px] font-bold">{{ pendingImages.length }}</span>
+            </button>
+
             <!-- Mode selector -->
             <div class="relative">
               <button
@@ -457,7 +560,7 @@ watch(() => store.isRunning, (running) => {
             <button
               v-else
               class="w-7 h-7 flex items-center justify-center rounded-md bg-emerald-500 hover:bg-emerald-600 text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-sm"
-              :disabled="!input.trim()"
+              :disabled="!input.trim() && pendingImages.length === 0"
               @click="send"
             >
               <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">

--- a/web/src/components/ChatMessage.vue
+++ b/web/src/components/ChatMessage.vue
@@ -39,6 +39,16 @@ defineProps<{
         {{ message.role === 'user' ? (message.source === 'wechat' ? 'WeChat' : 'You') : message.role === 'assistant' ? '[J]CODE' : 'System' }}
       </span>
     </div>
+    <!-- Images -->
+    <div v-if="message.images && message.images.length > 0" class="pl-7 mb-2 flex flex-wrap gap-2">
+      <img
+        v-for="(img, i) in message.images"
+        :key="i"
+        :src="`data:${img.media_type};base64,${img.data}`"
+        class="max-w-64 max-h-48 rounded border border-zinc-200 dark:border-zinc-700 object-contain cursor-pointer hover:opacity-90 transition-opacity"
+        @click="($event.target as HTMLImageElement).classList.toggle('max-w-64'); ($event.target as HTMLImageElement).classList.toggle('max-w-full')"
+      />
+    </div>
     <!-- Content -->
     <div
       class="prose-chat pl-7"

--- a/web/src/composables/api.ts
+++ b/web/src/composables/api.ts
@@ -1,5 +1,5 @@
 // API client for jcode backend
-import type { ModelsResponse, AgentMode, ExecResponse, DiffResponse, MCPListResponse, BrowseResponse, SSHListResponse, SkillInfo, TodoItem, SessionItem, SessionEntry, FileItem, SetupProvider, SetupModel, ProviderDetail, ModelStateResponse } from '@/types/api'
+import type { ModelsResponse, AgentMode, ExecResponse, DiffResponse, MCPListResponse, BrowseResponse, SSHListResponse, SkillInfo, TodoItem, SessionItem, SessionEntry, FileItem, SetupProvider, SetupModel, ProviderDetail, ModelStateResponse, ChatImage } from '@/types/api'
 
 const BASE = ''
 
@@ -20,7 +20,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 export const api = {
   health: () =>
-    request<{ status: string; version: string; pwd: string; provider: string; model: string; mode: string; session_id: string; running: boolean }>(
+    request<{ status: string; version: string; pwd: string; provider: string; model: string; mode: string; session_id: string; running: boolean; image_support?: boolean }>(
       '/api/health',
     ),
   status: () =>
@@ -49,10 +49,15 @@ export const api = {
   },
   fileContent: (path: string) =>
     request<{ path: string; content: string }>(`/api/files/content?path=${encodeURIComponent(path)}`),
-  chat: (message: string, mode?: AgentMode, sessionId?: string) =>
+  chat: (message: string, mode?: AgentMode, sessionId?: string, images?: ChatImage[]) =>
     request<{ status: string; session_id: string }>('/api/chat', {
       method: 'POST',
-      body: JSON.stringify({ message, mode, session_id: sessionId || undefined }),
+      body: JSON.stringify({
+        message,
+        mode,
+        session_id: sessionId || undefined,
+        images: images && images.length > 0 ? images : undefined,
+      }),
     }),
   approval: (id: string, approved: boolean) =>
     request<{ status: string }>('/api/approval', {

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type {
   ChatMessage,
+  ChatImage,
   ToolCall,
   PendingApproval,
   TodoItem,
@@ -55,6 +56,12 @@ export const useChatStore = defineStore('chat', () => {
   const channelAvailable = ref(false)
   const channelEnabled = ref(false)
 
+  // Image support for current model
+  const imageSupport = ref(false)
+
+  // Server version
+  const serverVersion = ref('')
+
   // Model favorites & recent
   const favoriteModels = ref<Set<string>>(new Set())
   const recentModels = ref<ModelRef[]>([])
@@ -86,9 +93,9 @@ export const useChatStore = defineStore('chat', () => {
   })
 
   // --- Actions ---
-  function addMessage(role: ChatMessage['role'], content: string, source?: string): string {
+  function addMessage(role: ChatMessage['role'], content: string, source?: string, images?: ChatImage[]): string {
     const id = genId('msg')
-    const msg: ChatMessage = { id, role, content, timestamp: Date.now(), source }
+    const msg: ChatMessage = { id, role, content, timestamp: Date.now(), source, images }
     timeline.value.push({ kind: 'message', data: msg, seq: nextSeqId() })
     return id
   }
@@ -215,8 +222,8 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  async function sendMessage(text: string) {
-    addMessage('user', text)
+  async function sendMessage(text: string, images?: ChatImage[]) {
+    addMessage('user', text, undefined, images)
     isRunning.value = true
     streamingText = ''
     streamingMsgId = ''
@@ -225,6 +232,7 @@ export const useChatStore = defineStore('chat', () => {
         text,
         mode.value === 'agent' ? ('build' as AgentMode) : mode.value,
         currentSessionId.value || undefined,
+        images,
       )
       // Track the session_id returned by the backend so subsequent messages
       // continue the same session (prevents duplicate session creation).
@@ -319,6 +327,8 @@ export const useChatStore = defineStore('chat', () => {
       mode.value = m === 'build' ? 'agent' : (m as AgentMode)
       currentSessionId.value = h.session_id || ''
       isRunning.value = h.running || false
+      imageSupport.value = h.image_support || false
+      serverVersion.value = h.version || ''
       return h
     } catch (err) {
       console.error('Failed to fetch health:', err)
@@ -341,8 +351,20 @@ export const useChatStore = defineStore('chat', () => {
       await api.switchModel(provider, model)
       providerName.value = provider
       modelName.value = model
+      // Update image support based on the new model's capabilities.
+      updateImageSupport(provider, model)
     } catch (err: unknown) {
       addMessage('system', `Failed to switch model: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  function updateImageSupport(provider: string, model: string) {
+    const p = providers.value.find(pv => pv.id === provider)
+    if (p) {
+      const m = p.models.find(mv => mv.id === model)
+      imageSupport.value = m?.image_support || false
+    } else {
+      imageSupport.value = false
     }
   }
 
@@ -614,6 +636,8 @@ export const useChatStore = defineStore('chat', () => {
     autoApprove,
     channelAvailable,
     channelEnabled,
+    imageSupport,
+    serverVersion,
     currentSessionId,
     // Getters
     messages,

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -94,6 +94,7 @@ export interface ModelInfo {
   recommended?: boolean
   default_enabled?: boolean
   enabled?: boolean
+  image_support?: boolean
 }
 
 export interface ProviderInfo {
@@ -209,12 +210,18 @@ export type MessageRole = 'user' | 'assistant' | 'system'
 
 export type AgentMode = 'agent' | 'plan'
 
+export interface ChatImage {
+  data: string       // base64 data (without data: prefix)
+  media_type: string // e.g. "image/png", "image/jpeg"
+}
+
 export interface ChatMessage {
   id: string
   role: MessageRole
   content: string
   timestamp: number
   source?: string
+  images?: ChatImage[]
 }
 
 export interface ToolCall {


### PR DESCRIPTION
## Summary

Add image input support across the Web UI, ACP protocol, and session persistence layer. When the selected model advertises `"image"` in its `Modalities.Input`, users can attach images to their messages.

## Changes

### Backend — OpenAI model adapter (`internal/model/chatmodel.go`)
- `toOpenAIMessage()` now converts `UserInputMultiContent` (Eino schema) into `openai.MultiContent` (`[]ChatMessagePart`), supporting both base64 data-URI images and URL-based images.

### Backend — Web server (`internal/web/server.go`)
- `currentModelSupportsImage()` helper to check model capabilities.
- Health endpoint returns `image_support` field.
- Chat endpoint accepts `images []chatImage` in the request body (request size limit raised to 20 MB).
- `submitMessage()` builds multimodal `schema.Message` with `UserInputMultiContent` when images are provided.
- Models list API returns `image_support` per model.

### Backend — ACP transport (`internal/command/acp.go`)
- `Initialize()` advertises `PromptCapabilities.Image` based on the configured model.
- `Prompt()` extracts `ContentBlock.Image` from ACP prompt blocks and builds multimodal messages.

### Session persistence (`internal/session/`)
- New `EntryImage` struct (`media_type` + `data`) for JSONL serialization.
- `Entry.Images` field stores base64 images alongside user text.
- `RecordUser()` accepts variadic `EntryImage` (backward-compatible).
- `entryToUserMessage()` helper reconstructs `UserInputMultiContent` from stored images.
- Both `ReconstructHistory()` and `ReconstructState()` restore multimodal messages on session resume.

### Frontend — Vue 3 web UI (`web/src/`)
- **Types**: `ChatImage` interface, `image_support` on `ModelInfo`, `images` on `ChatMessage`.
- **API**: `chat()` accepts optional `images` parameter; health response includes `image_support`.
- **Store**: `imageSupport` / `serverVersion` refs; `sendMessage()` passes images; `switchModel()` updates image support.
- **ChatInput**: "+" button for image attachment (always visible, disabled when model lacks support); clipboard paste via `Ctrl+V`; file picker with 10 MB limit; thumbnail previews with remove buttons.
- **ChatMessage**: Renders attached images inline with click-to-expand.
- **App.vue**: Displays server version next to status indicator.

### Other
- Added `xiaomi` and `xiaomi-token-plan-cn` providers to model registry generator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attach and send images in chat messages (10MB per-file limit) via toolbar or paste
  * View images in conversations with thumbnails; click to expand/collapse image size
  * Auto-detect which models support image input
  * Persist attached images in session history and recordings
  * Display server version in UI header

<!-- end of auto-generated comment: release notes by coderabbit.ai -->