### PR TITLE
feat: enhance terminal, ACP, and web UI with team tools, skill display, and session improvements

### DIFF
--- a/internal/handler/acp.go
+++ b/internal/handler/acp.go
@@ -74,11 +74,11 @@ func (h *ACPHandler) OnAgentText(text string) {
 // toolKindForName maps a jcode tool name to an ACP ToolKind.
 func toolKindForName(name string) acp.ToolKind {
 	switch name {
-	case "read", "glob", "grep", "todoread", "check_background":
+	case "read", "glob", "grep", "todoread", "check_background", "team_list":
 		return acp.ToolKindRead
 	case "edit", "multi_edit", "write", "todowrite":
 		return acp.ToolKindEdit
-	case "execute", "background":
+	case "execute", "background", "team_send_message", "team_create", "team_spawn", "team_delete":
 		return acp.ToolKindExecute
 	default:
 		return acp.ToolKindOther

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -126,6 +126,11 @@ type Recorder struct {
 	resuming bool
 	title    string
 	hasTitle bool // true after title has been generated or when resuming
+	// pendingSystemPrompt / pendingEnvInfo buffer the system prompt until the
+	// first real message is recorded so that opening and immediately closing
+	// jcode does not leave an empty session on disk.
+	pendingSystemPrompt string
+	pendingEnvInfo      string
 }
 
 // NewRecorder returns a Recorder that will create the session file only when
@@ -286,12 +291,14 @@ func (r *Recorder) RecordCompact(summary string, compactedN int) {
 	_ = r.writeEntry(Entry{Type: EntryCompact, Summary: summary, CompactedN: compactedN})
 }
 
-// RecordSystemPrompt records the system prompt and a snapshot of the
-// environment information used to generate it. This allows resume to reuse
-// the exact same system prompt (maximising KV-cache hit) and inject only
-// an environment diff as an appended system message.
+// RecordSystemPrompt buffers the system prompt so it can be written together
+// with the first real message. This avoids creating a session file when the
+// user opens and immediately closes jcode without any conversation.
 func (r *Recorder) RecordSystemPrompt(prompt, envInfo string) {
-	_ = r.writeEntry(Entry{Type: EntrySystemPrompt, Content: prompt, EnvInfo: envInfo})
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pendingSystemPrompt = prompt
+	r.pendingEnvInfo = envInfo
 }
 
 // TruncateAtUserMessage rewrites the session file keeping only entries that
@@ -500,6 +507,20 @@ func (r *Recorder) writeEntry(e Entry) error {
 	// Lazily initialise the file on the first real write.
 	if err := r.ensureFile(); err != nil {
 		return err
+	}
+	// Flush buffered system prompt before the first real entry.
+	if r.pendingSystemPrompt != "" {
+		sp := Entry{
+			Type:      EntrySystemPrompt,
+			Content:   r.pendingSystemPrompt,
+			EnvInfo:   r.pendingEnvInfo,
+			Timestamp: e.Timestamp,
+		}
+		r.pendingSystemPrompt = ""
+		r.pendingEnvInfo = ""
+		if spData, spErr := json.Marshal(sp); spErr == nil {
+			_, _ = r.file.WriteString(string(spData) + "\n")
+		}
 	}
 	if _, err = r.file.WriteString(string(data) + "\n"); err != nil {
 		return err

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -91,6 +91,12 @@ func formatToolResultBody(toolName, output string, err error, termWidth int, exp
 		return formatSubagentOutput(output, termWidth, expanded, mdRenderer)
 	case "todowrite":
 		return formatTodoWriteOutput(output)
+	case "load_skill":
+		return formatLoadSkillOutput(output)
+	case "team_list":
+		return formatTeamListOutput(output)
+	case "team_send_message", "team_create", "team_spawn", "team_delete":
+		return formatTeamShortOutput(output)
 	default:
 		return formatDefaultOutput(output, termWidth)
 	}
@@ -287,5 +293,74 @@ func formatTodoWriteOutput(output string) []string {
 	}
 	return []string{
 		fmt.Sprintf("   %s %s", toolSuccessStyle.Render("✓"), toolArgsStyle.Render(summary)),
+	}
+}
+
+// formatLoadSkillOutput shows skill name + description, skipping the full markdown body.
+func formatLoadSkillOutput(output string) []string {
+	nameMatch := regexp.MustCompile(`name="([^"]+)"`).FindStringSubmatch(output)
+	descMatch := regexp.MustCompile(`description="([^"]*)"`).FindStringSubmatch(output)
+	name := ""
+	desc := ""
+	if len(nameMatch) > 1 {
+		name = nameMatch[1]
+	}
+	if len(descMatch) > 1 {
+		desc = descMatch[1]
+	}
+	if name == "" {
+		return formatDefaultOutput(output, 80)
+	}
+	line := fmt.Sprintf("   %s %s",
+		toolSuccessStyle.Render("✓"),
+		lipgloss.NewStyle().Foreground(colorText).Bold(true).Render(name))
+	if desc != "" {
+		line += "  " + lipgloss.NewStyle().Foreground(colorMuted).Italic(true).Render(desc)
+	}
+	return []string{line}
+}
+
+// formatTeamListOutput renders team_list output as a structured member list.
+func formatTeamListOutput(output string) []string {
+	memberRe := regexp.MustCompile(`@(\S+)\s+status=(\S+)\s+type=(\S*)`)
+	teamRe := regexp.MustCompile(`^Team: (.+?) \(`)
+	var result []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if m := teamRe.FindStringSubmatch(line); len(m) > 1 {
+			result = append(result, fmt.Sprintf("   %s  %s",
+				lipgloss.NewStyle().Foreground(colorDimText).Render("team"),
+				lipgloss.NewStyle().Foreground(colorText).Bold(true).Render(m[1])))
+		} else if m := memberRe.FindStringSubmatch(line); len(m) > 2 {
+			statusColor := colorMuted
+			if m[2] == "running" || m[2] == "busy" {
+				statusColor = colorPrimary
+			}
+			memberLine := fmt.Sprintf("   %s  %-16s  %s",
+				lipgloss.NewStyle().Foreground(statusColor).Render("●"),
+				lipgloss.NewStyle().Foreground(colorText).Render("@"+m[1]),
+				lipgloss.NewStyle().Foreground(colorMuted).Render(m[2]))
+			if len(m) > 3 && m[3] != "" {
+				memberLine += "  " + lipgloss.NewStyle().Foreground(colorDimText).Render(m[3])
+			}
+			result = append(result, memberLine)
+		}
+	}
+	if len(result) == 0 {
+		return formatDefaultOutput(output, 80)
+	}
+	return result
+}
+
+// formatTeamShortOutput shows the first line of a team operation result as a compact status.
+func formatTeamShortOutput(output string) []string {
+	summary := strings.SplitN(strings.TrimRight(output, "\n"), "\n", 2)[0]
+	if summary == "" {
+		summary = "done"
+	}
+	return []string{
+		fmt.Sprintf("   %s %s",
+			toolSuccessStyle.Render("✓"),
+			lipgloss.NewStyle().Foreground(colorDimText).Render(truncate(summary, 80))),
 	}
 }


### PR DESCRIPTION
## Summary

Enhance the terminal/ACP handler, TUI formatting, web UI tool cards, and session recording across the stack — adding rich display for team and skill tools, fixing light-mode terminal rendering, and preventing empty session files.

## Related Issues / Tickets

-

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Performance improvement
- [ ] Test update

## Changes Made

1. **ACP handler — team tool kind mapping** (`internal/handler/acp.go`): Added `team_list` as `ToolKindRead`; `team_send_message`, `team_create`, `team_spawn`, `team_delete` as `ToolKindExecute`.

2. **Web handler — tool display info** (`internal/handler/web.go`): Added display metadata (title, icon, category, subtitle) for `load_skill`, `team_list`, `team_send_message`, `team_create`, `team_spawn`, `team_delete`.

3. **Session recorder — lazy system prompt flush** (`internal/session/session.go`): Buffer system prompt + env info until the first real message is recorded, preventing empty session files when jcode is opened and immediately closed.

4. **Skills loader — description in output** (`internal/skills/skills.go`): Include `description` attribute in the `<skill>` tag so consumers (TUI, web) can show a short summary instead of the full body.

5. **TUI formatting — new tool renderers** (`internal/tui/format.go`): Added compact formatters for `load_skill` (name + description), `team_list` (structured member list with status dots), and team operations (`team_send_message`, `team_create`, `team_spawn`, `team_delete`).

6. **Web UI — ToolCallCard rich renderers** (`web/src/components/ToolCallCard.vue`): Added dedicated card renderers for skill loader, team list (member table with status badges), team create (name + lead), team spawn (name + prompt preview + ID), and team message (recipient + summary + body preview).

7. **Web UI — terminal panel UX** (`web/src/components/TerminalPanel.vue`): Moved `+` button inline after last tab; close (×) icon appears on hover instead of always-visible; active tab shows × at reduced opacity.

8. **Web UI — light mode fixes** (`web/src/style.css`, `TerminalInstance.vue`): Added light-mode terminal background color; xterm viewport background override; light-mode code block styling (GitHub-style `#f6f8fa`).

9. **Web UI — chat prose tightening** (`web/src/style.css`): Reduced line-height to 1.625, tighter paragraph/list spacing, adjusted font-size to 15px for a more compact chat feel.

10. **Web UI — alignment tweaks** (`App.vue`, `ToolCallCard.vue`): Added `pl-9` indent on tool cards; removed left padding on tool card headers for visual alignment with the gutter.

## Testing

- Manual verification of TUI tool output formatting for `load_skill`, `team_list`, and team operation tools
- Web UI inspected for all new tool card renderers (skill, team-list, team-create, team-spawn, team-message)
- Light/dark mode terminal background verified
- Session recorder tested: opening and immediately closing jcode no longer creates an empty `.jsonl` file

## Screenshots / Recordings

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code follows the project style guidelines.
- [x] I have performed a self-review of my code.
- [ ] I have added/updated tests as needed.
- [ ] I have updated relevant documentation.
- [x] All new and existing tests pass.

## Additional Notes

- The session recorder change is backward-compatible — existing session files are unaffected, and resume logic reads the same `EntrySystemPrompt` entry format.
- The skill loader output change (`description` attribute) is additive — existing consumers that only parsed `name` will continue to work.