### PR TITLE
feat(tool-view): enhance tool display info and add skill/team renderers

### DIFF
--- a/internal/handler/web.go
+++ b/internal/handler/web.go
@@ -124,6 +124,39 @@ func extractToolDisplayInfo(name, argsJSON string) *ToolDisplayInfo {
 		if len(info.Subtitle) > 60 {
 			info.Subtitle = info.Subtitle[:60] + "…"
 		}
+	case "load_skill":
+		info.Title = "Load Skill"
+		info.Icon = "skill"
+		info.Category = "context"
+		info.Subtitle = getString("name")
+	case "team_list":
+		info.Title = "Team"
+		info.Icon = "agent"
+		info.Category = "context"
+	case "team_send_message":
+		info.Title = "Message"
+		info.Icon = "agent"
+		info.Category = "execution"
+		to := getString("to")
+		if to == "*" {
+			info.Subtitle = "→ all"
+		} else if to != "" {
+			info.Subtitle = "→ @" + to
+		}
+	case "team_create":
+		info.Title = "Create Team"
+		info.Icon = "agent"
+		info.Category = "execution"
+		info.Subtitle = getString("team_name")
+	case "team_spawn":
+		info.Title = "Spawn"
+		info.Icon = "agent"
+		info.Category = "execution"
+		info.Subtitle = getString("name")
+	case "team_delete":
+		info.Title = "Delete Team"
+		info.Icon = "agent"
+		info.Category = "mutation"
 	default:
 		// MCP or unknown tools
 		info.Title = name

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -198,7 +198,7 @@ func (l *Loader) GetContent(name string) string {
 	if sk == nil {
 		return fmt.Sprintf("Error: Unknown skill '%s'. Available skills:\n%s", name, l.Descriptions())
 	}
-	return fmt.Sprintf("<skill name=%q>\n%s\n</skill>", sk.Name, sk.Body)
+	return fmt.Sprintf("<skill name=%q description=%q>\n%s\n</skill>", sk.Name, sk.Description, sk.Body)
 }
 
 // SlashCommands returns all skills that have a slash command trigger.

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -285,7 +285,7 @@ function startResize(e: MouseEvent) {
                 @retry="store.retryFromMessage(item.data.id)"
                 @edit="(text) => store.editAndResend(item.data.id, text)"
               />
-              <ToolCallCard v-else-if="item.kind === 'tool'" :tool="item.data" class="animate-fade-up" />
+              <ToolCallCard v-else-if="item.kind === 'tool'" :tool="item.data" class="animate-fade-up pl-9" />
               <ApprovalBanner v-else-if="item.kind === 'approval'" :approval="item.data" class="animate-fade-up" />
             </template>
 

--- a/web/src/components/TerminalInstance.vue
+++ b/web/src/components/TerminalInstance.vue
@@ -25,6 +25,8 @@ let sessionId = ''
 let resizeObserver: ResizeObserver | null = null
 let themeObserver: MutationObserver | null = null
 
+const termBg = ref(isDarkMode() ? '#18181b' : '#fafafa')
+
 function isDarkMode(): boolean {
   return document.documentElement.classList.contains('dark')
 }
@@ -83,6 +85,7 @@ async function init() {
 
   themeObserver = new MutationObserver(() => {
     if (term) term.options.theme = isDarkMode() ? darkTheme : lightTheme
+    termBg.value = isDarkMode() ? '#18181b' : '#fafafa'
   })
   themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
 
@@ -170,6 +173,7 @@ onUnmounted(cleanup)
   <div
     class="term-instance"
     :class="{ 'term-inactive': !active }"
+    :style="{ background: termBg }"
     ref="termEl"
   />
 </template>

--- a/web/src/components/TerminalPanel.vue
+++ b/web/src/components/TerminalPanel.vue
@@ -58,14 +58,18 @@ function closeTab(id: string) {
           @click="activeId = tab.id"
         >
           <!-- × on the left of the label, appears on hover -->
-          <span
+          <button
             class="tab-close"
+            :aria-label="`Close ${tab.label}`"
+            tabindex="-1"
             @click.stop="closeTab(tab.id)"
+            @keydown.enter.stop.prevent="closeTab(tab.id)"
+            @keydown.space.stop.prevent="closeTab(tab.id)"
           >
             <svg class="w-2.5 h-2.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
               <path d="M18 6L6 18M6 6l12 12" />
             </svg>
-          </span>
+          </button>
           <span class="tab-label">{{ tab.label }}</span>
         </button>
 
@@ -134,14 +138,21 @@ function closeTab(id: string) {
   justify-content: center;
   width: 14px;
   height: 14px;
+  padding: 0;
+  border: none;
   border-radius: 2px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
   flex-shrink: 0;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 0.1s, background 0.1s;
 }
 /* Show × when hovering the tab or for the active tab */
 .tab-btn:hover .tab-close {
   opacity: 0.6;
+  pointer-events: auto;
 }
 .tab-btn:hover .tab-close:hover {
   opacity: 1;
@@ -149,6 +160,7 @@ function closeTab(id: string) {
 }
 .tab-active .tab-close {
   opacity: 0.4;
+  pointer-events: auto;
 }
 .tab-active:hover .tab-close {
   opacity: 0.7;

--- a/web/src/components/TerminalPanel.vue
+++ b/web/src/components/TerminalPanel.vue
@@ -57,9 +57,8 @@ function closeTab(id: string) {
           :class="{ 'tab-active': tab.id === activeId }"
           @click="activeId = tab.id"
         >
-          <span class="tab-label">{{ tab.label }}</span>
+          <!-- × on the left of the label, appears on hover -->
           <span
-            v-if="tabs.length > 1"
             class="tab-close"
             @click.stop="closeTab(tab.id)"
           >
@@ -67,16 +66,19 @@ function closeTab(id: string) {
               <path d="M18 6L6 18M6 6l12 12" />
             </svg>
           </span>
+          <span class="tab-label">{{ tab.label }}</span>
         </button>
-      </div>
 
-      <!-- Controls -->
-      <div class="flex items-center gap-0.5 shrink-0">
+        <!-- + New terminal after the last tab -->
         <button class="ctrl-btn" title="New terminal" @click="addTab">
           <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
             <path d="M12 5v14M5 12h14" />
           </svg>
         </button>
+      </div>
+
+      <!-- Controls: close panel only -->
+      <div class="flex items-center gap-0.5 shrink-0">
         <button class="ctrl-btn" title="Close panel" @click="emit('close')">
           <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
             <path d="M18 6L6 18M6 6l12 12" />
@@ -130,15 +132,26 @@ function closeTab(id: string) {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 12px;
-  height: 12px;
+  width: 14px;
+  height: 14px;
   border-radius: 2px;
-  opacity: 0.4;
+  flex-shrink: 0;
+  opacity: 0;
   transition: opacity 0.1s, background 0.1s;
 }
-.tab-close:hover {
+/* Show × when hovering the tab or for the active tab */
+.tab-btn:hover .tab-close {
+  opacity: 0.6;
+}
+.tab-btn:hover .tab-close:hover {
   opacity: 1;
   background: color-mix(in srgb, var(--color-foreground) 15%, transparent);
+}
+.tab-active .tab-close {
+  opacity: 0.4;
+}
+.tab-active:hover .tab-close {
+  opacity: 0.7;
 }
 .ctrl-btn {
   display: flex;

--- a/web/src/components/ToolCallCard.vue
+++ b/web/src/components/ToolCallCard.vue
@@ -32,7 +32,87 @@ const renderType = computed(() => {
   if (name === 'edit' || name === 'multi_edit') return 'diff'
   if (name === 'grep') return 'search'
   if (name === 'todowrite' || name === 'todoread') return 'todo'
+  if (name === 'load_skill') return 'skill'
+  if (name === 'team_list') return 'team-list'
+  if (name === 'team_send_message') return 'team-message'
+  if (name === 'team_create') return 'team-create'
+  if (name === 'team_spawn') return 'team-spawn'
   return 'generic'
+})
+
+// ─── Skill renderer helpers ───
+const skillData = computed(() => {
+  try {
+    const skillName = JSON.parse(props.tool.args).name || ''
+    const output = props.tool.output || ''
+    const descMatch = output.match(/description="([^"]*)"/)
+    return { name: skillName, description: descMatch ? descMatch[1] : '' }
+  } catch { return { name: '', description: '' } }
+})
+
+// ─── Team list renderer helpers ───
+interface TeamMember { name: string; status: string; type: string; progress: string }
+const teamListData = computed(() => {
+  const output = props.tool.output || ''
+  const teamMatch = output.match(/^Team: (.+?) \((\d+)/)
+  const teamName = teamMatch ? teamMatch[1] : ''
+  const members: TeamMember[] = []
+  for (const line of output.split('\n')) {
+    const m = line.match(/@(\S+)\s+status=(\S+)\s+type=(\S*)(.*)/)
+    if (m) {
+      const progress = m[4] ? m[4].trim() : ''
+      members.push({ name: m[1], status: m[2], type: m[3], progress })
+    }
+  }
+  return { teamName, members }
+})
+
+function memberStatusColor(status: string): string {
+  if (status === 'running' || status === 'busy') return 'var(--color-primary)'
+  if (status === 'done' || status === 'finished') return 'var(--color-success-fg)'
+  if (status === 'error') return 'var(--color-destructive)'
+  return 'var(--color-muted-foreground)'
+}
+
+// ─── Team create renderer helpers ───
+const teamCreateData = computed(() => {
+  try {
+    const parsed = JSON.parse(props.tool.args)
+    const output = props.tool.output || ''
+    const leadMatch = output.match(/Lead agent: (\S+)/)
+    return {
+      teamName: parsed.team_name || '',
+      description: parsed.description || '',
+      lead: leadMatch ? leadMatch[1] : '',
+    }
+  } catch { return { teamName: '', description: '', lead: '' } }
+})
+
+// ─── Team spawn renderer helpers ───
+const teamSpawnData = computed(() => {
+  try {
+    const parsed = JSON.parse(props.tool.args)
+    const output = props.tool.output || ''
+    const idMatch = output.match(/\(ID: ([^)]+)\)/)
+    return {
+      name: parsed.name || '',
+      prompt: parsed.prompt || '',
+      agentType: parsed.agent_type || '',
+      id: idMatch ? idMatch[1] : '',
+    }
+  } catch { return { name: '', prompt: '', agentType: '', id: '' } }
+})
+
+// ─── Team message renderer helpers ───
+const teamMsgData = computed(() => {
+  try {
+    const parsed = JSON.parse(props.tool.args)
+    return {
+      to: parsed.to || '',
+      message: parsed.message || '',
+      summary: parsed.summary || '',
+    }
+  } catch { return { to: '', message: '', summary: '' } }
 })
 
 // ─── Todo renderer helpers ───
@@ -241,7 +321,7 @@ function formatArgs(args: string): string {
   <div v-if="isSubagent" class="my-1">
     <!-- Header: no box, just a plain label row -->
     <button
-      class="w-full flex items-center gap-1.5 px-1 py-1 text-left cursor-pointer hover:opacity-70 transition-opacity"
+      class="w-full flex items-center gap-1.5 pl-0 pr-1 py-1 text-left cursor-pointer hover:opacity-70 transition-opacity"
       style="background: transparent"
       @click="subagentExpanded = !subagentExpanded"
     >
@@ -297,7 +377,7 @@ function formatArgs(args: string): string {
     <!-- Trigger: only shown when collapsed -->
     <button
       v-if="!expanded"
-      class="w-full flex items-center gap-1.5 px-1 py-1 text-left cursor-pointer hover:opacity-70 transition-opacity"
+      class="w-full flex items-center gap-1.5 pl-0 pr-1 py-1 text-left cursor-pointer hover:opacity-70 transition-opacity"
       style="background: transparent"
       @click="expanded = true"
     >
@@ -324,7 +404,7 @@ function formatArgs(args: string): string {
     <!-- Expanded: header outside, content box below -->
     <div v-else>
       <!-- Header: plain text row, no box — click to collapse -->
-      <div class="flex items-center gap-1.5 px-1 py-1 cursor-pointer hover:opacity-70 transition-opacity" @click="expanded = false">
+      <div class="flex items-center gap-1.5 pl-0 pr-1 py-1 cursor-pointer hover:opacity-70 transition-opacity" @click="expanded = false">
         <span
           class="text-xs font-medium"
           :class="{ 'shimmer-running': tool.status === 'running' }"
@@ -346,7 +426,7 @@ function formatArgs(args: string): string {
       </div>
       <!-- Content box: only content gets the border -->
       <div
-        class="overflow-hidden mx-2 mt-1 mb-1"
+        class="overflow-hidden ml-0 mr-2 mt-1 mb-1"
         :class="tool.status === 'error' ? 'border border-red-300/60 dark:border-red-500/30' : ''"
         :style="{ borderRadius: 'var(--radius-xl)', border: tool.status !== 'error' ? '1px solid var(--color-border)' : undefined }"
       >
@@ -443,6 +523,116 @@ function formatArgs(args: string): string {
         <div v-else-if="tool.status === 'running'" class="py-1 text-xs animate-pulse" style="color: var(--color-muted-foreground)">Loading…</div>
         <div v-else class="py-1 text-xs italic" style="color: var(--color-muted-foreground)">No todos</div>
         <div v-if="tool.error" class="mt-1.5 text-xs font-mono whitespace-pre-wrap" style="color: var(--color-destructive)">{{ tool.error }}</div>
+      </div>
+
+      <!-- ═══════ Skill Loader ═══════ -->
+      <div v-else-if="renderType === 'skill'" class="px-3 py-2.5" style="background: var(--color-surface)">
+        <div class="flex items-center gap-2">
+          <span class="text-[11px] font-semibold font-mono" style="color: var(--color-foreground)">{{ skillData.name }}</span>
+          <span
+            v-if="tool.status === 'running'"
+            class="text-[10px] animate-pulse"
+            style="color: var(--color-muted-foreground)"
+          >loading…</span>
+        </div>
+        <div
+          v-if="skillData.description"
+          class="mt-1 text-[11px] leading-snug"
+          style="color: var(--color-muted-foreground)"
+        >{{ skillData.description }}</div>
+        <div v-if="tool.error" class="mt-1 text-[11px] font-mono" style="color: var(--color-destructive)">{{ tool.error }}</div>
+      </div>
+
+      <!-- ═══════ Team List ═══════ -->
+      <div v-else-if="renderType === 'team-list'" class="px-3 py-2 max-h-64 overflow-y-auto" style="background: var(--color-surface)">
+        <div
+          v-if="teamListData.teamName"
+          class="flex items-center gap-2 mb-2 pb-1.5"
+          style="border-bottom: 1px solid var(--color-border)"
+        >
+          <span class="text-[10px] uppercase tracking-wider font-semibold" style="color: var(--color-muted-foreground)">team</span>
+          <span class="text-xs font-mono font-semibold" style="color: var(--color-foreground)">{{ teamListData.teamName }}</span>
+          <span class="ml-auto text-[10px] tabular-nums" style="color: var(--color-muted-foreground)">{{ teamListData.members.length }} members</span>
+        </div>
+        <div v-if="teamListData.members.length" class="space-y-0.5">
+          <div v-for="member in teamListData.members" :key="member.name" class="flex items-center gap-2 py-0.5">
+            <span class="text-[11px] w-3 text-center shrink-0" :style="{ color: memberStatusColor(member.status) }">●</span>
+            <span class="text-xs font-mono flex-1" style="color: var(--color-foreground)">@{{ member.name }}</span>
+            <span
+              class="text-[10px] font-mono px-1.5 py-0.5 rounded tabular-nums"
+              style="background: var(--color-muted); color: var(--color-muted-foreground)"
+            >{{ member.status }}</span>
+            <span v-if="member.type" class="text-[10px]" style="color: var(--color-muted-foreground)">{{ member.type }}</span>
+          </div>
+        </div>
+        <div v-else-if="tool.status === 'running'" class="py-1 text-xs animate-pulse" style="color: var(--color-muted-foreground)">Loading…</div>
+        <div v-else class="py-1 text-xs italic" style="color: var(--color-muted-foreground)">No teammates</div>
+        <div v-if="tool.error" class="mt-1.5 text-xs font-mono" style="color: var(--color-destructive)">{{ tool.error }}</div>
+      </div>
+
+      <!-- ═══════ Team Create ═══════ -->
+      <div v-else-if="renderType === 'team-create'" class="px-3 py-2.5" style="background: var(--color-surface)">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="text-xs font-mono font-semibold" style="color: var(--color-foreground)">{{ teamCreateData.teamName }}</span>
+          <span v-if="tool.status === 'done' && !tool.error" class="ml-auto text-[10px] font-semibold" style="color: var(--color-primary)">✓ created</span>
+          <span v-else-if="tool.status === 'running'" class="ml-auto text-[10px] animate-pulse" style="color: var(--color-muted-foreground)">creating…</span>
+        </div>
+        <div v-if="teamCreateData.description" class="text-[11px] leading-snug" style="color: var(--color-muted-foreground)">{{ teamCreateData.description }}</div>
+        <div v-if="teamCreateData.lead" class="mt-1.5 text-[10px] font-mono" style="color: var(--color-muted-foreground)">lead: {{ teamCreateData.lead }}</div>
+        <div v-if="tool.error" class="mt-1 text-xs font-mono" style="color: var(--color-destructive)">{{ tool.error }}</div>
+      </div>
+
+      <!-- ═══════ Team Spawn ═══════ -->
+      <div v-else-if="renderType === 'team-spawn'" class="px-3 py-2.5" style="background: var(--color-surface)">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="text-xs font-mono font-semibold" style="color: var(--color-foreground)">@{{ teamSpawnData.name }}</span>
+          <span
+            v-if="teamSpawnData.agentType"
+            class="text-[10px] px-1.5 py-0.5 rounded"
+            style="background: var(--color-muted); color: var(--color-muted-foreground)"
+          >{{ teamSpawnData.agentType }}</span>
+          <span v-if="tool.status === 'done' && !tool.error" class="ml-auto text-[10px] font-semibold" style="color: var(--color-primary)">✓ running</span>
+          <span v-else-if="tool.status === 'running'" class="ml-auto text-[10px] animate-pulse" style="color: var(--color-muted-foreground)">spawning…</span>
+        </div>
+        <div
+          v-if="teamSpawnData.prompt"
+          class="text-[11px] leading-snug"
+          style="color: var(--color-muted-foreground); font-style: italic; white-space: pre-wrap"
+        >{{ truncate(teamSpawnData.prompt, 150) }}</div>
+        <div v-if="teamSpawnData.id" class="mt-1.5 text-[10px] font-mono" style="color: var(--color-muted-foreground)">id: {{ teamSpawnData.id }}</div>
+        <div v-if="tool.error" class="mt-1 text-xs font-mono" style="color: var(--color-destructive)">{{ tool.error }}</div>
+      </div>
+
+      <!-- ═══════ Team Message ═══════ -->
+      <div v-else-if="renderType === 'team-message'" class="px-3 py-2.5" style="background: var(--color-surface)">
+        <!-- Header: recipient + sent status -->
+        <div class="flex items-center gap-2 mb-1.5">
+          <span class="text-[10px]" style="color: var(--color-muted-foreground)">→</span>
+          <span class="text-xs font-mono font-semibold" style="color: var(--color-foreground)">
+            {{ teamMsgData.to === '*' ? 'all' : '@' + teamMsgData.to }}
+          </span>
+          <span
+            v-if="tool.status === 'done' && !tool.error"
+            class="ml-auto text-[10px] font-semibold"
+            style="color: var(--color-primary)"
+          >✓ sent</span>
+          <span
+            v-else-if="tool.status === 'running'"
+            class="ml-auto text-[10px] animate-pulse"
+            style="color: var(--color-muted-foreground)"
+          >sending…</span>
+        </div>
+        <!-- Summary -->
+        <div v-if="teamMsgData.summary" class="text-[11px] leading-snug font-medium mb-1" style="color: var(--color-foreground)">
+          {{ teamMsgData.summary }}
+        </div>
+        <!-- Message body (truncated) -->
+        <div
+          v-if="teamMsgData.message"
+          class="text-[11px] leading-snug"
+          style="color: var(--color-muted-foreground); font-style: italic; white-space: pre-wrap"
+        >{{ truncate(teamMsgData.message, 200) }}</div>
+        <div v-if="tool.error" class="mt-1.5 text-xs font-mono" style="color: var(--color-destructive)">{{ tool.error }}</div>
       </div>
 
       <!-- ═══════ Generic fallback ═══════ -->

--- a/web/src/components/ToolCallCard.vue
+++ b/web/src/components/ToolCallCard.vue
@@ -555,7 +555,7 @@ function formatArgs(args: string): string {
           <span class="ml-auto text-[10px] tabular-nums" style="color: var(--color-muted-foreground)">{{ teamListData.members.length }} members</span>
         </div>
         <div v-if="teamListData.members.length" class="space-y-0.5">
-          <div v-for="member in teamListData.members" :key="member.name" class="flex items-center gap-2 py-0.5">
+          <div v-for="(member, idx) in teamListData.members" :key="`${member.name}-${idx}`" class="flex items-center gap-2 py-0.5">
             <span class="text-[11px] w-3 text-center shrink-0" :style="{ color: memberStatusColor(member.status) }">●</span>
             <span class="text-xs font-mono flex-1" style="color: var(--color-foreground)">@{{ member.name }}</span>
             <span

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -62,6 +62,31 @@ html {
   --tw-prose-code: var(--color-foreground);
   --tw-prose-pre-bg: #1A1A1A;
   --tw-prose-pre-code: #e4e4e7;
+  /* GitHub-style: tighter line-height than prose default (1.75) */
+  line-height: 1.625;
+  font-size: 0.9375rem; /* 15px */
+}
+
+/* Tighter paragraph spacing — GitHub uses margin-bottom: 16px, no top margin */
+.prose-chat p {
+  margin-top: 0.6em;
+  margin-bottom: 0.6em;
+}
+.prose-chat p:first-child {
+  margin-top: 0;
+}
+.prose-chat p:last-child {
+  margin-bottom: 0;
+}
+/* Tighter list spacing */
+.prose-chat ul,
+.prose-chat ol {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+.prose-chat li {
+  margin-top: 0.25em;
+  margin-bottom: 0.25em;
 }
 
 .prose-chat pre {
@@ -69,8 +94,16 @@ html {
   border: 1px solid var(--color-border);
   font-size: 0.8125rem;
   line-height: 1.625;
+  padding: 0.875em 1em;
   background: #1A1A1A !important;
   color: #e4e4e7;
+}
+
+/* Light mode: GitHub-style code block */
+:root:not(.dark) .prose-chat pre {
+  background: #f6f8fa !important;
+  color: var(--hljs-fg);
+  border-color: #d0d7de;
 }
 
 .prose-chat code:not(pre code) {
@@ -134,4 +167,13 @@ html {
 }
 :root:not(.dark) .diff-bar-empty {
   background: #d4d4d8;
+}
+
+/* ─── xterm terminal light mode fix ─── */
+/* Make the area surrounding the xterm canvas match the terminal theme background */
+:root:not(.dark) .xterm {
+  background-color: #fafafa;
+}
+:root:not(.dark) .xterm-viewport {
+  background-color: #fafafa !important;
 }


### PR DESCRIPTION
## Summary

Enhance the web UI tool call card display with rich renderers for skill and team tools, fix terminal light-mode rendering, and improve overall chat prose styling.

## Related Issues / Tickets

-

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Performance improvement
- [ ] Test update

## Changes Made

1. **Backend — new tool display info** (`internal/handler/web.go`): Added `ToolDisplayInfo` entries for `load_skill`, `team_list`, `team_send_message`, `team_create`, `team_spawn`, and `team_delete` tools so the web handler produces proper title/icon/category metadata.

2. **Skill content enrichment** (`internal/skills/skills.go`): Include the skill `description` attribute in the `<skill>` tag output so the frontend can display it.

3. **Rich tool renderers** (`web/src/components/ToolCallCard.vue`): Added dedicated Vue renderers for:
   - **Skill Loader** — shows skill name and description with loading state
   - **Team List** — displays team name, member list with status indicators (● color-coded), and member count
   - **Team Create** — shows team name, description, lead agent, and creation status
   - **Team Spawn** — shows agent name, type badge, truncated prompt, and spawn ID
   - **Team Message** — shows recipient (with @ prefix or "all" for broadcast), summary, and truncated message body

4. **Terminal light-mode fix** (`web/src/components/TerminalInstance.vue`, `web/src/style.css`): Added reactive `termBg` binding and CSS overrides for `.xterm` / `.xterm-viewport` backgrounds in light mode so the terminal canvas no longer shows a dark background.

5. **Chat prose styling** (`web/src/style.css`): Tightened line-height (1.625), adjusted font-size (15px), reduced paragraph and list spacing, added code block padding, and added light-mode code block background (`#f6f8fa`).

6. **Tool card alignment** (`web/src/App.vue`, `web/src/components/ToolCallCard.vue`): Added `pl-9` indent on tool cards and adjusted internal padding (`pl-0`/`ml-0`) so expanded tool content aligns flush with the header icon.

7. **Terminal tab bar UX** (`web/src/components/TerminalPanel.vue`): Moved the "+" new terminal button inline after the last tab, swapped close-icon to appear left of the label, and changed hover/active visibility behavior for the × button.

## Testing

- Manual testing in the web UI: verified all new tool renderers display correctly in both light and dark modes
- Verified terminal background matches theme in both modes
- Verified chat prose spacing and code block styling
- Verified tool card alignment and tab bar interactions

## Screenshots / Recordings

<!-- Attach if available -->

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [ ] I have added/updated tests as needed.
- [ ] I have updated relevant documentation.
- [x] All new and existing tests pass.

## Additional Notes

- The team list renderer parses the output text of `team_list` to extract member info. If the output format changes, the regex matching in `teamListData` will need updating.
- Light-mode terminal fix uses `!important` on `.xterm-viewport` because xterm.js sets inline styles that must be overridden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for skill loading and team operations (list, create, spawn, delete, messaging) with dedicated tool card views
  * Terminal background now adapts to dark/light theme changes automatically

* **Bug Fixes**
  * Fixed light mode styling for terminal and chat content

* **UI/UX Improvements**
  * Terminal tab close button now always visible; "New terminal" button repositioned to tab bar
  * Enhanced chat content typography and spacing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cnjack/jcode/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->