### PR TITLE
feat(config): implement custom model support in ModelRegistry and upd…

### DIFF
--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -185,7 +185,7 @@ func (a *acpAgent) Initialize(_ context.Context, params acp.InitializeRequest) (
 	imageSupport := false
 	if cfg, err := config.LoadConfig(); err == nil {
 		providerName, modelName := cfg.GetProviderModel()
-		registry := internalmodel.NewModelRegistry()
+		registry := internalmodel.NewModelRegistryWithConfig(cfg)
 		if _, m, ok := registry.LookupModel(providerName, modelName); ok && m != nil && m.Modalities != nil {
 			for _, mod := range m.Modalities.Input {
 				if mod == "image" {
@@ -283,7 +283,7 @@ func (a *acpAgent) buildAgentSession(
 		return nil, fmt.Errorf("provider %q not found in config", providerName)
 	}
 
-	registry := internalmodel.NewModelRegistry()
+	registry := internalmodel.NewModelRegistryWithConfig(cfg)
 	baseURL := providerCfg.BaseURL
 	if baseURL == "" {
 		baseURL = registry.GetProviderAPI(providerName)

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -66,7 +66,7 @@ func runDoctorMode() {
 	// Resolve base URL from config or registry
 	baseURL := providerCfg.BaseURL
 	if baseURL == "" {
-		registry := internalmodel.NewModelRegistry()
+		registry := internalmodel.NewModelRegistryWithConfig(cfg)
 		baseURL = registry.GetProviderAPI(providerName)
 	}
 

--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -496,6 +496,9 @@ func (s *interactiveState) handleConfig(cfgMsg *config.Config) {
 		return
 	}
 
+	// Refresh registry so new custom models / providers are available.
+	s.registry = internalmodel.NewModelRegistryWithConfig(cfgMsg)
+
 	newBaseURL := newProvCfg.BaseURL
 	if newBaseURL == "" {
 		newBaseURL = s.registry.GetProviderAPI(newProvName)
@@ -566,6 +569,9 @@ func (s *interactiveState) handleAddModel() {
 	if newProvCfg == nil {
 		return
 	}
+	// Refresh registry so new custom models / providers are available.
+	s.registry = internalmodel.NewModelRegistryWithConfig(newCfg)
+
 	newBaseURL := newProvCfg.BaseURL
 	if newBaseURL == "" {
 		newBaseURL = s.registry.GetProviderAPI(newProvName)

--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -774,7 +774,7 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 		return fmt.Errorf("provider %q not found in config", providerName)
 	}
 
-	registry := internalmodel.NewModelRegistry()
+	registry := internalmodel.NewModelRegistryWithConfig(cfg)
 	baseURL := providerCfg.BaseURL
 	if baseURL == "" {
 		baseURL = registry.GetProviderAPI(providerName)

--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -90,7 +90,7 @@ func runWebServer(port int, host string, openBrowser bool) error {
 		}
 	}
 
-	registry := internalmodel.NewModelRegistry()
+	registry := internalmodel.NewModelRegistryWithConfig(cfg)
 
 	env := tools.NewEnv(pwd, platform)
 	bgManager := tools.NewBackgroundManager(env)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,9 +15,23 @@ const (
 type ProviderConfig struct {
 	APIKey  string `json:"api_key"`
 	BaseURL string `json:"base_url,omitempty"`
+	// Name is an optional display name for custom providers not in the registry.
+	Name string `json:"name,omitempty"`
 	// Deprecated: model lists are now sourced from the models.dev registry.
 	// Preserved for backward compatibility with existing config files.
 	Models []string `json:"models,omitempty"`
+	// CustomModels defines additional models for this provider.
+	// These are merged into the registry and treated identically to built-in models.
+	CustomModels []CustomModelConfig `json:"custom_models,omitempty"`
+}
+
+// CustomModelConfig defines a model that can be added via config.
+type CustomModelConfig struct {
+	ID        string `json:"id"`
+	Name      string `json:"name,omitempty"`
+	ToolCall  bool   `json:"tool_call,omitempty"`
+	Reasoning bool   `json:"reasoning,omitempty"`
+	Context   int    `json:"context,omitempty"`
 }
 
 // SSHAlias represents a saved SSH connection alias

--- a/internal/model/factory.go
+++ b/internal/model/factory.go
@@ -25,7 +25,7 @@ func NewModelFactory(cfg *config.Config, fallback einomodel.ToolCallingChatModel
 		cfg:      cfg,
 		cache:    make(map[string]einomodel.ToolCallingChatModel),
 		fallback: fallback,
-		registry: NewModelRegistry(),
+		registry: NewModelRegistryWithConfig(cfg),
 	}
 }
 

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cnjack/jcode/internal/config"
 )
 
+
 // RegistryProvider represents a provider from models.dev API.
 type RegistryProvider struct {
 	ID     string                    `json:"id"`
@@ -158,10 +159,14 @@ func (r *ModelRegistry) MergeConfigProviders(providers map[string]*config.Provid
 			if name == "" {
 				name = provID
 			}
+			// Derive an env-var name so that the setup wizard's len(rp.Env)>0 check
+			// correctly prompts for an API key for this provider.
+			envKey := strings.ToUpper(strings.ReplaceAll(provID, "-", "_")) + "_API_KEY"
 			prov = &RegistryProvider{
 				ID:     provID,
 				Name:   name,
 				API:    provCfg.BaseURL,
+				Env:    []string{envKey},
 				Models: make(map[string]*RegistryModel),
 			}
 			r.providers[provID] = prov

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -4,6 +4,8 @@ package model
 
 import (
 	"strings"
+
+	"github.com/cnjack/jcode/internal/config"
 )
 
 // RegistryProvider represents a provider from models.dev API.
@@ -59,27 +61,94 @@ type ModelLimit struct {
 	Output  int `json:"output,omitempty"`
 }
 
-// ModelRegistry provides model metadata from models.dev.
-// The data is statically generated at build time via go:generate.
+// ModelRegistry provides model metadata from models.dev and custom config.
+// The base data is statically generated at build time via go:generate.
+// Custom models from config are merged in at runtime.
 type ModelRegistry struct {
+	providers     map[string]*RegistryProvider
+	providerOrder []string
 }
 
-// NewModelRegistry creates a new ModelRegistry.
+// NewModelRegistry creates a new ModelRegistry with generated data only.
 func NewModelRegistry() *ModelRegistry {
-	return &ModelRegistry{}
+	providers := make(map[string]*RegistryProvider, len(generatedProviders))
+	for k, v := range generatedProviders {
+		providers[k] = v
+	}
+	providerOrder := make([]string, len(generatedProviderOrder))
+	copy(providerOrder, generatedProviderOrder)
+	return &ModelRegistry{
+		providers:     providers,
+		providerOrder: providerOrder,
+	}
 }
 
-// Load returns the statically generated provider/model data.
+// NewModelRegistryWithConfig creates a ModelRegistry and merges custom models from config.
+func NewModelRegistryWithConfig(cfg *config.Config) *ModelRegistry {
+	r := NewModelRegistry()
+	if cfg != nil {
+		r.MergeConfigProviders(cfg.GetProviders())
+	}
+	return r
+}
+
+// MergeConfigProviders merges custom models from config providers into the registry.
+// For providers not in the registry, a new entry is created.
+// For existing providers, custom models are added (existing models are not overridden).
+func (r *ModelRegistry) MergeConfigProviders(providers map[string]*config.ProviderConfig) {
+	for provID, provCfg := range providers {
+		if len(provCfg.CustomModels) == 0 {
+			continue
+		}
+
+		prov, exists := r.providers[provID]
+		if !exists {
+			name := provCfg.Name
+			if name == "" {
+				name = provID
+			}
+			prov = &RegistryProvider{
+				ID:     provID,
+				Name:   name,
+				API:    provCfg.BaseURL,
+				Models: make(map[string]*RegistryModel),
+			}
+			r.providers[provID] = prov
+			r.providerOrder = append(r.providerOrder, provID)
+		}
+
+		for _, cm := range provCfg.CustomModels {
+			if _, exists := prov.Models[cm.ID]; exists {
+				continue
+			}
+			name := cm.Name
+			if name == "" {
+				name = cm.ID
+			}
+			rm := &RegistryModel{
+				ID:             cm.ID,
+				Name:           name,
+				ToolCall:       cm.ToolCall,
+				Reasoning:      cm.Reasoning,
+				DefaultEnabled: true,
+			}
+			if cm.Context > 0 {
+				rm.Limit = &ModelLimit{Context: cm.Context}
+			}
+			prov.Models[cm.ID] = rm
+		}
+	}
+}
+
+// Load returns the provider/model data.
 func (r *ModelRegistry) Load() (map[string]*RegistryProvider, error) {
-	return generatedProviders, nil
+	return r.providers, nil
 }
 
 // LookupModel finds a model by "provider/model" identifier.
 // Returns the provider info, model info, and whether it was found.
 func (r *ModelRegistry) LookupModel(providerID, modelID string) (*RegistryProvider, *RegistryModel, bool) {
-	providers := generatedProviders
-
-	prov, ok := providers[providerID]
+	prov, ok := r.providers[providerID]
 	if !ok {
 		return nil, nil, false
 	}
@@ -135,7 +204,7 @@ func (r *ModelRegistry) GetProviderEnvVars(providerID string) []string {
 
 // GetProvider returns provider info by ID, or nil if not found.
 func (r *ModelRegistry) GetProvider(providerID string) *RegistryProvider {
-	return generatedProviders[providerID]
+	return r.providers[providerID]
 }
 
 // ListProviderModels returns models for a provider from the registry.
@@ -165,9 +234,9 @@ func (r *ModelRegistry) HasProvider(providerID string) bool {
 
 // ListProviders returns all providers in the curated display order.
 func (r *ModelRegistry) ListProviders() []*RegistryProvider {
-	result := make([]*RegistryProvider, 0, len(generatedProviderOrder))
-	for _, id := range generatedProviderOrder {
-		if prov, ok := generatedProviders[id]; ok {
+	result := make([]*RegistryProvider, 0, len(r.providerOrder))
+	for _, id := range r.providerOrder {
+		if prov, ok := r.providers[id]; ok {
 			result = append(result, prov)
 		}
 	}
@@ -232,7 +301,96 @@ var recommendedModels = map[string]map[string]bool{
 }
 
 func init() {
+	applyStaticProviders()
 	applyRecommendedModels()
+}
+
+// staticProviders defines providers that are not on models.dev but should be
+// built into the registry. They are added to generatedProviders/generatedProviderOrder
+// at init time so they behave identically to models.dev providers.
+var staticProviders = map[string]*RegistryProvider{
+	"tencent-tokenhub-ep": {
+		ID:   "tencent-tokenhub-ep",
+		Name: "Tencent TokenHub Enterprise",
+		Env:  []string{"TENCENT_TOKENHUB_EP_API_KEY"},
+		API:  "https://tokenhub.tencentmaas.com/plan/v3",
+		Models: map[string]*RegistryModel{
+			"auto": {
+				ID: "auto", Name: "Auto", Family: "auto",
+				ToolCall: true, Temperature: true,
+				DefaultEnabled: true,
+				Modalities:     &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+			"glm-5": {
+				ID: "glm-5", Name: "GLM-5", Family: "glm",
+				ToolCall: true, Temperature: true,
+				DefaultEnabled: true,
+				Modalities:     &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+			"glm-5.1": {
+				ID: "glm-5.1", Name: "GLM-5.1", Family: "glm",
+				ToolCall: true, Temperature: true,
+				DefaultEnabled: true, Recommended: true,
+				Modalities: &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+			"glm-5-turbo": {
+				ID: "glm-5-turbo", Name: "GLM-5-Turbo", Family: "glm",
+				ToolCall: true, Temperature: true,
+				DefaultEnabled: true,
+				Modalities:     &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+			"kimi-k2.5": {
+				ID: "kimi-k2.5", Name: "Kimi-K2.5", Family: "kimi",
+				Reasoning: true, ToolCall: true, Temperature: true,
+				DefaultEnabled: true,
+				Modalities:     &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+			"kimi-k2.6": {
+				ID: "kimi-k2.6", Name: "Kimi-K2.6", Family: "kimi",
+				Reasoning: true, ToolCall: true, Temperature: true,
+				DefaultEnabled: true, Recommended: true,
+				Modalities: &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+			"minimax-m2.5": {
+				ID: "minimax-m2.5", Name: "MiniMax-M2.5", Family: "minimax",
+				Reasoning: true, ToolCall: true, Temperature: true,
+				DefaultEnabled: true,
+				Modalities:     &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+			"minimax-m2.7": {
+				ID: "minimax-m2.7", Name: "MiniMax-M2.7", Family: "minimax",
+				Reasoning: true, ToolCall: true, Temperature: true,
+				DefaultEnabled: true, Recommended: true,
+				Modalities: &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+			"deepseek-v4-flash": {
+				ID: "deepseek-v4-flash", Name: "DeepSeek-V4-Flash", Family: "deepseek",
+				Reasoning: true, ToolCall: true, Temperature: true,
+				DefaultEnabled: true,
+				Modalities:     &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+			"deepseek-v4-pro": {
+				ID: "deepseek-v4-pro", Name: "DeepSeek-V4-Pro", Family: "deepseek",
+				Reasoning: true, ToolCall: true, Temperature: true,
+				DefaultEnabled: true, Recommended: true,
+				Modalities: &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+			},
+		},
+	},
+}
+
+// staticProviderOrder defines the display order for static providers.
+// They are appended after the generated providers.
+var staticProviderOrder = []string{
+	"tencent-tokenhub-ep",
+}
+
+// applyStaticProviders merges staticProviders into generatedProviders.
+func applyStaticProviders() {
+	for id, prov := range staticProviders {
+		generatedProviders[id] = prov
+	}
+	generatedProviderOrder = append(generatedProviderOrder, staticProviderOrder...)
 }
 
 // applyRecommendedModels sets Recommended and DefaultEnabled on models in the generated registry.

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cnjack/jcode/internal/config"
 )
 
-
 // RegistryProvider represents a provider from models.dev API.
 type RegistryProvider struct {
 	ID     string                    `json:"id"`

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -69,11 +69,13 @@ type ModelRegistry struct {
 	providerOrder []string
 }
 
-// NewModelRegistry creates a new ModelRegistry with generated data only.
+// NewModelRegistry creates a new ModelRegistry with a deep copy of generated data.
+// Each RegistryProvider and its Models map are copied so that merging custom models
+// at runtime never mutates the shared generatedProviders.
 func NewModelRegistry() *ModelRegistry {
 	providers := make(map[string]*RegistryProvider, len(generatedProviders))
 	for k, v := range generatedProviders {
-		providers[k] = v
+		providers[k] = deepCopyProvider(v)
 	}
 	providerOrder := make([]string, len(generatedProviderOrder))
 	copy(providerOrder, generatedProviderOrder)
@@ -81,6 +83,55 @@ func NewModelRegistry() *ModelRegistry {
 		providers:     providers,
 		providerOrder: providerOrder,
 	}
+}
+
+// deepCopyProvider creates a deep copy of a RegistryProvider, including its Models map.
+func deepCopyProvider(src *RegistryProvider) *RegistryProvider {
+	if src == nil {
+		return nil
+	}
+	cp := *src // shallow copy of value fields
+	// Deep copy Env slice
+	if src.Env != nil {
+		cp.Env = make([]string, len(src.Env))
+		copy(cp.Env, src.Env)
+	}
+	// Deep copy Models map
+	if src.Models != nil {
+		cp.Models = make(map[string]*RegistryModel, len(src.Models))
+		for mk, mv := range src.Models {
+			cp.Models[mk] = deepCopyModel(mv)
+		}
+	}
+	return &cp
+}
+
+// deepCopyModel creates a deep copy of a RegistryModel, including pointer fields.
+func deepCopyModel(src *RegistryModel) *RegistryModel {
+	if src == nil {
+		return nil
+	}
+	cp := *src
+	if src.Modalities != nil {
+		cp.Modalities = &ModelModalities{}
+		if src.Modalities.Input != nil {
+			cp.Modalities.Input = make([]string, len(src.Modalities.Input))
+			copy(cp.Modalities.Input, src.Modalities.Input)
+		}
+		if src.Modalities.Output != nil {
+			cp.Modalities.Output = make([]string, len(src.Modalities.Output))
+			copy(cp.Modalities.Output, src.Modalities.Output)
+		}
+	}
+	if src.Cost != nil {
+		costCopy := *src.Cost
+		cp.Cost = &costCopy
+	}
+	if src.Limit != nil {
+		limitCopy := *src.Limit
+		cp.Limit = &limitCopy
+	}
+	return &cp
 }
 
 // NewModelRegistryWithConfig creates a ModelRegistry and merges custom models from config.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -251,7 +251,7 @@ func modelContextLimit() int {
 	// Try registry lookup first (provider/model format)
 	provider, modelName := cfg.GetProviderModel()
 	if provider != "" && modelName != "" {
-		registry := internalmodel.NewModelRegistry()
+		registry := internalmodel.NewModelRegistryWithConfig(cfg)
 		if limit := registry.GetModelContextLimit(provider, modelName); limit > 0 {
 			return limit
 		}

--- a/internal/tui/manage_models.go
+++ b/internal/tui/manage_models.go
@@ -60,7 +60,7 @@ func (m Model) openManageModels(cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	}
 
 	configuredProviders := cfg.GetProviders()
-	registry := model.NewModelRegistry()
+	registry := model.NewModelRegistryWithConfig(cfg)
 	modelState, _ := config.LoadModelState()
 
 	var items []list.Item

--- a/internal/tui/pickers.go
+++ b/internal/tui/pickers.go
@@ -20,7 +20,7 @@ func (m Model) handleModelInput(cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	}
 
 	currentProvider, currentModel := cfg.GetProviderModel()
-	registry := model.NewModelRegistry()
+	registry := model.NewModelRegistryWithConfig(cfg)
 
 	// Configured providers (have API key)
 	configuredProviders := cfg.GetProviders()
@@ -46,7 +46,7 @@ func (m Model) handleModelInput(cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	})
 
 	// Get current model info from registry
-	reg := model.NewModelRegistry()
+	reg := model.NewModelRegistryWithConfig(cfg)
 	if _, rm, ok := reg.LookupModel(currentProvider, currentModel); ok && rm != nil {
 		var tags []string
 		if rm.Recommended {

--- a/internal/tui/setup.go
+++ b/internal/tui/setup.go
@@ -116,9 +116,10 @@ func NewSetupModel() SetupModel {
 
 	// Show all providers from the generated registry in curated order
 	for _, rp := range m.registry.ListProviders() {
-		// Providers need a key if they have env vars defined, or if they are custom
-		// providers (no env vars, not from models.dev) that don't yet have a key configured.
-		needKey := len(rp.Env) > 0 || !configuredProviders[rp.ID]
+		// Providers need a key if they declare environment variable names.
+		// Custom providers added via MergeConfigProviders always get a derived
+		// Env entry, so this single check covers all cases.
+		needKey := len(rp.Env) > 0
 		items = append(items, providerItem{
 			profile: ProviderProfile{
 				ID:           rp.ID,

--- a/internal/tui/setup.go
+++ b/internal/tui/setup.go
@@ -91,9 +91,15 @@ type SetupModel struct {
 }
 
 func NewSetupModel() SetupModel {
+	// Load existing config for custom model merging
+	var cfg *config.Config
+	if loadedCfg, err := config.LoadConfig(); err == nil {
+		cfg = loadedCfg
+	}
+
 	m := SetupModel{
 		state:    StateProvider,
-		registry: model.NewModelRegistry(),
+		registry: model.NewModelRegistryWithConfig(cfg),
 	}
 
 	// Build a set of configured providers (from existing config)
@@ -110,7 +116,9 @@ func NewSetupModel() SetupModel {
 
 	// Show all providers from the generated registry in curated order
 	for _, rp := range m.registry.ListProviders() {
-		needKey := len(rp.Env) > 0
+		// Providers need a key if they have env vars defined, or if they are custom
+		// providers (no env vars, not from models.dev) that don't yet have a key configured.
+		needKey := len(rp.Env) > 0 || !configuredProviders[rp.ID]
 		items = append(items, providerItem{
 			profile: ProviderProfile{
 				ID:           rp.ID,

--- a/script/generate_models.go
+++ b/script/generate_models.go
@@ -39,6 +39,7 @@ var wantedProviders = []string{
 	"minimax-coding-plan",
 	"siliconflow",
 	"tencent-coding-plan",
+	"tencent-tokenhub",
 	"zai",
 	"zai-coding-plan",
 	"xiaomi",


### PR DESCRIPTION
## Summary

Add support for custom models and two new model providers in the `ModelRegistry`, enabling users to define additional models via config and include providers not available on models.dev.

## Changes

### Custom model support via config (`internal/config/config.go`)
- Add `Name` field to `ProviderConfig` for display names of custom providers
- Add `CustomModels` field (`[]CustomModelConfig`) to define models with `id`, `name`, `tool_call`, `reasoning`, and `context` limit
- New `CustomModelConfig` struct for per-model configuration

### ModelRegistry refactor (`internal/model/registry.go`)
- Convert `ModelRegistry` from stateless (delegating to generated globals) to stateful (owns `providers` map + `providerOrder` slice)
- `NewModelRegistry()` now materializes generated data into instance fields
- `NewModelRegistryWithConfig(cfg)` creates a registry and merges custom models from config
- `MergeConfigProviders()` merges config-defined providers/models into the registry — creates new provider entries for unknown providers, adds custom models to existing providers (without overriding built-in models)
- All registry methods (`Load`, `LookupModel`, `GetProvider`, `ListProviders`, etc.) now read from instance state instead of global `generatedProviders`

### New built-in provider: Tencent TokenHub Enterprise (`tencent-tokenhub-ep`)
- Static provider with 9 models: auto, glm-5, glm-5.1, glm-5-turbo, kimi-k2.5, kimi-k2.6, minimax-m2.5, minimax-m2.7, deepseek-v4-flash, deepseek-v4-pro
- Models marked with recommended flags where appropriate
- Added to `generatedProviderOrder` at init time via `applyStaticProviders()`

### New models.dev provider: Tencent TokenHub (`script/generate_models.go`)
- Added `tencent-tokenhub` to the `wantedProviders` list for code generation

### Call-site updates (9 files)
- All callers of `NewModelRegistry()` switched to `NewModelRegistryWithConfig(cfg)` so custom models are available everywhere:
  - `internal/command/interactive.go`
  - `internal/command/acp.go`
  - `internal/command/web.go`
  - `internal/command/commands.go`
  - `internal/model/factory.go`
  - `internal/runner/runner.go`
  - `internal/tui/manage_models.go`
  - `internal/tui/pickers.go`
  - `internal/tui/setup.go`

### Setup flow tweak (`internal/tui/setup.go`)
- Custom providers without env vars now correctly require key configuration when not yet configured
- `NewSetupModel()` loads existing config to pass to registry construction

## Config Example

```json
{
  "providers": {
    "my-custom-provider": {
      "name": "My Custom Provider",
      "base_url": "https://api.example.com/v1",
      "api_key": "sk-xxx",
      "custom_models": [
        {
          "id": "my-model-v2",
          "name": "My Model V2",
          "tool_call": true,
          "reasoning": true,
          "context": 128000
        }
      ]
    }
  }
}
```

## Testing

- [x] Existing tests pass (`go test ./...`)
- [x] Custom models appear in TUI model picker
- [x] Static provider models appear alongside generated providers
- [x] Config-defined providers without env vars work in setup flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Define custom models in configuration to supplement built-in models
  * Customize provider display names in configuration settings
  * Added Tencent TokenHub provider support
  * Model and provider resolution now consistently incorporates your configuration across all application components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cnjack/jcode/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->