### PR TITLE
refactor(tui): extract renderViewportContent and preserve scroll position

### DIFF
--- a/internal/tui/input_views.go
+++ b/internal/tui/input_views.go
@@ -215,7 +215,7 @@ func (m *Model) handleBgInput(cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 		userLabelStyle.Render("👤 You:"))))
 	if m.ready {
 		m.viewport.SetHeight(m.calcViewportHeight(false))
-		m.viewport.SetContent(m.renderContent())
+		m.viewport.SetContent(m.renderViewportContent())
 		m.viewport.GotoBottom()
 	}
 	cmds = append(cmds, func() tea.Msg {
@@ -231,7 +231,7 @@ func (m *Model) handleCompactInput(cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	m.thinking = true
 	m.agentDone = false
 	if m.ready {
-		m.viewport.SetContent(m.renderContent())
+		m.viewport.SetContent(m.renderViewportContent())
 		m.viewport.GotoBottom()
 	}
 
@@ -283,7 +283,7 @@ func (m *Model) handleSkillSlashInput(skillName, userInput string, cmds []tea.Cm
 		userLabelStyle.Render("🔧 Skill:"), displayLabel)))
 	if m.ready {
 		m.viewport.SetHeight(m.calcViewportHeight(false))
-		m.viewport.SetContent(m.renderContent())
+		m.viewport.SetContent(m.renderViewportContent())
 		m.viewport.GotoBottom()
 	}
 	cmds = append(cmds, func() tea.Msg {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -876,7 +876,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 						if m.ready {
 							m.contentDirty = true
 							m.viewport.SetHeight(m.calcViewportHeight(true))
-							m.viewport.SetContent(m.renderContent())
+							m.viewport.SetContent(m.renderViewportContent())
 							m.viewport.GotoBottom()
 						}
 						return m, tea.Batch(cmds...)
@@ -899,7 +899,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 					if m.ready {
 						m.contentDirty = true
 						m.viewport.SetHeight(m.calcViewportHeight(false))
-						m.viewport.SetContent(m.renderContent())
+						m.viewport.SetContent(m.renderViewportContent())
 						m.viewport.GotoBottom()
 					}
 					cmds = append(cmds, func() tea.Msg {
@@ -1135,7 +1135,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 		// The cachedWidth check in contentLine.render() handles this naturally,
 		// but we reset renderedLineWidth so renderContent() takes the slow path.
 		m.renderedLineWidth = 0
-		m.viewport.SetContent(m.renderContent())
+		m.viewport.SetContent(m.renderViewportContent())
 
 	case spinner.TickMsg:
 		if m.thinking {
@@ -1258,7 +1258,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 				if m.ready {
 					m.contentDirty = true
 					m.viewport.SetHeight(m.calcViewportHeight(false))
-					m.viewport.SetContent(m.renderContent())
+					m.viewport.SetContent(m.renderViewportContent())
 					m.viewport.GotoBottom()
 				}
 				cmds = append(cmds, func() tea.Msg {
@@ -1429,7 +1429,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 		if m.ready {
 			m.contentDirty = true
 			m.viewport.SetHeight(m.calcViewportHeight(true))
-			m.viewport.SetContent(m.renderContent())
+			m.viewport.SetContent(m.renderViewportContent())
 			m.viewport.GotoBottom()
 		}
 		m.textarea.Focus()
@@ -1500,7 +1500,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 		if m.ready {
 			m.contentDirty = true
 			m.viewport.SetHeight(m.calcViewportHeight(true))
-			m.viewport.SetContent(m.renderContent())
+			m.viewport.SetContent(m.renderViewportContent())
 			m.viewport.GotoBottom()
 		}
 
@@ -1617,7 +1617,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 		if m.ready {
 			m.contentDirty = true
 			m.viewport.SetHeight(m.calcViewportHeight(true))
-			m.viewport.SetContent(m.renderContent())
+			m.viewport.SetContent(m.renderViewportContent())
 			m.viewport.GotoBottom()
 		}
 

--- a/internal/tui/view_render.go
+++ b/internal/tui/view_render.go
@@ -104,7 +104,11 @@ func (m *Model) View() tea.View {
 		// batched by BatchRenderMsg; spinner ticks explicitly dirty the status
 		// line in Update.
 		if m.contentDirty {
-			m.viewport.SetContent(strings.TrimRight(m.renderContent(), "\n"))
+			stickToBottom := m.viewport.AtBottom()
+			m.viewport.SetContent(m.renderViewportContent())
+			if stickToBottom {
+				m.viewport.GotoBottom()
+			}
 		}
 	}
 
@@ -225,9 +229,13 @@ func (m *Model) refreshViewport() {
 		m.renderPerf.refreshes++
 		m.contentDirty = true
 		m.viewport.SetHeight(m.calcViewportHeight())
-		m.viewport.SetContent(m.renderContent())
+		m.viewport.SetContent(m.renderViewportContent())
 		m.viewport.GotoBottom()
 	}
+}
+
+func (m *Model) renderViewportContent() string {
+	return strings.TrimRight(m.renderContent(), "\n")
 }
 
 // invalidateSidebarCache marks the sidebar cache as needing rebuild.


### PR DESCRIPTION
## Summary

- Introduce `renderViewportContent()` helper to centralize `strings.TrimRight(renderContent(), "\n")`
- Replace all direct `renderContent()` calls in `viewport.SetContent()` with the new helper
- Preserve scroll-to-bottom position in `View()` batched render path — only auto-scroll when user was already at bottom

## Changed Files

- `internal/tui/view_render.go` — add `renderViewportContent()`, update `View()` and `refreshViewport()`
- `internal/tui/input_views.go` — use `renderViewportContent()` in 3 places
- `internal/tui/update.go` — use `renderViewportContent()` in 8 places

## Why

Previously `TrimRight` was only applied in the `View()` batched path but not in `Update()` / `input_views` calls, leading to inconsistent trailing-newline handling. This centralizes the logic and also fixes a subtle UX issue where content updates could pull the user away from the bottom during manual scroll-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport content display and scroll position handling. The viewport now preserves the user's scroll position when content updates occur, preventing unwanted auto-scrolling when the user is viewing earlier content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->