### PR TITLE
fix: remove unused variables and simplify function signatures to pass lint

### DIFF
--- a/internal/telemetry/langfuse.go
+++ b/internal/telemetry/langfuse.go
@@ -20,7 +20,6 @@ type contextKey string
 
 const traceIDKey contextKey = "langfuse_trace_id"
 const parentSpanIDKey contextKey = "langfuse_parent_span_id"
-const toolSpanIDKey contextKey = "langfuse_tool_span_id"
 const toolSpanTracerKey contextKey = "langfuse_tool_span_tracer"
 
 // SubSpanFunc creates a child span under the current tool span.

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -159,7 +159,7 @@ onUnmounted(() => {
   document.removeEventListener('keydown', handleGlobalKeydown)
 })
 
-function openFile(path: string, content: string) {
+function openFile() {
   // Open file in right panel files tab
   rightPanelOpen.value = true
   rightPanelTab.value = 'files'

--- a/web/src/components/TerminalPanel.vue
+++ b/web/src/components/TerminalPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import TerminalInstance from './TerminalInstance.vue'
 
 const emit = defineEmits<{
@@ -18,8 +18,6 @@ function makeTab(): Tab {
 
 const tabs = ref<Tab[]>([makeTab()])
 const activeId = ref(tabs.value[0].id)
-
-const activeIndex = computed(() => tabs.value.findIndex(t => t.id === activeId.value))
 
 function addTab() {
   const tab = makeTab()

--- a/web/src/components/ToolCallCard.vue
+++ b/web/src/components/ToolCallCard.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import type { ToolCall } from '@/types/api'
-import { TOOL_ICONS } from '@/composables/toolInfo'
 
 defineOptions({ name: 'ToolCallCard' })
 
@@ -17,10 +16,6 @@ const subagentExpanded = ref(true)
 // Display info: use backend-provided or fall back to name
 const displayTitle = computed(() => props.tool.displayInfo?.title || props.tool.name)
 const displaySubtitle = computed(() => props.tool.displayInfo?.subtitle || '')
-const displayIcon = computed(() => {
-  const iconKey = props.tool.displayInfo?.icon || 'tool'
-  return TOOL_ICONS[iconKey] || '🔧'
-})
 const isContextTool = computed(() => props.tool.displayInfo?.category === 'context')
 
 // Determine render type for expanded content
@@ -184,34 +179,6 @@ const searchResults = computed(() => {
 })
 
 // ─── File viewer helpers ───
-const filePath = computed(() => {
-  try {
-    const parsed = JSON.parse(props.tool.args)
-    return parsed.file_path || ''
-  } catch { return '' }
-})
-
-const fileName = computed(() => {
-  if (!filePath.value) return ''
-  const parts = filePath.value.replace(/\\/g, '/').split('/')
-  return parts[parts.length - 1] || ''
-})
-
-const fileDir = computed(() => {
-  if (!filePath.value) return ''
-  const parts = filePath.value.replace(/\\/g, '/').split('/')
-  parts.pop()
-  const dir = parts.join('/')
-  return dir || '/'
-})
-
-const shortFileDir = computed(() => {
-  if (!fileDir.value) return ''
-  const parts = fileDir.value.split('/').filter((p: string) => p)
-  const lastTwo = parts.slice(-2)
-  return lastTwo.length ? '…/' + lastTwo.join('/') : fileDir.value
-})
-
 const fileContent = computed(() => {
   const name = props.tool.name
   if (name === 'write') {


### PR DESCRIPTION
## Summary

Fixes lint errors caused by unused variables and unnecessary function parameters across Go and Vue components.

### Changes

- **`internal/telemetry/langfuse.go`**: Remove unused `toolSpanIDKey` constant
- **`web/src/App.vue`**: Remove unused `path` and `content` parameters from `openFile()` function signature
- **`web/src/components/TerminalPanel.vue`**: Remove unused `computed` import and unused `activeIndex` computed property
- **`web/src/components/ToolCallCard.vue`**: Remove unused `TOOL_ICONS` import, unused `displayIcon` computed, and unused file path helper computeds (`filePath`, `fileName`, `fileDir`, `shortFileDir`)

### Test plan

- [x] `make lint` passes
- [x] `go test ./...` passes
- [x] Frontend builds successfully (`make build-web`)