### PR TITLE
fix: disable pager and interactive prompts in all executors

### DIFF
--- a/internal/tools/acp_executor.go
+++ b/internal/tools/acp_executor.go
@@ -99,12 +99,16 @@ func (a *ACPExecutor) Stat(ctx context.Context, path string) (*FileInfo, error) 
 func (a *ACPExecutor) Exec(ctx context.Context, command, workDir string, timeout time.Duration) (string, string, error) {
 	appconfig.Logger().Printf("[acp-exec] Exec: cmd=%q workDir=%q timeout=%v", command, workDir, timeout)
 
+	// Prepend environment variables to disable pagers/editors/prompts,
+	// preventing interactive programs (less, vim, etc.) from blocking forever.
+	wrappedCmd := "export GIT_TERMINAL_PROMPT=0 GIT_PAGER=cat PAGER=cat GIT_EDITOR=true; " + command
+
 	// Build the terminal create request. We pass the full command via "bash -c"
 	// so that shell features (pipes, redirects, &&) work as expected.
 	req := acp.CreateTerminalRequest{
 		SessionId: a.sessionID,
 		Command:   "bash",
-		Args:      []string{"-c", command},
+		Args:      []string{"-c", wrappedCmd},
 	}
 	if workDir != "" {
 		req.Cwd = &workDir

--- a/internal/tools/env.go
+++ b/internal/tools/env.go
@@ -214,6 +214,24 @@ func (l *LocalExecutor) Exec(ctx context.Context, command, workDir string, timeo
 		cmd.Dir = workDir
 	}
 
+	// Prevent interactive programs (pagers, editors, prompts) from blocking
+	// forever by closing stdin. This causes programs like `less` (invoked by
+	// git diff, git log, etc.) to exit immediately instead of waiting for
+	// keyboard input. Same approach as opencode's stdin:"ignore".
+	cmd.Stdin = nil
+
+	// Set environment variables to further disable interactive behaviors:
+	// - GIT_TERMINAL_PROMPT=0: prevent git from prompting for credentials
+	// - GIT_PAGER=cat: disable git's pager (less/more) entirely
+	// - PAGER=cat: disable generic pager for other commands (man, etc.)
+	// - GIT_EDITOR=true: prevent git from opening an editor (rebase -i, commit without -m)
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_PAGER=cat",
+		"PAGER=cat",
+		"GIT_EDITOR=true",
+	)
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -353,9 +371,11 @@ func (s *SSHExecutor) Stat(ctx context.Context, path string) (*FileInfo, error) 
 }
 
 func (s *SSHExecutor) Exec(ctx context.Context, command, workDir string, timeout time.Duration) (string, string, error) {
-	fullCmd := command
+	// Prepend environment variables to disable pagers/editors/prompts on remote.
+	envPrefix := "export GIT_TERMINAL_PROMPT=0 GIT_PAGER=cat PAGER=cat GIT_EDITOR=true; "
+	fullCmd := envPrefix + command
 	if workDir != "" {
-		fullCmd = fmt.Sprintf("cd %s && %s", ShellQuote(workDir), command)
+		fullCmd = fmt.Sprintf("cd %s && %s", ShellQuote(workDir), envPrefix+command)
 	}
 	return s.run(ctx, fullCmd, "", timeout)
 }


### PR DESCRIPTION
## Problem

Commands like `git diff --stat`, `git log`, `man` etc. invoke a pager (`less`) which blocks forever waiting for stdin input. This causes the `execute` tool to hang indefinitely.

Affects all three executor implementations:
- `LocalExecutor`
- `SSHExecutor`
- `ACPExecutor`

## Solution

### LocalExecutor (`env.go`)
- Set `cmd.Stdin = nil` to close stdin (pager detects no TTY and exits immediately)
- Inject env vars via `cmd.Env`: `GIT_PAGER=cat`, `PAGER=cat`, `GIT_TERMINAL_PROMPT=0`, `GIT_EDITOR=true`

### SSHExecutor (`env.go`)
- Prepend `export GIT_TERMINAL_PROMPT=0 GIT_PAGER=cat PAGER=cat GIT_EDITOR=true;` to the command

### ACPExecutor (`acp_executor.go`)
- Same `export` prefix approach as SSH

## Reference

This follows patterns used by other coding agents:
- **opencode**: `stdin: "ignore"` in `ChildProcess.make()`
- **Claude Code**: `< /dev/null` redirect + `GIT_EDITOR=true` env var

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved command execution blocking when encountering interactive git terminal prompts, pagination dialogs, or editor windows. Environment variables are now automatically configured to disable git terminal prompts, suppress pagination, prevent editor launches, and disable standard input. This ensures all commands execute non-interactively without hanging in both local and remote environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->