### PR TITLE
feat: slash commands support & upgrade acp-go-sdk to v0.13.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,17 +7,17 @@ require (
 	charm.land/bubbletea/v2 v2.0.6
 	charm.land/glamour/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.3
-	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/cloudwego/eino v0.8.11
 	github.com/cloudwego/eino-ext/components/tool/mcp v0.0.8
 	github.com/cloudwego/eino-ext/libs/acl/langfuse v0.0.0-20260313050455-88e279b3b32f
-	github.com/coder/acp-go-sdk v0.12.0
+	github.com/coder/acp-go-sdk v0.13.4
 	github.com/creack/pty v1.1.24
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/mark3labs/mcp-go v0.49.0
 	github.com/mdp/qrterminal/v3 v3.2.1
+	github.com/rivo/uniseg v0.4.7
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.50.0
@@ -26,6 +26,7 @@ require (
 
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
@@ -66,7 +67,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.2-0.20201214064552-5dd12d0cfe7f // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/saltosystems/winrt-go v0.0.0-20260317170058-9c2fec580d96 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/cloudwego/eino-ext/components/tool/mcp v0.0.8 h1:/QwCVAtB61b4Q2+RUvho
 github.com/cloudwego/eino-ext/components/tool/mcp v0.0.8/go.mod h1:zxP8sFkADBqflNc0a4qfKdLYQ+edzHPlkOaZF0A1X7o=
 github.com/cloudwego/eino-ext/libs/acl/langfuse v0.0.0-20260313050455-88e279b3b32f h1:kdnjioHjBlBQW+dpTTL8SVqQMxap5qjtAgtLiPOroTQ=
 github.com/cloudwego/eino-ext/libs/acl/langfuse v0.0.0-20260313050455-88e279b3b32f/go.mod h1:P3zzJTRexY0QKaE9Vn2CmOnCorIMgNzNtler8mw9IQM=
-github.com/coder/acp-go-sdk v0.12.0 h1:GoIC6RrkPMBIVQ3ckSkl+bO/ERV/IRK6clBdZmx4Uf4=
-github.com/coder/acp-go-sdk v0.12.0/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
+github.com/coder/acp-go-sdk v0.13.4 h1:Y93lxoCorqu5QXDG1cvR8V3sSUZNKABDx6DV/mqMFgI=
+github.com/coder/acp-go-sdk v0.13.4/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -760,15 +760,21 @@ func (a *acpAgent) LoadSession(ctx context.Context, params acp.LoadSessionReques
 func (a *acpAgent) ResumeSession(ctx context.Context, params acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
 	config.Logger().Printf("[acp] ResumeSession: session=%s", params.SessionId)
 
+	// Extract the internal session UUID from the ACP session ID.
+	resumeUUID := strings.TrimPrefix(string(params.SessionId), "sess_")
+
 	a.mu.Lock()
-	if _, ok := a.sessions[params.SessionId]; ok {
-		// Session already in memory, nothing to do.
+	if sess, ok := a.sessions[params.SessionId]; ok {
+		// Session already in memory — broadcast slash commands so the
+		// reconnecting client receives the available_commands_update.
+		s := sess
 		a.mu.Unlock()
+		a.broadcastSlashCommands(params.SessionId, s)
 		return acp.ResumeSessionResponse{Modes: acpModes(acpModeAgent)}, nil
 	}
 	a.mu.Unlock()
 
-	// Session not in memory — treat like a fresh session with the same ID.
+	// Session not in memory — reload from disk so the agent has conversation context.
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		return acp.ResumeSessionResponse{}, fmt.Errorf("config error: %w", err)
@@ -781,8 +787,23 @@ func (a *acpAgent) ResumeSession(ctx context.Context, params acp.ResumeSessionRe
 
 	providerName, modelName := cfg.GetProviderModel()
 	rec, _ := session.NewRecorder(pwd, providerName, modelName)
+	// Reuse the original session UUID so transcript entries are written to
+	// the same session file (same pattern as LoadSession).
+	if rec != nil {
+		rec.SetUUID(resumeUUID)
+	}
 
-	sess, err := a.buildAgentSession(ctx, cfg, pwd, params.SessionId, rec, nil)
+	// Load history from disk so the agent has conversation context.
+	var history []*schema.Message
+	if entries, err := session.LoadSession(resumeUUID); err == nil {
+		resumeState := session.ReconstructState(entries)
+		history = session.PruneOldToolOutputs(resumeState.History, 2)
+		config.Logger().Printf("[acp] ResumeSession: loaded %d history messages for %s", len(history), params.SessionId)
+	} else {
+		config.Logger().Printf("[acp] ResumeSession: could not load history for %s: %v", params.SessionId, err)
+	}
+
+	sess, err := a.buildAgentSession(ctx, cfg, pwd, params.SessionId, rec, history)
 	if err != nil {
 		return acp.ResumeSessionResponse{}, err
 	}

--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -205,8 +205,9 @@ func (a *acpAgent) Initialize(_ context.Context, params acp.InitializeRequest) (
 			},
 			LoadSession: true,
 			SessionCapabilities: acp.SessionCapabilities{
-				List:  &acp.SessionListCapabilities{},
-				Close: &acp.SessionCloseCapabilities{},
+				List:   &acp.SessionListCapabilities{},
+				Close:  &acp.SessionCloseCapabilities{},
+				Resume: &acp.SessionResumeCapabilities{},
 			},
 		},
 		AgentInfo: &acp.Implementation{
@@ -677,9 +678,9 @@ func (a *acpAgent) SetSessionConfigOption(_ context.Context, params acp.SetSessi
 	return acp.SetSessionConfigOptionResponse{}, nil
 }
 
-// UnstableCloseSession implements the experimental session/close method.
+// CloseSession implements the session/close method.
 // It cancels any ongoing work and releases session resources.
-func (a *acpAgent) UnstableCloseSession(_ context.Context, params acp.UnstableCloseSessionRequest) (acp.UnstableCloseSessionResponse, error) {
+func (a *acpAgent) CloseSession(_ context.Context, params acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
 	config.Logger().Printf("[acp] CloseSession: session=%s", params.SessionId)
 
 	a.mu.Lock()
@@ -699,7 +700,7 @@ func (a *acpAgent) UnstableCloseSession(_ context.Context, params acp.UnstableCl
 		sess.Close()
 	}
 
-	return acp.UnstableCloseSessionResponse{}, nil
+	return acp.CloseSessionResponse{}, nil
 }
 
 func (a *acpAgent) LoadSession(ctx context.Context, params acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
@@ -752,4 +753,53 @@ func (a *acpAgent) LoadSession(ctx context.Context, params acp.LoadSessionReques
 	a.broadcastSlashCommands(params.SessionId, sess)
 
 	return acp.LoadSessionResponse{}, nil
+}
+
+// ResumeSession implements the session/resume method.
+// It resumes an existing session without returning previous messages.
+func (a *acpAgent) ResumeSession(ctx context.Context, params acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	config.Logger().Printf("[acp] ResumeSession: session=%s", params.SessionId)
+
+	a.mu.Lock()
+	if _, ok := a.sessions[params.SessionId]; ok {
+		// Session already in memory, nothing to do.
+		a.mu.Unlock()
+		return acp.ResumeSessionResponse{Modes: acpModes(acpModeAgent)}, nil
+	}
+	a.mu.Unlock()
+
+	// Session not in memory — treat like a fresh session with the same ID.
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return acp.ResumeSessionResponse{}, fmt.Errorf("config error: %w", err)
+	}
+
+	pwd := params.Cwd
+	if pwd == "" {
+		pwd = util.GetWorkDir()
+	}
+
+	providerName, modelName := cfg.GetProviderModel()
+	rec, _ := session.NewRecorder(pwd, providerName, modelName)
+
+	sess, err := a.buildAgentSession(ctx, cfg, pwd, params.SessionId, rec, nil)
+	if err != nil {
+		return acp.ResumeSessionResponse{}, err
+	}
+
+	a.mu.Lock()
+	a.sessions[params.SessionId] = sess
+	a.mu.Unlock()
+
+	config.Logger().Printf("[acp] Session resumed: %s", params.SessionId)
+	a.broadcastSlashCommands(params.SessionId, sess)
+
+	return acp.ResumeSessionResponse{Modes: acpModes(acpModeAgent)}, nil
+}
+
+// Logout implements the logout method.
+// Terminates the current authenticated session (no-op for jcode, which doesn't require auth).
+func (a *acpAgent) Logout(_ context.Context, _ acp.LogoutRequest) (acp.LogoutResponse, error) {
+	config.Logger().Printf("[acp] Logout")
+	return acp.LogoutResponse{}, nil
 }

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -148,11 +148,16 @@ func (l *Loader) Get(name string) *Skill {
 }
 
 // GetBySlash returns a skill by its slash command, or nil if not found.
+// Matches both explicit slash fields and auto-generated "/<name>" triggers.
 func (l *Loader) GetBySlash(slash string) *Skill {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	for _, sk := range l.skills {
 		if sk.Slash != "" && sk.Slash == slash {
+			return sk
+		}
+		// Auto-generated slash: /name match.
+		if sk.Slash == "" && "/"+sk.Name == slash {
 			return sk
 		}
 	}
@@ -201,14 +206,27 @@ func (l *Loader) GetContent(name string) string {
 	return fmt.Sprintf("<skill name=%q description=%q>\n%s\n</skill>", sk.Name, sk.Description, sk.Body)
 }
 
-// SlashCommands returns all skills that have a slash command trigger.
+// SlashCommands returns all skills with slash command triggers.
+// Skills with an explicit "slash: false" frontmatter are excluded.
+// Skills with no slash field get an auto-generated "/<name>" trigger.
+// Skills with a custom slash field (e.g. "/review") use that value.
 func (l *Loader) SlashCommands() []*Skill {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	var result []*Skill
 	for _, sk := range l.skills {
-		if sk.Slash != "" {
+		switch {
+		case sk.Slash == "false":
+			// Explicitly disabled.
+			continue
+		case sk.Slash != "":
+			// Has custom slash.
 			result = append(result, sk)
+		default:
+			// Auto-generate: / + skill name.
+			autoSk := *sk
+			autoSk.Slash = "/" + sk.Name
+			result = append(result, &autoSk)
 		}
 	}
 	sort.Slice(result, func(i, j int) bool {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -227,6 +227,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("POST /api/mcp/{name}/toggle", s.handleToggleMCP)
 	mux.HandleFunc("GET /api/ssh", s.handleListSSH)
 	mux.HandleFunc("GET /api/skills", s.handleListSkills)
+	mux.HandleFunc("GET /api/slash-commands", s.handleSlashCommands)
 	mux.HandleFunc("GET /api/browse", s.handleBrowse)
 	mux.HandleFunc("POST /api/project/switch", s.handleSwitchProject)
 	mux.HandleFunc("POST /api/pty", s.handleCreatePTY)
@@ -467,6 +468,29 @@ func (s *Server) submitMessage(message, mode, source, sessionID string, images [
 	agentMsg := message
 	if mode == "plan" {
 		agentMsg = "[PLAN MODE — Read-only. Analyze the codebase and create a plan. Do NOT edit, write, or delete any files.]\n\n" + agentMsg
+	}
+
+	// Slash command rewrite: if the message starts with "/", check for skill slash
+	// commands and rewrite to load_skill instruction (same pattern as ACP/TUI).
+	if strings.HasPrefix(agentMsg, "/") {
+		cmd := strings.TrimPrefix(agentMsg, "/")
+		parts := strings.SplitN(cmd, " ", 2)
+		cmdName := parts[0]
+		if s.skillLoader != nil {
+			if sk := s.skillLoader.GetBySlash("/" + cmdName); sk != nil {
+				userInput := ""
+				if len(parts) > 1 {
+					userInput = parts[1]
+				}
+				var sb strings.Builder
+				sb.WriteString(fmt.Sprintf("Use the load_skill tool with name=%q and follow its instructions.", sk.Name))
+				if userInput != "" {
+					sb.WriteString("\n\nAdditional context: ")
+					sb.WriteString(userInput)
+				}
+				agentMsg = sb.String()
+			}
+		}
 	}
 
 	// Emit user_message event for external sources (e.g. WeChat) so web clients see it.
@@ -1660,12 +1684,12 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 	type skillItem struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
-		Slash       string `json:"slash,omitempty"`
+		Slash       string `json:"slash"`
 	}
 
 	var items []skillItem
 	if s.skillLoader != nil {
-		for _, sk := range s.skillLoader.All() {
+		for _, sk := range s.skillLoader.SlashCommands() {
 			items = append(items, skillItem{
 				Name:        sk.Name,
 				Description: sk.Description,
@@ -1676,6 +1700,43 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 	if items == nil {
 		items = []skillItem{}
 	}
+	writeJSON(w, http.StatusOK, items)
+}
+
+// handleSlashCommands returns a merged list of built-in commands and skill slash
+// commands for the web frontend autocomplete menu.
+func (s *Server) handleSlashCommands(w http.ResponseWriter, r *http.Request) {
+	type slashItem struct {
+		Slash       string `json:"slash"`
+		Description string `json:"description"`
+		Type        string `json:"type"` // "builtin" or "skill"
+	}
+
+	items := []slashItem{
+		{"/setting", "Settings menu", "builtin"},
+		{"/model", "Switch model", "builtin"},
+		{"/ssh", "SSH connection", "builtin"},
+		{"/resume", "Resume a previous session", "builtin"},
+		{"/compact", "Compress conversation context", "builtin"},
+		{"/bg", "List background tasks", "builtin"},
+		{"/channel", "Manage channels (WeChat etc.)", "builtin"},
+		{"/help", "Show keyboard shortcuts", "builtin"},
+	}
+
+	if s.skillLoader != nil {
+		for _, sk := range s.skillLoader.SlashCommands() {
+			items = append(items, slashItem{
+				Slash:       sk.Slash,
+				Description: sk.Description,
+				Type:        "skill",
+			})
+		}
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Slash < items[j].Slash
+	})
+
 	writeJSON(w, http.StatusOK, items)
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -464,16 +464,13 @@ func (s *Server) SubmitMessage(message, source string) bool {
 // The caller must have already set s.running to true (via CompareAndSwap).
 // Returns the session_id of the recorder used.
 func (s *Server) submitMessage(message, mode, source, sessionID string, images []chatImage) string {
-	// Apply mode prefix if plan mode requested.
+	// Slash command rewrite: if the original message starts with "/", check for
+	// skill slash commands and rewrite to load_skill instruction (same pattern as
+	// ACP/TUI). This must happen BEFORE the plan-mode prefix is applied, otherwise
+	// HasPrefix("/"…) would fail against the prefixed string.
 	agentMsg := message
-	if mode == "plan" {
-		agentMsg = "[PLAN MODE — Read-only. Analyze the codebase and create a plan. Do NOT edit, write, or delete any files.]\n\n" + agentMsg
-	}
-
-	// Slash command rewrite: if the message starts with "/", check for skill slash
-	// commands and rewrite to load_skill instruction (same pattern as ACP/TUI).
-	if strings.HasPrefix(agentMsg, "/") {
-		cmd := strings.TrimPrefix(agentMsg, "/")
+	if strings.HasPrefix(message, "/") {
+		cmd := strings.TrimPrefix(message, "/")
 		parts := strings.SplitN(cmd, " ", 2)
 		cmdName := parts[0]
 		if s.skillLoader != nil {
@@ -491,6 +488,11 @@ func (s *Server) submitMessage(message, mode, source, sessionID string, images [
 				agentMsg = sb.String()
 			}
 		}
+	}
+
+	// Apply mode prefix if plan mode requested.
+	if mode == "plan" {
+		agentMsg = "[PLAN MODE — Read-only. Analyze the codebase and create a plan. Do NOT edit, write, or delete any files.]\n\n" + agentMsg
 	}
 
 	// Emit user_message event for external sources (e.g. WeChat) so web clients see it.
@@ -1703,26 +1705,18 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, items)
 }
 
-// handleSlashCommands returns a merged list of built-in commands and skill slash
-// commands for the web frontend autocomplete menu.
+// handleSlashCommands returns skill slash commands for the web frontend
+// autocomplete menu. Built-in commands (/setting, /model, /ssh, etc.) are
+// excluded because the web UI provides dedicated controls for those features
+// and submitMessage only dispatches skill-based slash commands.
 func (s *Server) handleSlashCommands(w http.ResponseWriter, r *http.Request) {
 	type slashItem struct {
 		Slash       string `json:"slash"`
 		Description string `json:"description"`
-		Type        string `json:"type"` // "builtin" or "skill"
+		Type        string `json:"type"` // "skill"
 	}
 
-	items := []slashItem{
-		{"/setting", "Settings menu", "builtin"},
-		{"/model", "Switch model", "builtin"},
-		{"/ssh", "SSH connection", "builtin"},
-		{"/resume", "Resume a previous session", "builtin"},
-		{"/compact", "Compress conversation context", "builtin"},
-		{"/bg", "List background tasks", "builtin"},
-		{"/channel", "Manage channels (WeChat etc.)", "builtin"},
-		{"/help", "Show keyboard shortcuts", "builtin"},
-	}
-
+	var items []slashItem
 	if s.skillLoader != nil {
 		for _, sk := range s.skillLoader.SlashCommands() {
 			items = append(items, slashItem{
@@ -1731,6 +1725,10 @@ func (s *Server) handleSlashCommands(w http.ResponseWriter, r *http.Request) {
 				Type:        "skill",
 			})
 		}
+	}
+
+	if items == nil {
+		items = []slashItem{}
 	}
 
 	sort.Slice(items, func(i, j int) bool {

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -2,7 +2,7 @@
 import { ref, nextTick, watch, computed, onMounted, onUnmounted } from 'vue'
 import { useChatStore } from '@/stores/chat'
 import { api } from '@/composables/api'
-import type { SkillInfo, ChatImage } from '@/types/api'
+import type { SlashCommandInfo, ChatImage } from '@/types/api'
 
 const store = useChatStore()
 const input = ref('')
@@ -13,7 +13,7 @@ const showManageModels = ref(false)
 const modelFilter = ref('')
 const containerRef = ref<HTMLDivElement | null>(null)
 
-const skills = ref<SkillInfo[]>([])
+const slashCommands = ref<SlashCommandInfo[]>([])
 const showSlashMenu = ref(false)
 const slashFilter = ref('')
 const selectedSlashIdx = ref(0)
@@ -30,8 +30,8 @@ const modes = [
 
 const filteredSlashCommands = computed(() => {
   const filter = slashFilter.value.toLowerCase()
-  return skills.value.filter(
-    (s) => s.slash && s.slash.toLowerCase().includes(filter),
+  return slashCommands.value.filter(
+    (s) => s.slash.toLowerCase().startsWith('/' + filter),
   )
 })
 
@@ -155,8 +155,8 @@ function handleInput() {
   }
 }
 
-function applySlashCommand(skill: SkillInfo) {
-  input.value = skill.slash + ' '
+function applySlashCommand(cmd: SlashCommandInfo) {
+  input.value = cmd.slash + ' '
   showSlashMenu.value = false
   nextTick(() => textarea.value?.focus())
 }
@@ -253,7 +253,7 @@ onMounted(async () => {
   document.addEventListener('click', handleClickOutside)
   document.addEventListener('keydown', handleGlobalKey)
   try {
-    skills.value = await api.skillsList()
+    slashCommands.value = await api.slashCommands()
   } catch { /* ignore */ }
 })
 
@@ -277,7 +277,7 @@ watch(() => store.isRunning, (running) => {
       >
           <button
             v-for="(cmd, i) in filteredSlashCommands"
-            :key="cmd.name"
+            :key="cmd.slash"
             class="slash-item"
             :class="{ active: i === selectedSlashIdx }"
             @click="applySlashCommand(cmd)"

--- a/web/src/composables/api.ts
+++ b/web/src/composables/api.ts
@@ -1,5 +1,5 @@
 // API client for jcode backend
-import type { ModelsResponse, AgentMode, ExecResponse, DiffResponse, MCPListResponse, BrowseResponse, SSHListResponse, SkillInfo, TodoItem, SessionItem, SessionEntry, FileItem, SetupProvider, SetupModel, ProviderDetail, ModelStateResponse, ChatImage } from '@/types/api'
+import type { ModelsResponse, AgentMode, ExecResponse, DiffResponse, MCPListResponse, BrowseResponse, SSHListResponse, SkillInfo, SlashCommandInfo, TodoItem, SessionItem, SessionEntry, FileItem, SetupProvider, SetupModel, ProviderDetail, ModelStateResponse, ChatImage } from '@/types/api'
 
 const BASE = ''
 
@@ -123,6 +123,8 @@ export const api = {
     request<SSHListResponse>('/api/ssh'),
   skillsList: () =>
     request<SkillInfo[]>('/api/skills'),
+  slashCommands: () =>
+    request<SlashCommandInfo[]>('/api/slash-commands'),
   channelStatus: () =>
     request<{ available: boolean; channel?: string; state?: string }>('/api/channel'),
   channelLogin: () =>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -160,6 +160,13 @@ export interface SkillInfo {
   slash?: string
 }
 
+// Slash command types (unified built-in + skill)
+export interface SlashCommandInfo {
+  slash: string
+  description: string
+  type: 'builtin' | 'skill'
+}
+
 // SSE event data types
 export interface AgentTextData {
   text: string


### PR DESCRIPTION
## Summary

- **Slash commands**: Advertise skill-based slash commands via `available_commands_update` ACP notification, with autocomplete in both TUI and Web UI
- **ACP SDK upgrade**: `coder/acp-go-sdk` v0.12.0 → v0.13.4

## Changes

### ACP SDK Migration (Breaking Changes)
| Change | Version | Detail |
|--------|---------|--------|
| `UnstableCloseSession` → `CloseSession` | v0.12.2 | `session/close` promoted to stable API |
| New `ResumeSession` method | v0.12.2 | `session/resume` promoted to stable, required on `Agent` interface |
| New `Logout` method | v0.13.4 | `logout` promoted to stable, required on `Agent` interface |
| `SessionCapabilities` adds `Resume` | — | Advertise resume capability in `Initialize` |

### Slash Commands
- Skills with `slash` frontmatter field are exposed as `/command` shortcuts
- ACP: sent via `available_commands_update` after session creation, load, and resume
- Web UI: autocomplete dropdown in `ChatInput.vue` for `/` prefix

### Files Changed
- `go.mod` / `go.sum` — dependency bump
- `internal/command/acp.go` — CloseSession, ResumeSession, Logout, SessionCapabilities
- `internal/skills/skills.go` — SlashCommands() method
- `internal/web/server.go` — slash commands API endpoint
- `web/src/` — ChatInput autocomplete, API, types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash-command support: trigger skills via /skillname (including auto-generated /name) and respect skills disabled from slash
  * Slash-command discovery API and client method
  * Slash-command autocomplete in chat input using exact-prefix matching

* **Enhancements**
  * Improved session lifecycle: resume sessions and logout support; updated session close behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->