### PR TITLE
fix: passthrough reasoning_content for DeepSeek thinking mode

### DIFF
--- a/internal/model/chatmodel.go
+++ b/internal/model/chatmodel.go
@@ -263,8 +263,9 @@ func (m *chatModel) Stream(ctx context.Context, input []*schema.Message, opts ..
 				config.Logger().Printf("[chatmodel] Stream: first tool call detected at chunk %d: %s", chunkCount, delta.ToolCalls[0].Function.Name)
 			}
 			msg := &schema.Message{
-				Role:    schema.Assistant,
-				Content: delta.Content,
+				Role:             schema.Assistant,
+				Content:          delta.Content,
+				ReasoningContent: delta.ReasoningContent,
 			}
 			if len(delta.ToolCalls) > 0 {
 				msg.ToolCalls = toEinoToolCalls(delta.ToolCalls)
@@ -320,10 +321,11 @@ func (m *chatModel) buildRequest(input []*schema.Message, stream bool, opts ...e
 
 func toOpenAIMessage(msg *schema.Message) openai.ChatCompletionMessage {
 	m := openai.ChatCompletionMessage{
-		Role:       string(msg.Role),
-		Content:    msg.Content,
-		Name:       msg.Name,
-		ToolCallID: msg.ToolCallID,
+		Role:             string(msg.Role),
+		Content:          msg.Content,
+		Name:             msg.Name,
+		ToolCallID:       msg.ToolCallID,
+		ReasoningContent: msg.ReasoningContent,
 	}
 	if len(msg.ToolCalls) > 0 {
 		m.ToolCalls = toOpenAIToolCalls(msg.ToolCalls)
@@ -365,10 +367,11 @@ func toOpenAIMessage(msg *schema.Message) openai.ChatCompletionMessage {
 
 func toEinoMessage(msg openai.ChatCompletionMessage) *schema.Message {
 	m := &schema.Message{
-		Role:       schema.RoleType(msg.Role),
-		Content:    msg.Content,
-		Name:       msg.Name,
-		ToolCallID: msg.ToolCallID,
+		Role:             schema.RoleType(msg.Role),
+		Content:          msg.Content,
+		Name:             msg.Name,
+		ToolCallID:       msg.ToolCallID,
+		ReasoningContent: msg.ReasoningContent,
 	}
 	if len(msg.ToolCalls) > 0 {
 		m.ToolCalls = toEinoToolCalls(msg.ToolCalls)


### PR DESCRIPTION
## Problem

DeepSeek reasoning models (e.g. `deepseek-reasoner`, `deepseek-v4-pro` with thinking mode) return `reasoning_content` alongside `content` in API responses. Per [DeepSeek API docs](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode):

- When **tool calls** are involved, `reasoning_content` from assistant messages **must** be sent back in subsequent API requests
- Failure to do so results in a **400 Bad Request** error

The `toOpenAIMessage()`, `toEinoMessage()`, and stream delta handling in `chatmodel.go` were all dropping the `reasoning_content` field, causing multi-turn tool-calling conversations with DeepSeek reasoning models to fail.

## Fix

Map `ReasoningContent` in all three message conversion points:

1. **`toOpenAIMessage()`** — Eino Message → OpenAI request message (sends reasoning_content back to API)
2. **`toEinoMessage()`** — OpenAI response → Eino Message (captures reasoning_content from non-streaming responses)
3. **Stream handler** — stream delta → Eino Message (captures reasoning_content from streaming responses)

Both `go-openai` v1.41.2 and Eino v0.8.11 already support the `ReasoningContent` field — only the conversion layer was missing the mapping.