### PR TITLE
feat: persistent session goal with auto-continuation (TUI/Web/ACP)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -74,6 +74,7 @@ Type these in the TUI input area:
 | `/ssh` | Open SSH connection wizard |
 | `/resume` | Resume a previous session |
 | `/compact` | Compact conversation context |
+| `/goal` | Set a persistent objective the agent works toward ([Goals](goal.html)) |
 | `/bg` | Show background tasks |
 | `/review-pr` | Run PR review skill |
 | `/pr-comments` | Fetch PR comments |

--- a/docs/goal.md
+++ b/docs/goal.md
@@ -1,0 +1,126 @@
+---
+title: Goals
+nav_order: 8
+---
+
+# Goals
+
+A **goal** is a persistent objective for your session. Instead of answering one
+prompt and handing control back to you, jcode keeps working — turn after turn —
+until the objective is done. Set it once and let the agent drive itself to the
+finish line.
+
+{: .note }
+> Use a goal for substantial work with a verifiable end state — "make every test
+> in `test/auth` pass", "migrate this module to the new API", "split this file
+> until each piece is under 300 lines". For a quick question, just ask normally.
+
+## Set a goal
+
+In the TUI input area, type `/goal` followed by what you want done:
+
+```text
+/goal all tests in ./internal/auth pass and `go vet ./...` is clean
+```
+
+Setting a goal **immediately starts working** — you don't need to send a
+separate prompt. While a goal is active, a `🎯` indicator above the input shows
+its status, objective, and token usage.
+
+Setting a new goal replaces any existing one.
+
+## How it works
+
+After each turn, jcode checks whether the goal is done. If not, it injects a
+short reminder and starts another turn on its own, instead of returning control
+to you. The agent verifies completion against the real state of your project —
+files, command output, test results — and only then marks the goal complete and
+stops.
+
+A goal keeps running until one of these happens:
+
+- The agent **verifies it's complete** and stops.
+- The agent decides it is **genuinely blocked** and stops.
+- It hits the **safety cap** of 25 automatic turns.
+- You **cancel** it (press <kbd>Esc</kbd>) or run `/goal clear`.
+
+## Check status and clear
+
+Run `/goal` with no arguments to see the current objective, status, and how many
+tokens it has used:
+
+```text
+/goal
+```
+
+Remove an active goal before it finishes:
+
+```text
+/goal clear
+```
+
+## Writing a good objective
+
+The agent proves a goal is done by checking your project's real state, so phrase
+the objective around something it can verify:
+
+- **A measurable end state** — tests pass, a build exits 0, a file count, an
+  empty queue.
+- **How to check it** — e.g. "`go test ./...` exits 0" or "`git status` is
+  clean".
+- **Constraints that must hold** — e.g. "without changing any test files".
+
+The objective can be up to 4,000 characters.
+
+## Goals vs. todos
+
+They work together but mean different things:
+
+| | Purpose |
+|---|---|
+| **Goal** | The overall end state you want reached — the "where". Keeps the agent going. |
+| **Todos** | The step-by-step checklist *within* the work — the "how". |
+
+A single goal usually spawns several todos as the agent breaks the work down.
+
+## In the web UI
+
+Open the web interface (`jcode web`) and click the **🎯 Goal** toggle in the
+input toolbar. The prompt box is now armed: the next message you send becomes
+the session goal and work starts immediately. While a goal is active a banner
+shows its status and token usage, with a **Clear** button to remove it.
+Typing `/goal …` in the chat box works too.
+
+## In editors (ACP)
+
+When jcode runs as a headless agent (`jcode acp`), `goal` appears in the editor's
+slash-command list. Use it the same way: `/goal <objective>`, `/goal status`, or
+`/goal clear`.
+
+## Resuming a session
+
+A goal that is still active when you close a session is restored when you resume
+that session — with `--resume`, the in-TUI `/resume` command, the web session
+list, or an editor's session restore. The objective and recorded token usage are
+preserved.
+
+## When to use a goal
+
+**Good fits** — big jobs that need to be driven to completion:
+
+- Fix every lint error across the project
+- Add tests for a module until coverage hits a target
+- Migrate an old API to a new framework
+- Work through a backlog of flagged issues until the queue is empty
+
+**Skip it** for one-line questions, or for open-ended exploration with no clear
+"done" ("see what could be improved") — without a verifiable finish line the
+agent has no way to know when to stop.
+
+## Command summary
+
+| Command | Action |
+|---|---|
+| `/goal <objective>` | Set a goal and start working toward it |
+| `/goal` or `/goal status` | Show the current goal's status |
+| `/goal clear` | Remove the active goal |

--- a/internal/agent/reminder.go
+++ b/internal/agent/reminder.go
@@ -16,6 +16,7 @@ import (
 // ReminderConfig holds the static configuration for the reminder middleware.
 type ReminderConfig struct {
 	TodoStore    *tools.TodoStore
+	GoalStore    *tools.GoalStore
 	PlanStore    *tools.PlanStore
 	EnvLabel     string
 	IsRemote     bool
@@ -84,6 +85,14 @@ func (m *reminderMiddleware) BeforeModelRewriteState(
 	// Inject approved plan context for execution mode.
 	if m.cfg.PlanStore != nil && m.cfg.PlanStore.HasApprovedPlan() {
 		rc.PlanContent = m.cfg.PlanStore.Content()
+	}
+
+	// Inject active goal context so the agent never loses the objective.
+	if m.cfg.GoalStore != nil {
+		if g := m.cfg.GoalStore.Get(); g != nil && g.Status == tools.GoalActive {
+			rc.GoalActive = true
+			rc.GoalObjective = g.Objective
+		}
 	}
 
 	msgs := prompts.CollectReminders(rc)

--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -149,8 +149,14 @@ func availableCommandList(skillLoader *skills.Loader) []acp.AvailableCommand {
 	}
 	if skillLoader != nil {
 		for _, sk := range skillLoader.SlashCommands() {
+			name := strings.TrimPrefix(sk.Slash, "/")
+			// "/goal" is consumed by Prompt() before the skill lookup, so a
+			// skill with that name could never run — don't advertise it.
+			if name == "goal" {
+				continue
+			}
 			cmds = append(cmds, acp.AvailableCommand{
-				Name:        strings.TrimPrefix(sk.Slash, "/"),
+				Name:        name,
 				Description: sk.Description,
 				Input: &acp.AvailableCommandInput{
 					Unstructured: &acp.UnstructuredCommandInput{
@@ -349,12 +355,16 @@ func (a *acpAgent) buildAgentSession(
 	}
 	allTools = append(allTools, mcpTools...)
 
-	// Plan mode tools: read-only subset.
+	// Plan mode tools: read-only subset. Goal tools are included — like the
+	// todo tools they only mutate session metadata, and the continuation
+	// guard runs in every mode, so the agent must be able to inspect and
+	// complete/block an active goal here too.
 	planTools := []tool.BaseTool{
 		env.NewReadTool(),
 		env.NewExecuteTool(nil),
 		env.NewGrepTool(),
 		env.NewTodoWriteTool(), env.NewTodoReadTool(),
+		env.NewGoalSetTool(), env.NewGoalGetTool(), env.NewGoalUpdateTool(),
 	}
 
 	normalPrompt := prompts.GetSystemPrompt(platform, pwd, "local", envInfo, skillLoader.Descriptions())

--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -58,6 +58,7 @@ type acpSession struct {
 	rec           *session.Recorder
 	todoStore     *tools.TodoStore
 	tracer        *telemetry.LangfuseTracer
+	tokenUsage    *internalmodel.TokenUsage
 	cancel        context.CancelFunc
 	mu            sync.Mutex
 
@@ -132,28 +133,40 @@ func handleACPSubcommand() {
 	config.Logger().Printf("[acp] ACP connection closed")
 }
 
+// availableCommandList builds the slash commands advertised to ACP clients:
+// the built-in /goal command plus any skill-based commands.
+func availableCommandList(skillLoader *skills.Loader) []acp.AvailableCommand {
+	cmds := []acp.AvailableCommand{
+		{
+			Name:        "goal",
+			Description: "Set a persistent objective the agent pursues across turns (or 'clear' / status)",
+			Input: &acp.AvailableCommandInput{
+				Unstructured: &acp.UnstructuredCommandInput{
+					Hint: "<objective> | clear | status",
+				},
+			},
+		},
+	}
+	if skillLoader != nil {
+		for _, sk := range skillLoader.SlashCommands() {
+			cmds = append(cmds, acp.AvailableCommand{
+				Name:        strings.TrimPrefix(sk.Slash, "/"),
+				Description: sk.Description,
+				Input: &acp.AvailableCommandInput{
+					Unstructured: &acp.UnstructuredCommandInput{
+						Hint: "additional instructions",
+					},
+				},
+			})
+		}
+	}
+	return cmds
+}
+
 // broadcastSlashCommands sends the available slash commands to the client via
 // an available_commands_update session notification.
 func (a *acpAgent) broadcastSlashCommands(sessionID acp.SessionId, sess *acpSession) {
-	var cmds []acp.AvailableCommand
-
-	// Skill-based slash commands.
-	if sess.skillLoader != nil {
-		for _, sk := range sess.skillLoader.SlashCommands() {
-			name := strings.TrimPrefix(sk.Slash, "/")
-			cmd := acp.AvailableCommand{
-				Name:        name,
-				Description: sk.Description,
-			}
-			cmd.Input = &acp.AvailableCommandInput{
-				Unstructured: &acp.UnstructuredCommandInput{
-					Hint: "additional instructions",
-				},
-			}
-			cmds = append(cmds, cmd)
-		}
-	}
-
+	cmds := availableCommandList(sess.skillLoader)
 	if len(cmds) == 0 {
 		return
 	}
@@ -316,6 +329,10 @@ func (a *acpAgent) buildAgentSession(
 	config.Logger().Printf("[acp] using LocalExecutor for session %s", sessionID)
 	bgManager := tools.NewBackgroundManager(env)
 
+	// Per-session token tracker for usage display (goal status, reminders,
+	// token updates).
+	tokenUsage := &internalmodel.TokenUsage{}
+
 	// Load MCP tools from config.
 	var mcpTools []tool.BaseTool
 	if len(cfg.MCPServers) > 0 {
@@ -326,6 +343,7 @@ func (a *acpAgent) buildAgentSession(
 		env.NewReadTool(), env.NewEditTool(), env.NewWriteTool(),
 		env.NewExecuteTool(bgManager), env.NewGrepTool(),
 		env.NewTodoWriteTool(), env.NewTodoReadTool(),
+		env.NewGoalSetTool(), env.NewGoalGetTool(), env.NewGoalUpdateTool(),
 		env.NewSwitchEnvTool(),
 		env.NewCheckBackgroundTool(bgManager),
 	}
@@ -372,6 +390,7 @@ func (a *acpAgent) buildAgentSession(
 			}
 			rec.RecordTodoSnapshot(snapItems)
 		}
+		env.GoalStore.OnUpdate = tools.GoalRecorderHook(rec)
 	}
 
 	// Langfuse tracer
@@ -419,10 +438,11 @@ func (a *acpAgent) buildAgentSession(
 
 	reminderMw := agent.NewReminderMiddleware(agent.ReminderConfig{
 		TodoStore:    env.TodoStore,
+		GoalStore:    env.GoalStore,
 		EnvLabel:     "local",
 		IsRemote:     env.IsRemote(),
 		ContextLimit: contextLimit,
-	}, nil)
+	}, tokenUsage)
 	handlers = append(handlers, reminderMw)
 
 	ag, err := agent.NewAgent(ctx, chatModel, allTools, normalPrompt, approvalState.RequestApproval, nil, handlers)
@@ -444,6 +464,7 @@ func (a *acpAgent) buildAgentSession(
 		rec:           rec,
 		todoStore:     env.TodoStore,
 		tracer:        tracer,
+		tokenUsage:    tokenUsage,
 		history:       history,
 		mode:          acpModeAgent,
 		createAgent:   makeAgent,
@@ -502,6 +523,47 @@ func (a *acpAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Pr
 		parts := strings.SplitN(cmd, " ", 2)
 		cmdName := parts[0]
 
+		// Built-in /goal command. Status and clear are answered locally —
+		// the goal state lives in GoalStore, so no agent run is needed (and
+		// running one would let the continuation guard auto-continue an
+		// active goal from a mere status query).
+		if cmdName == "goal" {
+			rest := ""
+			if len(parts) > 1 {
+				rest = parts[1]
+			}
+			var goalStore *tools.GoalStore
+			if sess.env != nil {
+				goalStore = sess.env.GoalStore
+			}
+			action := tools.ParseGoalCommand(rest)
+			switch action.Kind {
+			case "status":
+				line := "🎯 No goal set. Use /goal <objective> to set one."
+				if goalStore != nil && goalStore.Has() {
+					line = goalStore.StatusLine()
+				}
+				sess.h.OnAgentText(line)
+				return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+			case "clear":
+				if goalStore != nil {
+					goalStore.Clear()
+				}
+				sess.h.OnAgentText("🎯 Goal cleared.")
+				return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+			default: // "set"
+				objective, err := tools.ValidateGoalObjective(action.Objective)
+				if err != nil {
+					sess.h.OnAgentText("🎯 " + err.Error())
+					return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+				}
+				if goalStore != nil {
+					goalStore.Set(objective)
+				}
+				prompt = tools.GoalKickoffPrompt(objective)
+			}
+		}
+
 		// Check if it's a skill slash command.
 		if sess.skillLoader != nil {
 			if sk := sess.skillLoader.GetBySlash("/" + cmdName); sk != nil {
@@ -556,7 +618,7 @@ func (a *acpAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Pr
 	copy(history, sess.history)
 	sess.mu.Unlock()
 
-	resp := runner.Run(promptCtx, sess.ag, history, sess.h, sess.rec, sess.todoStore, sess.tracer, nil)
+	resp := runner.Run(promptCtx, sess.ag, history, sess.h, sess.rec, sess.todoStore, sess.env.GoalStore, sess.tracer, sess.tokenUsage)
 
 	sess.mu.Lock()
 	if resp != "" {
@@ -749,6 +811,7 @@ func (a *acpAgent) LoadSession(ctx context.Context, params acp.LoadSessionReques
 	if err != nil {
 		return acp.LoadSessionResponse{}, err
 	}
+	sess.env.GoalStore.RestoreFromSnapshot(resumeState.Goal)
 
 	a.mu.Lock()
 	if old, ok := a.sessions[params.SessionId]; ok {
@@ -806,9 +869,11 @@ func (a *acpAgent) ResumeSession(ctx context.Context, params acp.ResumeSessionRe
 
 	// Load history from disk so the agent has conversation context.
 	var history []*schema.Message
+	var goalSnap *session.GoalSnapshot
 	if entries, err := session.LoadSession(resumeUUID); err == nil {
 		resumeState := session.ReconstructState(entries)
 		history = session.PruneOldToolOutputs(resumeState.History, 2)
+		goalSnap = resumeState.Goal
 		config.Logger().Printf("[acp] ResumeSession: loaded %d history messages for %s", len(history), params.SessionId)
 	} else {
 		config.Logger().Printf("[acp] ResumeSession: could not load history for %s: %v", params.SessionId, err)
@@ -818,6 +883,7 @@ func (a *acpAgent) ResumeSession(ctx context.Context, params acp.ResumeSessionRe
 	if err != nil {
 		return acp.ResumeSessionResponse{}, err
 	}
+	sess.env.GoalStore.RestoreFromSnapshot(goalSnap)
 
 	a.mu.Lock()
 	a.sessions[params.SessionId] = sess

--- a/internal/command/acp_goal_test.go
+++ b/internal/command/acp_goal_test.go
@@ -1,0 +1,22 @@
+package command
+
+import "testing"
+
+func TestAvailableCommandList_IncludesGoal(t *testing.T) {
+	cmds := availableCommandList(nil)
+	if len(cmds) == 0 {
+		t.Fatal("expected at least the goal command")
+	}
+	found := false
+	for _, c := range cmds {
+		if c.Name == "goal" {
+			found = true
+			if c.Input == nil || c.Input.Unstructured == nil {
+				t.Error("goal command should advertise unstructured input")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("goal command not advertised in availableCommandList")
+	}
+}

--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -83,6 +83,7 @@ func (s *interactiveState) buildAllTools() []tool.BaseTool {
 		s.env.NewReadTool(), s.env.NewEditTool(), s.env.NewWriteTool(),
 		s.env.NewExecuteTool(s.bgManager), s.env.NewGrepTool(),
 		s.env.NewTodoWriteTool(), s.env.NewTodoReadTool(),
+		s.env.NewGoalSetTool(), s.env.NewGoalGetTool(), s.env.NewGoalUpdateTool(),
 		s.env.NewCheckBackgroundTool(s.bgManager),
 		s.env.NewSubagentTool(&tools.SubagentDeps{
 			ChatModel:  s.chatModel,
@@ -213,6 +214,7 @@ func (s *interactiveState) createAgent() (*adk.ChatModelAgent, error) {
 
 	reminderMw := agent.NewReminderMiddleware(agent.ReminderConfig{
 		TodoStore:    s.env.TodoStore,
+		GoalStore:    s.env.GoalStore,
 		PlanStore:    s.planStore,
 		EnvLabel:     "local",
 		IsRemote:     s.env.IsRemote(),
@@ -312,7 +314,7 @@ func (s *interactiveState) handlePrompt(userPrompt string) {
 	}
 	s.history = append(s.history, schema.UserMessage(userPrompt))
 	s.history = agent.DrainBgNotifications(s.bgManager, s.history)
-	resp := runner.Run(runCtx, s.ag, s.history, s.h, s.rec, s.env.TodoStore, s.langfuseTracer, s.agentTokenUsage)
+	resp := runner.Run(runCtx, s.ag, s.history, s.h, s.rec, s.env.TodoStore, s.env.GoalStore, s.langfuseTracer, s.agentTokenUsage)
 	if resp != "" {
 		s.history = append(s.history, &schema.Message{Role: schema.Assistant, Content: resp})
 	}
@@ -354,7 +356,7 @@ func (s *interactiveState) handlePlanCompletion(resp string) {
 			s.rec.RecordUser(revisePrompt)
 		}
 		s.history = append(s.history, schema.UserMessage(revisePrompt))
-		newResp := runner.Run(s.runCtx, s.ag, s.history, s.h, s.rec, s.env.TodoStore, s.langfuseTracer, s.agentTokenUsage)
+		newResp := runner.Run(s.runCtx, s.ag, s.history, s.h, s.rec, s.env.TodoStore, s.env.GoalStore, s.langfuseTracer, s.agentTokenUsage)
 		if newResp != "" {
 			s.history = append(s.history, &schema.Message{Role: schema.Assistant, Content: newResp})
 		}
@@ -384,7 +386,7 @@ func (s *interactiveState) handlePlanCompletion(resp string) {
 		s.rec.RecordUser(execPrompt)
 	}
 	s.history = append(s.history, schema.UserMessage(execPrompt))
-	execResp := runner.Run(s.ctx, s.ag, s.history, s.h, s.rec, s.env.TodoStore, s.langfuseTracer, s.agentTokenUsage)
+	execResp := runner.Run(s.ctx, s.ag, s.history, s.h, s.rec, s.env.TodoStore, s.env.GoalStore, s.langfuseTracer, s.agentTokenUsage)
 	if execResp != "" {
 		s.history = append(s.history, &schema.Message{Role: schema.Assistant, Content: execResp})
 	}
@@ -479,6 +481,10 @@ func (s *interactiveState) handleResume(uuid string) {
 		s.env.TodoStore.Update(todoItems)
 		s.p.Send(tui.TodoUpdateMsg{})
 	}
+
+	// Restore the resumed session's goal — or reset the store when it has
+	// none, so a goal from the previously open session does not leak across.
+	s.env.GoalStore.RestoreFromSnapshot(st.Goal)
 
 	if targetEnv := st.EnvTarget; targetEnv != "local" {
 		s.sessionResumeWarning = s.attemptSSHResume(targetEnv)
@@ -661,7 +667,7 @@ func (s *interactiveState) runEventLoop(initialHistory []adk.Message, initialRes
 		s.runCtx = runCtx
 		s.agentRunning.Store(true)
 		s.history = append(s.history, schema.UserMessage(prompt))
-		resp := runner.Run(runCtx, s.ag, s.history, s.h, s.rec, s.env.TodoStore, s.langfuseTracer, s.agentTokenUsage)
+		resp := runner.Run(runCtx, s.ag, s.history, s.h, s.rec, s.env.TodoStore, s.env.GoalStore, s.langfuseTracer, s.agentTokenUsage)
 		runCancel()
 		s.runCtx = nil
 		s.agentRunning.Store(false)
@@ -828,6 +834,8 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 		}
 	}
 
+	env.GoalStore.OnUpdate = tools.GoalRecorderHook(rec)
+
 	askUserCh := make(chan tools.AskUserResponse, 1)
 	askUserDeps := &tools.AskUserDeps{
 		ResponseCh: askUserCh,
@@ -937,7 +945,7 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 	approvalState := runner.NewApprovalState(pwd, autoApprove)
 	st.approvalState = approvalState
 
-	p, _ := tui.RunTUI(hasPrompt, pwd, env.TodoStore, tui.WithVersion(Version), tui.WithApprovalModeChange(func(enabled bool) {
+	p, _ := tui.RunTUI(hasPrompt, pwd, env.TodoStore, tui.WithVersion(Version), tui.WithGoalStore(env.GoalStore), tui.WithApprovalModeChange(func(enabled bool) {
 		approvalState.SetSessionApproval(enabled)
 	}))
 	st.p = p
@@ -1095,6 +1103,8 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 			}
 			env.TodoStore.Update(todoItems)
 		}
+
+		env.GoalStore.RestoreFromSnapshot(resumeState.Goal)
 
 		if targetEnv := resumeState.EnvTarget; targetEnv != "local" {
 			st.sessionResumeWarning = st.attemptSSHResume(targetEnv)

--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -96,6 +96,10 @@ func runWebServer(port int, host string, openBrowser bool) error {
 	bgManager := tools.NewBackgroundManager(env)
 	rec, _ := session.NewRecorder(pwd, providerName, modelName)
 
+	// Shared token tracker for usage display (goal status, reminders, token
+	// updates).
+	agentTokenUsage := &internalmodel.TokenUsage{}
+
 	// Load MCP tools.
 	var mcpTools []tool.BaseTool
 	if len(cfg.MCPServers) > 0 {
@@ -163,6 +167,7 @@ func runWebServer(port int, host string, openBrowser bool) error {
 			env.NewReadTool(), env.NewEditTool(), env.NewWriteTool(),
 			env.NewExecuteTool(bgManager), env.NewGrepTool(),
 			env.NewTodoWriteTool(), env.NewTodoReadTool(),
+			env.NewGoalSetTool(), env.NewGoalGetTool(), env.NewGoalUpdateTool(),
 			env.NewSwitchEnvTool(),
 			env.NewCheckBackgroundTool(bgManager),
 			env.NewSubagentTool(&tools.SubagentDeps{
@@ -248,11 +253,12 @@ func runWebServer(port int, host string, openBrowser bool) error {
 
 		reminderMw := agent.NewReminderMiddleware(agent.ReminderConfig{
 			TodoStore:    env.TodoStore,
+			GoalStore:    env.GoalStore,
 			PlanStore:    planStore,
 			EnvLabel:     "local",
 			IsRemote:     env.IsRemote(),
 			ContextLimit: ctxLimit,
-		}, nil)
+		}, agentTokenUsage)
 		handlers = append(handlers, reminderMw)
 
 		tools := buildAllTools(cm)
@@ -326,6 +332,7 @@ func runWebServer(port int, host string, openBrowser bool) error {
 		WebHandler:    webHandler,
 		EventHandler:  finalHandler,
 		NeedsSetup:    needsSetup,
+		TokenUsage:    agentTokenUsage,
 	})
 
 	// Set handler for approval routing.

--- a/internal/prompts/reminders.go
+++ b/internal/prompts/reminders.go
@@ -16,6 +16,10 @@ type ReminderContext struct {
 	EnvLabel          string
 	IsRemote          bool
 	PlanContent       string // non-empty when executing an approved plan
+
+	// Goal context, set when an active session goal exists.
+	GoalActive    bool
+	GoalObjective string
 }
 
 // reminder is a single conditional reminder rule.
@@ -26,6 +30,19 @@ type reminder struct {
 }
 
 var builtinReminders = []reminder{
+	{
+		name: "goal_active",
+		condition: func(rc *ReminderContext) bool {
+			return rc.GoalActive && rc.GoalObjective != ""
+		},
+		message: func(rc *ReminderContext) string {
+			obj := rc.GoalObjective
+			if len(obj) > 2000 {
+				obj = obj[:2000] + "\n... (objective truncated)"
+			}
+			return fmt.Sprintf("[Active Goal]\nYou are pursuing a persistent session goal. Keep working toward it until it is verifiably complete, then call goal_update with status=\"complete\".\n\nObjective: %s", obj)
+		},
+	},
 	{
 		name: "plan_execution",
 		condition: func(rc *ReminderContext) bool {

--- a/internal/prompts/system.md
+++ b/internal/prompts/system.md
@@ -39,6 +39,9 @@ Note: The TUI displays your current environment to the user. Do not state "I wil
 - **grep**: Search for patterns across files with regex support and file-type filtering
 - **todowrite**: Manage a structured todo list to track multi-step tasks. Send the full list of items each time with id, title, and status (pending/in_progress/completed/cancelled). Use for complex tasks with 3+ steps.
 - **todoread**: Read the current todo list. Use frequently to stay on track.
+- **goal_set**: Set a persistent, cross-turn objective for the session. While a goal is active you are automatically reminded to keep working — even across turns — until it is verifiably complete. Use when the user hands you a substantial multi-step objective they want pursued to the finish. Provide a clear, self-contained objective. A goal differs from todos: todos track sub-steps *within* your work, while the goal is the overarching end state you must reach and prove.
+- **goal_get**: Read the current goal (objective, status, token usage). Takes no parameters.
+- **goal_update**: Mark the goal `complete` or `blocked`. Mark `complete` ONLY when the objective is verifiably done — checked against the real state of files, command output, or tests, not your intent. Mark `blocked` only when genuinely and repeatedly stuck on something you cannot clear. Marking either stops the automatic continuation. Do not mark complete just to stop.
 - **subagent**: Delegate a task to a subagent that runs in its own context. Types: 'explore' (read-only research) or 'general' (full tools). Use for:
   - Codebase exploration that would clutter your context
   - Research questions requiring many search/read steps

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -27,6 +27,7 @@ func Run(
 	h handler.AgentEventHandler,
 	rec *session.Recorder,
 	todoStore *tools.TodoStore,
+	goalStore *tools.GoalStore,
 	tracer *telemetry.LangfuseTracer,
 	tokenUsage *internalmodel.TokenUsage,
 ) string {
@@ -39,6 +40,10 @@ func Run(
 	h.OnAgentStart()
 
 	resp := runInner(ctx, ag, messages, h, rec)
+	// pending is the assistant text produced since messages was last extended;
+	// each continuation appends only this delta, never the accumulated resp,
+	// so earlier turns are not duplicated into the context.
+	pending := resp
 
 	// Completion guard: if the agent finished but there are still incomplete
 	// todos, re-run with a reminder so nothing is left behind.
@@ -49,10 +54,46 @@ func Run(
 		}
 		reminder := todoStore.IncompleteSummary()
 		h.OnAgentText("\n⚠️ Incomplete todos detected, continuing...\n")
-		messages = append(messages, &schema.Message{Role: schema.Assistant, Content: resp})
+		messages = append(messages, &schema.Message{Role: schema.Assistant, Content: pending})
 		messages = append(messages, schema.UserMessage(reminder))
 		extra := runInner(ctx, ag, messages, h, rec)
 		resp += extra
+		pending = extra
+	}
+
+	// Goal continuation guard: if an active goal exists and the agent stopped
+	// without proving it complete, keep injecting a continuation prompt and
+	// re-running — mirroring codex's idle auto-continuation. Bounded by a hard
+	// turn cap and context cancellation.
+	if goalStore != nil {
+		const maxGoalContinuations = 25
+	goalLoop:
+		for turns := 0; turns < maxGoalContinuations; turns++ {
+			select {
+			case <-ctx.Done():
+				config.Logger().Printf("[runner] goal continuation cancelled")
+				break goalLoop
+			default:
+			}
+			// Record observed tokens for the informational usage display.
+			if tokenUsage != nil {
+				goalStore.RecordTokens(tokenUsage.GetLastTotal())
+			}
+			if !goalStore.IsActive() {
+				break
+			}
+			cont := goalStore.ContinuationPrompt()
+			if cont == "" {
+				break
+			}
+			config.Logger().Printf("[runner] goal continuation #%d", turns+1)
+			h.OnAgentText("\n🎯 Goal active — continuing toward objective...\n")
+			messages = append(messages, &schema.Message{Role: schema.Assistant, Content: pending})
+			messages = append(messages, schema.UserMessage(cont))
+			extra := runInner(ctx, ag, messages, h, rec)
+			resp += extra
+			pending = extra
+		}
 	}
 
 	// Send token usage update before signalling done.

--- a/internal/session/goal_test.go
+++ b/internal/session/goal_test.go
@@ -1,0 +1,34 @@
+package session
+
+import "testing"
+
+func TestReconstructState_Goal(t *testing.T) {
+	entries := []Entry{
+		{Type: EntrySessionStart},
+		{Type: EntryUser, Content: "hi"},
+		{Type: EntryGoalUpdate, GoalObjective: "Ship it", GoalStatus: "active", GoalTokensUsed: 100},
+		{Type: EntryGoalUpdate, GoalObjective: "Ship it", GoalStatus: "active", GoalTokensUsed: 900},
+	}
+	st := ReconstructState(entries)
+	if st.Goal == nil {
+		t.Fatal("expected goal to be reconstructed")
+	}
+	if st.Goal.Objective != "Ship it" || st.Goal.Status != "active" {
+		t.Fatalf("unexpected goal: %+v", st.Goal)
+	}
+	// Last snapshot wins.
+	if st.Goal.TokensUsed != 900 {
+		t.Fatalf("tokens used = %d, want 900 (last snapshot)", st.Goal.TokensUsed)
+	}
+}
+
+func TestReconstructState_GoalCleared(t *testing.T) {
+	entries := []Entry{
+		{Type: EntryGoalUpdate, GoalObjective: "x", GoalStatus: "active"},
+		{Type: EntryGoalUpdate, GoalStatus: "cleared"},
+	}
+	st := ReconstructState(entries)
+	if st.Goal != nil {
+		t.Fatalf("goal should be nil after a cleared marker, got %+v", st.Goal)
+	}
+}

--- a/internal/session/goal_test.go
+++ b/internal/session/goal_test.go
@@ -6,8 +6,8 @@ func TestReconstructState_Goal(t *testing.T) {
 	entries := []Entry{
 		{Type: EntrySessionStart},
 		{Type: EntryUser, Content: "hi"},
-		{Type: EntryGoalUpdate, GoalObjective: "Ship it", GoalStatus: "active", GoalTokensUsed: 100},
-		{Type: EntryGoalUpdate, GoalObjective: "Ship it", GoalStatus: "active", GoalTokensUsed: 900},
+		{Type: EntryGoalUpdate, GoalObjective: "Ship it", GoalStatus: "active", GoalTokensUsed: 100, GoalCreatedAt: 1700000000, GoalUpdatedAt: 1700000100},
+		{Type: EntryGoalUpdate, GoalObjective: "Ship it", GoalStatus: "active", GoalTokensUsed: 900, GoalCreatedAt: 1700000000, GoalUpdatedAt: 1700000900},
 	}
 	st := ReconstructState(entries)
 	if st.Goal == nil {
@@ -19,6 +19,9 @@ func TestReconstructState_Goal(t *testing.T) {
 	// Last snapshot wins.
 	if st.Goal.TokensUsed != 900 {
 		t.Fatalf("tokens used = %d, want 900 (last snapshot)", st.Goal.TokensUsed)
+	}
+	if st.Goal.CreatedAt != 1700000000 || st.Goal.UpdatedAt != 1700000900 {
+		t.Fatalf("timestamps not restored: %+v", st.Goal)
 	}
 }
 

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -174,12 +174,20 @@ type PlanSnapshot struct {
 	Feedback string
 }
 
+// GoalSnapshot is the recoverable state of a session goal.
+type GoalSnapshot struct {
+	Objective  string
+	Status     string
+	TokensUsed int64
+}
+
 // SessionState is the full recoverable state from a session file, including
 // conversation history, plan, todos, mode, and environment.
 type SessionState struct {
 	History      []adk.Message
 	Plan         *PlanSnapshot      // nil if no plan events found
 	Todos        []TodoSnapshotItem // last todo snapshot, nil if none
+	Goal         *GoalSnapshot      // nil if no goal events or last event cleared it
 	Mode         string             // last mode (normal/planning/executing), empty = normal
 	EnvTarget    string             // last environment (local/ssh alias)
 	SystemPrompt string             // recorded system prompt for KV-cache-friendly resume
@@ -291,6 +299,17 @@ func ReconstructState(entries []Entry) *SessionState {
 
 		case EntryTodoSnapshot:
 			state.Todos = e.Todos
+
+		case EntryGoalUpdate:
+			if e.GoalStatus == "cleared" {
+				state.Goal = nil
+			} else {
+				state.Goal = &GoalSnapshot{
+					Objective:  e.GoalObjective,
+					Status:     e.GoalStatus,
+					TokensUsed: e.GoalTokensUsed,
+				}
+			}
 
 		case EntryModeChange:
 			state.Mode = e.Mode

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -179,6 +179,8 @@ type GoalSnapshot struct {
 	Objective  string
 	Status     string
 	TokensUsed int64
+	CreatedAt  int64
+	UpdatedAt  int64
 }
 
 // SessionState is the full recoverable state from a session file, including
@@ -308,6 +310,8 @@ func ReconstructState(entries []Entry) *SessionState {
 					Objective:  e.GoalObjective,
 					Status:     e.GoalStatus,
 					TokensUsed: e.GoalTokensUsed,
+					CreatedAt:  e.GoalCreatedAt,
+					UpdatedAt:  e.GoalUpdatedAt,
 				}
 			}
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -95,6 +95,8 @@ type Entry struct {
 	GoalObjective  string `json:"goal_objective,omitempty"`
 	GoalStatus     string `json:"goal_status,omitempty"`
 	GoalTokensUsed int64  `json:"goal_tokens_used,omitempty"`
+	GoalCreatedAt  int64  `json:"goal_created_at,omitempty"`
+	GoalUpdatedAt  int64  `json:"goal_updated_at,omitempty"`
 }
 
 // SessionMeta is stored in the index for fast listing.
@@ -265,7 +267,7 @@ func (r *Recorder) RecordPlanUpdate(status, title, content, feedback string) {
 
 // RecordGoalUpdate appends a goal state change entry. An empty status records
 // a "cleared" marker so resume knows the goal was removed.
-func (r *Recorder) RecordGoalUpdate(objective, status string, tokensUsed int64) {
+func (r *Recorder) RecordGoalUpdate(objective, status string, tokensUsed, createdAt, updatedAt int64) {
 	if status == "" {
 		status = "cleared"
 	}
@@ -274,6 +276,8 @@ func (r *Recorder) RecordGoalUpdate(objective, status string, tokensUsed int64) 
 		GoalObjective:  objective,
 		GoalStatus:     status,
 		GoalTokensUsed: tokensUsed,
+		GoalCreatedAt:  createdAt,
+		GoalUpdatedAt:  updatedAt,
 	})
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -34,6 +34,7 @@ const (
 	EntryCompact        EntryType = "compact"
 	EntryBudgetWarning  EntryType = "budget_warning"
 	EntrySystemPrompt   EntryType = "system_prompt"
+	EntryGoalUpdate     EntryType = "goal_update"
 )
 
 // TodoSnapshotItem is a single todo entry stored in a todo_snapshot event.
@@ -89,6 +90,11 @@ type Entry struct {
 
 	// system_prompt fields
 	EnvInfo string `json:"env_info,omitempty"` // serialized environment snapshot
+
+	// goal_update fields. GoalStatus == "cleared" marks goal removal.
+	GoalObjective  string `json:"goal_objective,omitempty"`
+	GoalStatus     string `json:"goal_status,omitempty"`
+	GoalTokensUsed int64  `json:"goal_tokens_used,omitempty"`
 }
 
 // SessionMeta is stored in the index for fast listing.
@@ -254,6 +260,20 @@ func (r *Recorder) RecordPlanUpdate(status, title, content, feedback string) {
 		PlanTitle:   title,
 		PlanContent: content,
 		Feedback:    feedback,
+	})
+}
+
+// RecordGoalUpdate appends a goal state change entry. An empty status records
+// a "cleared" marker so resume knows the goal was removed.
+func (r *Recorder) RecordGoalUpdate(objective, status string, tokensUsed int64) {
+	if status == "" {
+		status = "cleared"
+	}
+	_ = r.writeEntry(Entry{
+		Type:           EntryGoalUpdate,
+		GoalObjective:  objective,
+		GoalStatus:     status,
+		GoalTokensUsed: tokensUsed,
 	})
 }
 

--- a/internal/tools/env.go
+++ b/internal/tools/env.go
@@ -24,6 +24,7 @@ type Env struct {
 	pwd         string
 	platform    string
 	TodoStore   *TodoStore
+	GoalStore   *GoalStore
 	FileTracker *FileTracker
 	OnEnvChange func(envLabel string, isLocal bool, err error)
 	Depth       int // subagent nesting depth, 0 for top-level
@@ -42,6 +43,7 @@ func NewEnv(pwd, platform string) *Env {
 		pwd:       pwd,
 		platform:  platform,
 		TodoStore: NewTodoStore(),
+		GoalStore: NewGoalStore(),
 		origExec:  exec,
 		origPwd:   pwd,
 	}

--- a/internal/tools/env.go
+++ b/internal/tools/env.go
@@ -89,7 +89,9 @@ func (e *Env) ResolvePath(path string) string {
 }
 
 // CloneForSubagent creates a copy of this Env with the same executor and pwd
-// but an isolated TodoStore, suitable for use by a subagent.
+// but an isolated TodoStore, suitable for use by a subagent. GoalStore is
+// intentionally left nil: the session goal belongs to the top-level agent and
+// subagents are not registered with the goal tools.
 func (e *Env) CloneForSubagent() *Env {
 	return &Env{
 		Exec:        e.Exec,

--- a/internal/tools/goal.go
+++ b/internal/tools/goal.go
@@ -114,10 +114,21 @@ func (s *GoalStore) RestoreFromSnapshot(snap *session.GoalSnapshot) {
 		s.Restore(nil)
 		return
 	}
+	// Entries written before timestamps were persisted have zero values;
+	// fall back to "restored now" so goal_get never reports created_at: 0.
+	createdAt, updatedAt := snap.CreatedAt, snap.UpdatedAt
+	if createdAt == 0 {
+		createdAt = s.now()
+	}
+	if updatedAt == 0 {
+		updatedAt = createdAt
+	}
 	s.Restore(&Goal{
 		Objective:  snap.Objective,
 		Status:     GoalStatus(snap.Status),
 		TokensUsed: snap.TokensUsed,
+		CreatedAt:  createdAt,
+		UpdatedAt:  updatedAt,
 	})
 }
 
@@ -130,10 +141,10 @@ func GoalRecorderHook(rec *session.Recorder) func(*Goal) {
 			return
 		}
 		if g == nil {
-			rec.RecordGoalUpdate("", "", 0)
+			rec.RecordGoalUpdate("", "", 0, 0, 0)
 			return
 		}
-		rec.RecordGoalUpdate(g.Objective, string(g.Status), g.TokensUsed)
+		rec.RecordGoalUpdate(g.Objective, string(g.Status), g.TokensUsed, g.CreatedAt, g.UpdatedAt)
 	}
 }
 
@@ -221,8 +232,8 @@ func (s *GoalStore) StatusLine() string {
 		return ""
 	}
 	obj := g.Objective
-	if len(obj) > 60 {
-		obj = strings.TrimSpace(string([]rune(obj)[:60])) + "…"
+	if runes := []rune(obj); len(runes) > 60 {
+		obj = strings.TrimSpace(string(runes[:60])) + "…"
 	}
 	usage := ""
 	if g.TokensUsed > 0 {

--- a/internal/tools/goal.go
+++ b/internal/tools/goal.go
@@ -1,0 +1,439 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+
+	"github.com/cnjack/jcode/internal/session"
+)
+
+// GoalStatus is the lifecycle state of a session goal.
+type GoalStatus string
+
+const (
+	// GoalActive means the agent should keep working toward the objective,
+	// auto-continuing across turns until it can prove completion.
+	GoalActive GoalStatus = "active"
+	// GoalComplete is a terminal status set once the objective is verifiably done.
+	GoalComplete GoalStatus = "complete"
+	// GoalBlocked is a terminal status for an obstacle the agent cannot clear.
+	GoalBlocked GoalStatus = "blocked"
+)
+
+// Goal is a persistent, cross-turn objective attached to a session. It mirrors
+// codex's ThreadGoal: the agent keeps working toward Objective, auto-continuing
+// when it would otherwise stop, until it can prove the goal Complete or Blocked.
+type Goal struct {
+	Objective  string     `json:"objective"`
+	Status     GoalStatus `json:"status"`
+	TokensUsed int64      `json:"tokens_used"` // informational only; goals are bounded by the turn cap, not tokens
+	CreatedAt  int64      `json:"created_at"`
+	UpdatedAt  int64      `json:"updated_at"`
+}
+
+// clone returns a copy so callers never mutate store-owned state.
+func (g *Goal) clone() *Goal {
+	if g == nil {
+		return nil
+	}
+	cp := *g
+	return &cp
+}
+
+// GoalStore is a concurrency-safe holder for the single active session goal.
+// It mirrors TodoStore: an OnUpdate callback fires (with a snapshot copy) after
+// every mutation so the session recorder can persist goal_update entries.
+type GoalStore struct {
+	mu        sync.RWMutex
+	goal      *Goal
+	tokenSeen int64 // last observed cumulative token total, for delta accounting
+	OnUpdate  func(g *Goal)
+	nowFn     func() int64 // injectable clock for tests
+}
+
+// NewGoalStore creates an empty GoalStore.
+func NewGoalStore() *GoalStore {
+	return &GoalStore{nowFn: func() int64 { return time.Now().Unix() }}
+}
+
+func (s *GoalStore) now() int64 {
+	if s.nowFn != nil {
+		return s.nowFn()
+	}
+	return time.Now().Unix()
+}
+
+// fireUpdate invokes OnUpdate with a snapshot copy. Must be called without the lock held.
+func (s *GoalStore) fireUpdate(snapshot *Goal) {
+	if s.OnUpdate != nil {
+		s.OnUpdate(snapshot)
+	}
+}
+
+// Set creates or replaces the active goal with a fresh objective. Token
+// accounting resets. Returns a snapshot copy.
+func (s *GoalStore) Set(objective string) *Goal {
+	now := s.now()
+	s.mu.Lock()
+	g := &Goal{
+		Objective:  objective,
+		Status:     GoalActive,
+		TokensUsed: 0,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	s.goal = g
+	s.tokenSeen = 0
+	snap := g.clone()
+	s.mu.Unlock()
+	s.fireUpdate(snap)
+	return snap
+}
+
+// Restore loads a goal verbatim (used when resuming a session). A nil goal
+// resets the store. No OnUpdate fires, so nothing is re-recorded.
+func (s *GoalStore) Restore(g *Goal) {
+	s.mu.Lock()
+	s.goal = g.clone()
+	s.tokenSeen = 0
+	s.mu.Unlock()
+}
+
+// RestoreFromSnapshot loads a goal snapshot produced by
+// session.ReconstructState. A nil snapshot resets the store. Shared by every
+// resume path (TUI /resume, CLI --resume, ACP load/resume, web resume).
+func (s *GoalStore) RestoreFromSnapshot(snap *session.GoalSnapshot) {
+	if snap == nil {
+		s.Restore(nil)
+		return
+	}
+	s.Restore(&Goal{
+		Objective:  snap.Objective,
+		Status:     GoalStatus(snap.Status),
+		TokensUsed: snap.TokensUsed,
+	})
+}
+
+// GoalRecorderHook returns an OnUpdate callback that persists goal changes via
+// rec.RecordGoalUpdate, including the nil-goal "cleared" marker. Shared by all
+// frontends so the persistence encoding lives in one place.
+func GoalRecorderHook(rec *session.Recorder) func(*Goal) {
+	return func(g *Goal) {
+		if rec == nil {
+			return
+		}
+		if g == nil {
+			rec.RecordGoalUpdate("", "", 0)
+			return
+		}
+		rec.RecordGoalUpdate(g.Objective, string(g.Status), g.TokensUsed)
+	}
+}
+
+// Get returns a snapshot copy of the current goal, or nil if none.
+func (s *GoalStore) Get() *Goal {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.goal.clone()
+}
+
+// Has reports whether any goal is set (in any status).
+func (s *GoalStore) Has() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.goal != nil
+}
+
+// IsActive reports whether a goal exists and is in the Active status.
+func (s *GoalStore) IsActive() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.goal != nil && s.goal.Status == GoalActive
+}
+
+// setStatus transitions the goal to a terminal status. Returns the snapshot and
+// whether a goal existed to update.
+func (s *GoalStore) setStatus(status GoalStatus) (*Goal, bool) {
+	s.mu.Lock()
+	if s.goal == nil {
+		s.mu.Unlock()
+		return nil, false
+	}
+	s.goal.Status = status
+	s.goal.UpdatedAt = s.now()
+	snap := s.goal.clone()
+	s.mu.Unlock()
+	s.fireUpdate(snap)
+	return snap, true
+}
+
+// Complete marks the goal complete. Returns false if no goal is set.
+func (s *GoalStore) Complete() bool {
+	_, ok := s.setStatus(GoalComplete)
+	return ok
+}
+
+// Block marks the goal blocked. Returns false if no goal is set.
+func (s *GoalStore) Block() bool {
+	_, ok := s.setStatus(GoalBlocked)
+	return ok
+}
+
+// Clear removes the goal entirely.
+func (s *GoalStore) Clear() {
+	s.mu.Lock()
+	had := s.goal != nil
+	s.goal = nil
+	s.tokenSeen = 0
+	s.mu.Unlock()
+	if had {
+		s.fireUpdate(nil)
+	}
+}
+
+// RecordTokens feeds an observed cumulative token total into the goal's
+// informational usage counter. Only positive deltas are added (the context
+// total can shrink after summarization). Usage is display-only — goals are
+// bounded by the runner's turn cap, never by tokens.
+func (s *GoalStore) RecordTokens(cumulativeTotal int64) {
+	s.mu.Lock()
+	if s.goal != nil {
+		if delta := cumulativeTotal - s.tokenSeen; delta > 0 {
+			s.goal.TokensUsed += delta
+		}
+	}
+	s.tokenSeen = cumulativeTotal
+	s.mu.Unlock()
+}
+
+// StatusLine returns a compact one-line human summary, e.g.
+// "🎯 active — Build the thing (1.2k tokens)". Empty if no goal.
+func (s *GoalStore) StatusLine() string {
+	g := s.Get()
+	if g == nil {
+		return ""
+	}
+	obj := g.Objective
+	if len(obj) > 60 {
+		obj = strings.TrimSpace(string([]rune(obj)[:60])) + "…"
+	}
+	usage := ""
+	if g.TokensUsed > 0 {
+		usage = fmt.Sprintf(" (%s tokens)", humanTokens(g.TokensUsed))
+	}
+	return fmt.Sprintf("🎯 %s — %s%s", g.Status, obj, usage)
+}
+
+// ContinuationPrompt is the steering message injected when the agent would
+// otherwise stop but the goal is still Active. It mirrors codex's
+// continuation.md: keep working, but only mark complete with real evidence.
+func (s *GoalStore) ContinuationPrompt() string {
+	g := s.Get()
+	if g == nil || g.Status != GoalActive {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("[Goal continuation]\n")
+	b.WriteString("You have an active session goal and have not yet proven it complete.\n\n")
+	b.WriteString("Objective: ")
+	b.WriteString(g.Objective)
+	b.WriteString("\n")
+	b.WriteString("\nContinue working toward the objective. When — and only when — it is")
+	b.WriteString(" verifiably done (checked against the actual files/commands/tests, not your")
+	b.WriteString(" intent), call goal_update with status=\"complete\". If you are genuinely and")
+	b.WriteString(" repeatedly blocked by an obstacle you cannot clear, call goal_update with")
+	b.WriteString(" status=\"blocked\" and explain why. Do not mark complete just to stop.")
+	return b.String()
+}
+
+// humanTokens formats a token count compactly (e.g. 1234 -> "1.2k").
+func humanTokens(n int64) string {
+	if n < 1000 {
+		return fmt.Sprintf("%d", n)
+	}
+	return fmt.Sprintf("%.1fk", float64(n)/1000)
+}
+
+// ---------------------------------------------------------------------------
+// /goal slash command — shared grammar and prompts for all frontends
+// ---------------------------------------------------------------------------
+
+// GoalCommand is the parsed intent of a "/goal ..." slash command.
+type GoalCommand struct {
+	Kind      string // "status", "clear", or "set"
+	Objective string // non-empty when Kind == "set"
+}
+
+// ParseGoalCommand parses the argument portion of a "/goal ..." command. The
+// grammar is shared by the TUI, ACP, and web frontends: no argument or
+// "status" reports the goal, "clear" removes it, anything else sets it as the
+// objective.
+func ParseGoalCommand(rest string) GoalCommand {
+	rest = strings.TrimSpace(rest)
+	switch rest {
+	case "", "status":
+		return GoalCommand{Kind: "status"}
+	case "clear":
+		return GoalCommand{Kind: "clear"}
+	default:
+		return GoalCommand{Kind: "set", Objective: rest}
+	}
+}
+
+// GoalKickoffPrompt is the prompt sent to the agent immediately after a goal
+// is set, so work starts without a separate user message.
+func GoalKickoffPrompt(objective string) string {
+	return "A persistent session goal has been set. Begin working toward it now, and keep going until it is verifiably complete:\n\n" + objective
+}
+
+// ValidateGoalObjective normalizes and validates a goal objective. It is the
+// single validation rule for every entry point (goal_set tool, HTTP API,
+// slash commands).
+func ValidateGoalObjective(objective string) (string, error) {
+	objective = strings.TrimSpace(objective)
+	if objective == "" {
+		return "", fmt.Errorf("objective must not be empty")
+	}
+	if len([]rune(objective)) > goalMaxObjectiveLen {
+		return "", fmt.Errorf("objective exceeds %d characters", goalMaxObjectiveLen)
+	}
+	return objective, nil
+}
+
+// ---------------------------------------------------------------------------
+// Tools: goal_set, goal_get, goal_update
+// ---------------------------------------------------------------------------
+
+const goalMaxObjectiveLen = 4000
+
+type goalSetInput struct {
+	Objective string `json:"objective"`
+}
+
+// NewGoalSetTool creates the goal_set tool: set or replace the session goal.
+func (e *Env) NewGoalSetTool() tool.InvokableTool {
+	info := &schema.ToolInfo{
+		Name: "goal_set",
+		Desc: `Set (or replace) the persistent objective for this session. A goal keeps you working across turns: when you would otherwise stop, you are automatically reminded to continue until the objective is verifiably complete.
+
+Use this when the user gives you a substantial, multi-step objective they want pursued to completion. Provide a clear, self-contained objective describing the desired end state.
+
+Setting a new goal replaces any existing one and resets accounting.`,
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"objective": {
+				Type:     schema.String,
+				Desc:     "A clear, self-contained description of the desired end state (max 4000 chars).",
+				Required: true,
+			},
+		}),
+	}
+	return &goalSetTool{env: e, info: info}
+}
+
+type goalSetTool struct {
+	env  *Env
+	info *schema.ToolInfo
+}
+
+func (t *goalSetTool) Info(_ context.Context) (*schema.ToolInfo, error) { return t.info, nil }
+
+func (t *goalSetTool) InvokableRun(_ context.Context, argumentsInJSON string, _ ...tool.Option) (string, error) {
+	var in goalSetInput
+	if err := json.Unmarshal([]byte(argumentsInJSON), &in); err != nil {
+		return "", fmt.Errorf("failed to parse goal_set input: %w", err)
+	}
+	objective, err := ValidateGoalObjective(in.Objective)
+	if err != nil {
+		return "", err
+	}
+	if t.env.GoalStore == nil {
+		return "", fmt.Errorf("goals are not enabled in this session")
+	}
+	g := t.env.GoalStore.Set(objective)
+	out, _ := json.Marshal(g)
+	return fmt.Sprintf("Goal set. Keep working until it is verifiably complete, then call goal_update.\n%s", string(out)), nil
+}
+
+// NewGoalGetTool creates the goal_get tool: read the current goal.
+func (e *Env) NewGoalGetTool() tool.InvokableTool {
+	info := &schema.ToolInfo{
+		Name:        "goal_get",
+		Desc:        "Read the current session goal: its objective, status, and token usage. Takes no parameters. Returns \"No goal set.\" when none exists.",
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{}),
+	}
+	return &goalGetTool{env: e, info: info}
+}
+
+type goalGetTool struct {
+	env  *Env
+	info *schema.ToolInfo
+}
+
+func (t *goalGetTool) Info(_ context.Context) (*schema.ToolInfo, error) { return t.info, nil }
+
+func (t *goalGetTool) InvokableRun(_ context.Context, _ string, _ ...tool.Option) (string, error) {
+	if t.env.GoalStore == nil {
+		return "No goal set.", nil
+	}
+	g := t.env.GoalStore.Get()
+	if g == nil {
+		return "No goal set.", nil
+	}
+	out, _ := json.Marshal(g)
+	return string(out), nil
+}
+
+type goalUpdateInput struct {
+	Status string `json:"status"`
+}
+
+// NewGoalUpdateTool creates the goal_update tool: mark the goal complete or blocked.
+func (e *Env) NewGoalUpdateTool() tool.InvokableTool {
+	info := &schema.ToolInfo{
+		Name: "goal_update",
+		Desc: `Update the status of the current session goal. Use status="complete" only when the objective is verifiably done — checked against the real state of files, command output, or tests, not your intent or memory. Use status="blocked" only when you are genuinely and repeatedly blocked by an obstacle you cannot clear. Marking the goal complete or blocked stops the automatic continuation.`,
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"status": {
+				Type:     schema.String,
+				Desc:     `New status: "complete" (objective verifiably achieved) or "blocked" (cannot proceed).`,
+				Required: true,
+				Enum:     []string{"complete", "blocked"},
+			},
+		}),
+	}
+	return &goalUpdateTool{env: e, info: info}
+}
+
+type goalUpdateTool struct {
+	env  *Env
+	info *schema.ToolInfo
+}
+
+func (t *goalUpdateTool) Info(_ context.Context) (*schema.ToolInfo, error) { return t.info, nil }
+
+func (t *goalUpdateTool) InvokableRun(_ context.Context, argumentsInJSON string, _ ...tool.Option) (string, error) {
+	var in goalUpdateInput
+	if err := json.Unmarshal([]byte(argumentsInJSON), &in); err != nil {
+		return "", fmt.Errorf("failed to parse goal_update input: %w", err)
+	}
+	if t.env.GoalStore == nil || !t.env.GoalStore.Has() {
+		return "", fmt.Errorf("no goal is set; nothing to update")
+	}
+	switch strings.ToLower(strings.TrimSpace(in.Status)) {
+	case "complete":
+		t.env.GoalStore.Complete()
+		return "Goal marked complete. Automatic continuation stopped.", nil
+	case "blocked":
+		t.env.GoalStore.Block()
+		return "Goal marked blocked. Automatic continuation stopped.", nil
+	default:
+		return "", fmt.Errorf("invalid status %q, must be \"complete\" or \"blocked\"", in.Status)
+	}
+}

--- a/internal/tools/goal_test.go
+++ b/internal/tools/goal_test.go
@@ -1,0 +1,217 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestGoalStore_SetAndGet(t *testing.T) {
+	s := NewGoalStore()
+	if s.Has() {
+		t.Fatal("new store should have no goal")
+	}
+	if s.StatusLine() != "" {
+		t.Fatal("empty store should have empty status line")
+	}
+
+	g := s.Set("Build the thing")
+	if g.Status != GoalActive {
+		t.Fatalf("new goal should be active, got %q", g.Status)
+	}
+	if !s.IsActive() {
+		t.Fatal("store should report active")
+	}
+	got := s.Get()
+	if got.Objective != "Build the thing" {
+		t.Fatalf("unexpected goal: %+v", got)
+	}
+
+	// Returned snapshot must be a copy — mutating it must not affect the store.
+	got.Objective = "mutated"
+	if s.Get().Objective != "Build the thing" {
+		t.Fatal("Get must return a defensive copy")
+	}
+}
+
+func TestGoalStore_StatusTransitions(t *testing.T) {
+	s := NewGoalStore()
+	s.Set("obj")
+
+	if !s.Complete() {
+		t.Fatal("Complete should succeed when goal set")
+	}
+	if s.IsActive() {
+		t.Fatal("completed goal must not be active")
+	}
+	if s.Get().Status != GoalComplete {
+		t.Fatal("status should be complete")
+	}
+	if s.ContinuationPrompt() != "" {
+		t.Fatal("non-active goal must not produce a continuation prompt")
+	}
+
+	s2 := NewGoalStore()
+	if s2.Complete() {
+		t.Fatal("Complete should fail when no goal set")
+	}
+
+	s.Set("again")
+	if !s.Block() {
+		t.Fatal("Block should succeed")
+	}
+	if s.IsActive() || s.Get().Status != GoalBlocked {
+		t.Fatal("goal should be blocked and inactive")
+	}
+}
+
+func TestGoalStore_RecordTokensUsageOnly(t *testing.T) {
+	s := NewGoalStore()
+	s.Set("obj")
+
+	s.RecordTokens(400)
+	if got := s.Get().TokensUsed; got != 400 {
+		t.Fatalf("tokens used = %d, want 400", got)
+	}
+	// Only positive deltas counted (context total can shrink after summarization).
+	s.RecordTokens(300)
+	if got := s.Get().TokensUsed; got != 400 {
+		t.Fatalf("tokens used = %d, want still 400", got)
+	}
+	s.RecordTokens(1300)
+	if got := s.Get().TokensUsed; got != 1400 {
+		t.Fatalf("tokens used = %d, want 1400", got)
+	}
+	// Usage is informational only — the goal never leaves Active because of tokens.
+	if !s.IsActive() {
+		t.Fatal("goal must stay active regardless of token usage")
+	}
+}
+
+func TestGoalStore_OnUpdateFires(t *testing.T) {
+	s := NewGoalStore()
+	var calls []string
+	s.OnUpdate = func(g *Goal) {
+		if g == nil {
+			calls = append(calls, "cleared")
+		} else {
+			calls = append(calls, string(g.Status))
+		}
+	}
+	s.Set("obj") // active
+	s.Complete() // complete
+	s.Clear()    // cleared
+	want := []string{"active", "complete", "cleared"}
+	if strings.Join(calls, ",") != strings.Join(want, ",") {
+		t.Fatalf("OnUpdate calls = %v, want %v", calls, want)
+	}
+}
+
+func TestGoalStore_ContinuationPromptIncludesObjective(t *testing.T) {
+	s := NewGoalStore()
+	s.Set("Migrate the database")
+	p := s.ContinuationPrompt()
+	if !strings.Contains(p, "Migrate the database") {
+		t.Fatal("continuation prompt should include the objective")
+	}
+	if !strings.Contains(p, "goal_update") {
+		t.Fatal("continuation prompt should instruct calling goal_update")
+	}
+}
+
+func TestGoalTools_SetGetUpdate(t *testing.T) {
+	env := NewEnv("/tmp", "darwin/arm64")
+	ctx := context.Background()
+
+	setTool := env.NewGoalSetTool()
+	out, err := setTool.InvokableRun(ctx, `{"objective":"Do the work"}`)
+	if err != nil {
+		t.Fatalf("goal_set failed: %v", err)
+	}
+	if !strings.Contains(out, "Do the work") {
+		t.Fatalf("goal_set output missing objective: %s", out)
+	}
+	if !env.GoalStore.IsActive() {
+		t.Fatal("goal_set should create an active goal")
+	}
+
+	// Empty objective is rejected.
+	if _, err := setTool.InvokableRun(ctx, `{"objective":"   "}`); err == nil {
+		t.Fatal("empty objective should be rejected")
+	}
+
+	getTool := env.NewGoalGetTool()
+	gout, err := getTool.InvokableRun(ctx, ``)
+	if err != nil {
+		t.Fatalf("goal_get failed: %v", err)
+	}
+	var g Goal
+	if err := json.Unmarshal([]byte(gout), &g); err != nil {
+		t.Fatalf("goal_get should return JSON: %v (%s)", err, gout)
+	}
+	if g.Objective != "Do the work" {
+		t.Fatalf("goal_get objective = %q", g.Objective)
+	}
+
+	updTool := env.NewGoalUpdateTool()
+	if _, err := updTool.InvokableRun(ctx, `{"status":"complete"}`); err != nil {
+		t.Fatalf("goal_update complete failed: %v", err)
+	}
+	if env.GoalStore.IsActive() {
+		t.Fatal("goal should be inactive after complete")
+	}
+	// Invalid status rejected.
+	env.GoalStore.Set("x")
+	if _, err := updTool.InvokableRun(ctx, `{"status":"bogus"}`); err == nil {
+		t.Fatal("invalid status should be rejected")
+	}
+}
+
+func TestGoalGet_NoGoal(t *testing.T) {
+	env := NewEnv("/tmp", "darwin/arm64")
+	out, err := env.NewGoalGetTool().InvokableRun(context.Background(), ``)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "No goal set." {
+		t.Fatalf("expected 'No goal set.', got %q", out)
+	}
+}
+
+func TestParseGoalCommand(t *testing.T) {
+	cases := []struct {
+		in        string
+		kind      string
+		objective string
+	}{
+		{"", "status", ""},
+		{"status", "status", ""},
+		{"  status  ", "status", ""},
+		{"clear", "clear", ""},
+		{"Refactor the parser", "set", "Refactor the parser"},
+		{"  keep all tests green  ", "set", "keep all tests green"},
+	}
+	for _, c := range cases {
+		got := ParseGoalCommand(c.in)
+		if got.Kind != c.kind {
+			t.Errorf("ParseGoalCommand(%q).Kind = %q, want %q", c.in, got.Kind, c.kind)
+		}
+		if got.Objective != c.objective {
+			t.Errorf("ParseGoalCommand(%q).Objective = %q, want %q", c.in, got.Objective, c.objective)
+		}
+	}
+}
+
+func TestValidateGoalObjective(t *testing.T) {
+	if _, err := ValidateGoalObjective("   "); err == nil {
+		t.Fatal("blank objective should be rejected")
+	}
+	if _, err := ValidateGoalObjective(strings.Repeat("x", goalMaxObjectiveLen+1)); err == nil {
+		t.Fatal("over-long objective should be rejected")
+	}
+	got, err := ValidateGoalObjective("  do the thing  ")
+	if err != nil || got != "do the thing" {
+		t.Fatalf("ValidateGoalObjective = %q, %v", got, err)
+	}
+}

--- a/internal/tools/goal_test.go
+++ b/internal/tools/goal_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"github.com/cnjack/jcode/internal/session"
 	"strings"
 	"testing"
 )
@@ -213,5 +214,36 @@ func TestValidateGoalObjective(t *testing.T) {
 	got, err := ValidateGoalObjective("  do the thing  ")
 	if err != nil || got != "do the thing" {
 		t.Fatalf("ValidateGoalObjective = %q, %v", got, err)
+	}
+}
+
+func TestGoalStore_StatusLineMultibyteObjective(t *testing.T) {
+	s := NewGoalStore()
+	// 70 runes of CJK text: byte length far exceeds 60 while rune-based
+	// truncation must not panic (regression: byte-length check + rune slice).
+	s.Set(strings.Repeat("目", 70))
+	line := s.StatusLine()
+	if !strings.Contains(line, "…") {
+		t.Fatalf("long multibyte objective should be truncated: %q", line)
+	}
+	// A 30-rune CJK objective is 90 bytes but must NOT be truncated.
+	s.Set(strings.Repeat("标", 30))
+	if strings.Contains(s.StatusLine(), "…") {
+		t.Fatalf("30-rune objective must not be truncated: %q", s.StatusLine())
+	}
+}
+
+func TestGoalStore_RestoreFromSnapshotTimestamps(t *testing.T) {
+	s := NewGoalStore()
+	s.RestoreFromSnapshot(&session.GoalSnapshot{Objective: "x", Status: "active", CreatedAt: 1700000000, UpdatedAt: 1700000900})
+	g := s.Get()
+	if g.CreatedAt != 1700000000 || g.UpdatedAt != 1700000900 {
+		t.Fatalf("timestamps not restored: %+v", g)
+	}
+	// Legacy entries without timestamps must not surface zero values.
+	s.RestoreFromSnapshot(&session.GoalSnapshot{Objective: "y", Status: "active"})
+	g = s.Get()
+	if g.CreatedAt == 0 || g.UpdatedAt == 0 {
+		t.Fatalf("zero timestamps should fall back to now: %+v", g)
 	}
 }

--- a/internal/tui/goal_test.go
+++ b/internal/tui/goal_test.go
@@ -1,0 +1,91 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/cnjack/jcode/internal/tools"
+)
+
+// TestHandleGoalInput exercises the /goal slash command dispatch in the TUI
+// without a running BubbleTea program (m.ready stays false, so the viewport
+// refresh is skipped).
+func TestHandleGoalInput(t *testing.T) {
+	// Set with a plain objective.
+	m := Model{goalStore: tools.NewGoalStore()}
+	m.handleGoalInput("/goal Build the feature", nil)
+	if !m.goalStore.IsActive() {
+		t.Fatal("/goal <obj> should create an active goal")
+	}
+	if g := m.goalStore.Get(); g.Objective != "Build the feature" {
+		t.Fatalf("objective = %q", g.Objective)
+	}
+	if !m.thinking {
+		t.Fatal("/goal <obj> should start the agent (thinking=true)")
+	}
+
+	m2 := Model{goalStore: tools.NewGoalStore()}
+	m2.handleGoalInput("/goal Migrate DB", nil)
+	g := m2.goalStore.Get()
+	if g == nil || g.Objective != "Migrate DB" {
+		t.Fatalf("goal = %+v", g)
+	}
+
+	// Clear.
+	m2.handleGoalInput("/goal clear", nil)
+	if m2.goalStore.Has() {
+		t.Fatal("/goal clear should remove the goal")
+	}
+
+	// Status on an empty store must not panic and must not set a goal.
+	m3 := Model{goalStore: tools.NewGoalStore()}
+	m3.handleGoalInput("/goal", nil)
+	if m3.goalStore.Has() {
+		t.Fatal("/goal status should not create a goal")
+	}
+
+	// While the agent is running, /goal sets the goal but must NOT submit a
+	// kickoff prompt (the in-flight run's continuation guard picks it up);
+	// a blocking channel send here would freeze the UI.
+	m4 := Model{goalStore: tools.NewGoalStore(), thinking: true, agentDone: false}
+	_, cmd := m4.handleGoalInput("/goal Fix the tests", nil)
+	if !m4.goalStore.IsActive() {
+		t.Fatal("/goal while running should still set the goal")
+	}
+	if msg := drainForPromptSubmit(cmd); msg != nil {
+		t.Fatalf("no PromptSubmitMsg should be emitted while the agent runs, got %+v", msg)
+	}
+}
+
+// drainForPromptSubmit executes a (possibly batched) command tree and returns
+// the first PromptSubmitMsg it produces, or nil.
+func drainForPromptSubmit(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	switch msg := cmd().(type) {
+	case PromptSubmitMsg:
+		return msg
+	case tea.BatchMsg:
+		for _, c := range msg {
+			if found := drainForPromptSubmit(c); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+func TestGoalCommandInSlashMenu(t *testing.T) {
+	m := Model{}
+	found := false
+	for _, c := range m.getAllCommands() {
+		if c.cmd == "/goal" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("/goal should appear in the slash command menu")
+	}
+}

--- a/internal/tui/input_views.go
+++ b/internal/tui/input_views.go
@@ -278,9 +278,12 @@ func (m *Model) handleGoalInput(prompt string, cmds []tea.Cmd) (tea.Model, tea.C
 		return m, tea.Batch(cmds...)
 
 	case "clear":
-		if m.goalStore != nil {
-			m.goalStore.Clear()
+		if m.goalStore == nil {
+			m.lines = append(m.lines, textLine(toolLabelStyle.Render("  🎯 Goals are not available in this session.")))
+			refresh()
+			return m, tea.Batch(cmds...)
 		}
+		m.goalStore.Clear()
 		m.lines = append(m.lines, textLine(toolLabelStyle.Render("  🎯 Goal cleared.")))
 		refresh()
 		return m, tea.Batch(cmds...)

--- a/internal/tui/input_views.go
+++ b/internal/tui/input_views.go
@@ -3,11 +3,13 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/cnjack/jcode/internal/config"
+	"github.com/cnjack/jcode/internal/tools"
 )
 
 // commandSuggestion represents a single slash command suggestion item.
@@ -24,6 +26,7 @@ func (m Model) getAllCommands() []commandSuggestion {
 		{"/ssh", "SSH connection"},
 		{"/resume", "Resume a previous session"},
 		{"/compact", "Compress conversation context"},
+		{"/goal", "Set a persistent objective (auto-continues)"},
 		{"/bg", "List background tasks"},
 		{"/channel", "Manage channels (WeChat etc.)"},
 		{"/help", "Show keyboard shortcuts"},
@@ -77,6 +80,13 @@ func (m Model) inputAreaView() string {
 
 	// 1. Mode pills line (Agent/Plan + Ask/Auto)
 	parts = append(parts, m.renderModePills())
+
+	// 1b. Active goal indicator (only while a goal exists).
+	if m.goalStore != nil {
+		if line := m.goalStore.StatusLine(); line != "" {
+			parts = append(parts, lipgloss.NewStyle().Foreground(colorPrimary).Render(line))
+		}
+	}
 
 	// 2. Input content: textarea or special prompts
 	switch {
@@ -240,6 +250,81 @@ func (m *Model) handleCompactInput(cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	default:
 	}
 
+	cmds = append(cmds, m.spinner.Tick)
+	return m, tea.Batch(cmds...)
+}
+
+// handleGoalInput handles `/goal` (status), `/goal clear`, and
+// `/goal <objective>` (set + start working toward it).
+func (m *Model) handleGoalInput(prompt string, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	refresh := func() {
+		if m.ready {
+			m.viewport.SetHeight(m.calcViewportHeight(m.inputActive()))
+			m.viewport.SetContent(m.renderViewportContent())
+			m.viewport.GotoBottom()
+		}
+	}
+
+	action := tools.ParseGoalCommand(strings.TrimPrefix(prompt, "/goal"))
+
+	switch action.Kind {
+	case "status":
+		if m.goalStore == nil || !m.goalStore.Has() {
+			m.lines = append(m.lines, textLine(toolLabelStyle.Render("  🎯 No goal set. Use /goal <objective> to set one.")))
+		} else {
+			m.lines = append(m.lines, textLine(toolLabelStyle.Render("  "+m.goalStore.StatusLine())))
+		}
+		refresh()
+		return m, tea.Batch(cmds...)
+
+	case "clear":
+		if m.goalStore != nil {
+			m.goalStore.Clear()
+		}
+		m.lines = append(m.lines, textLine(toolLabelStyle.Render("  🎯 Goal cleared.")))
+		refresh()
+		return m, tea.Batch(cmds...)
+	}
+
+	if m.goalStore == nil {
+		m.lines = append(m.lines, textLine(toolLabelStyle.Render("  🎯 Goals are not available in this session.")))
+		refresh()
+		return m, tea.Batch(cmds...)
+	}
+
+	objective, err := tools.ValidateGoalObjective(action.Objective)
+	if err != nil {
+		m.lines = append(m.lines, textLine(toolLabelStyle.Render("  🎯 "+err.Error())))
+		refresh()
+		return m, tea.Batch(cmds...)
+	}
+
+	m.goalStore.Set(objective)
+	m.lines = append(m.lines, textLine(""))
+	m.lines = append(m.lines, textLine(userPromptStyle.Render("🎯 "+prompt)))
+	m.lines = append(m.lines, textLine(toolLabelStyle.Render("  "+m.goalStore.StatusLine())))
+
+	// If the agent is already running, do not submit a kickoff: the in-flight
+	// run's goal-continuation guard picks the new goal up as soon as the
+	// current turn finishes (a blocking send to the prompt channel here could
+	// also freeze the UI).
+	if !m.agentDone && m.thinking {
+		m.lines = append(m.lines, textLine(toolLabelStyle.Render("  🎯 Agent is running — it will continue toward this goal after the current turn.")))
+		refresh()
+		return m, tea.Batch(cmds...)
+	}
+
+	// Idle: start the agent working toward the goal immediately.
+	m.mode = ModeAgent
+	m.agentDone = false
+	m.thinking = true
+	m.promptStartTime = time.Now()
+	refresh()
+
+	kickoff := tools.GoalKickoffPrompt(objective)
+	cmds = append(cmds, func() tea.Msg {
+		return PromptSubmitMsg{Prompt: kickoff}
+	})
 	cmds = append(cmds, m.spinner.Tick)
 	return m, tea.Batch(cmds...)
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -96,6 +96,7 @@ type Model struct {
 	pasteStore *PasteStore
 
 	todoStore *tools.TodoStore
+	goalStore *tools.GoalStore
 
 	totalTokens       int64
 	modelContextLimit int
@@ -373,6 +374,14 @@ func WithApprovalModeChange(fn func(bool)) ModelOption {
 func WithVersion(v string) ModelOption {
 	return func(m *Model) {
 		m.version = v
+	}
+}
+
+// WithGoalStore wires the session goal store so the TUI can render the active
+// goal indicator. The store is read directly when rendering.
+func WithGoalStore(gs *tools.GoalStore) ModelOption {
+	return func(m *Model) {
+		m.goalStore = gs
 	}
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -836,6 +836,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 						return m.handleCompactInput(cmds)
 					}
 
+					if prompt == "/goal" || strings.HasPrefix(prompt, "/goal ") {
+						return m.handleGoalInput(prompt, cmds)
+					}
+
 					if prompt == "/channel" {
 						return m.handleChannelInput(cmds)
 					}

--- a/internal/web/goal_test.go
+++ b/internal/web/goal_test.go
@@ -1,0 +1,81 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cnjack/jcode/internal/handler"
+	"github.com/cnjack/jcode/internal/tools"
+)
+
+// newGoalTestServer builds a minimal Server exercising only the goal handlers
+// (no network listener, no agent), so the HTTP layer can be tested in-process.
+func newGoalTestServer() *Server {
+	return &Server{
+		env:     tools.NewEnv("/tmp", "darwin/arm64"),
+		handler: handler.NewWebHandler(),
+	}
+}
+
+func TestWebGoalLifecycle(t *testing.T) {
+	s := newGoalTestServer()
+
+	// 1. GET with no goal -> null.
+	rec := httptest.NewRecorder()
+	s.handleGetGoal(rec, httptest.NewRequest(http.MethodGet, "/api/goal", nil))
+	if rec.Code != 200 || strings.TrimSpace(rec.Body.String()) != "null" {
+		t.Fatalf("GET empty goal: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+
+	// 2. POST sets the goal (start:false avoids needing an agent).
+	rec = httptest.NewRecorder()
+	body := strings.NewReader(`{"objective":"Refactor the parser","start":false}`)
+	s.handleSetGoal(rec, httptest.NewRequest(http.MethodPost, "/api/goal", body))
+	if rec.Code != 200 {
+		t.Fatalf("POST goal: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+	var g tools.Goal
+	if err := json.Unmarshal(rec.Body.Bytes(), &g); err != nil {
+		t.Fatalf("POST goal response not JSON: %v", err)
+	}
+	if g.Objective != "Refactor the parser" || g.Status != tools.GoalActive {
+		t.Fatalf("unexpected goal: %+v", g)
+	}
+	if !s.env.GoalStore.IsActive() {
+		t.Fatal("store should hold an active goal after POST")
+	}
+
+	// 3. GET now returns the goal.
+	rec = httptest.NewRecorder()
+	s.handleGetGoal(rec, httptest.NewRequest(http.MethodGet, "/api/goal", nil))
+	if !strings.Contains(rec.Body.String(), "Refactor the parser") {
+		t.Fatalf("GET goal missing objective: %s", rec.Body.String())
+	}
+
+	// 4. POST with empty objective -> 400.
+	rec = httptest.NewRecorder()
+	s.handleSetGoal(rec, httptest.NewRequest(http.MethodPost, "/api/goal", strings.NewReader(`{"objective":"","start":false}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty objective should be 400, got %d", rec.Code)
+	}
+
+	// 5. DELETE clears.
+	rec = httptest.NewRecorder()
+	s.handleClearGoal(rec, httptest.NewRequest(http.MethodDelete, "/api/goal", nil))
+	if rec.Code != 200 {
+		t.Fatalf("DELETE goal: code=%d", rec.Code)
+	}
+	if s.env.GoalStore.Has() {
+		t.Fatal("store should be empty after DELETE")
+	}
+
+	// 6. GET -> null again.
+	rec = httptest.NewRecorder()
+	s.handleGetGoal(rec, httptest.NewRequest(http.MethodGet, "/api/goal", nil))
+	if strings.TrimSpace(rec.Body.String()) != "null" {
+		t.Fatalf("GET after clear should be null, got %q", rec.Body.String())
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -101,6 +101,10 @@ type Server struct {
 	// setup mode and exposes setup API endpoints while blocking chat operations.
 	needsSetup bool
 	version    string
+
+	// tokenUsage tracks per-call token totals for the agent runs, used for
+	// usage display (goal status, token updates).
+	tokenUsage *model.TokenUsage
 }
 
 // ServerConfig holds the configuration for creating a new Server.
@@ -127,6 +131,7 @@ type ServerConfig struct {
 	WebHandler    *handler.WebHandler       // optional: pre-created handler for sharing with tools
 	EventHandler  handler.AgentEventHandler // optional: handler for runner (e.g. NotifyingHandler)
 	NeedsSetup    bool                      // true when no providers are configured (setup mode)
+	TokenUsage    *model.TokenUsage         // optional: shared token tracker (created when nil)
 }
 
 // NewServer creates a new web server.
@@ -167,6 +172,10 @@ func NewServer(cfg *ServerConfig) *Server {
 		wechatClient:  cfg.WechatClient,
 		eventHandler:  eh,
 		needsSetup:    cfg.NeedsSetup,
+		tokenUsage:    cfg.TokenUsage,
+	}
+	if s.tokenUsage == nil {
+		s.tokenUsage = &model.TokenUsage{}
 	}
 
 	// Wire TodoStore → session recording.
@@ -185,6 +194,19 @@ func NewServer(cfg *ServerConfig) *Server {
 					}
 				}
 				r.RecordTodoSnapshot(snapItems)
+			}
+		}
+	}
+
+	// Wire GoalStore → session recording, mirroring the TodoStore wiring above.
+	if cfg.Env != nil && cfg.Env.GoalStore != nil {
+		cfg.Env.GoalStore.OnUpdate = func(g *tools.Goal) {
+			s.mu.RLock()
+			r := s.recorder
+			s.mu.RUnlock()
+			tools.GoalRecorderHook(r)(g)
+			if s.handler != nil {
+				s.handler.Emit("goal_update", g)
 			}
 		}
 	}
@@ -214,6 +236,9 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("POST /api/sessions", s.handleNewSession)
 	mux.HandleFunc("GET /api/config", s.handleGetConfig)
 	mux.HandleFunc("GET /api/todos", s.handleGetTodos)
+	mux.HandleFunc("GET /api/goal", s.handleGetGoal)
+	mux.HandleFunc("POST /api/goal", s.handleSetGoal)
+	mux.HandleFunc("DELETE /api/goal", s.handleClearGoal)
 	mux.HandleFunc("POST /api/approval", s.handleApproval)
 	mux.HandleFunc("GET /api/files", s.handleListFiles)
 	mux.HandleFunc("GET /api/files/content", s.handleReadFile)
@@ -590,7 +615,7 @@ func (s *Server) submitMessage(message, mode, source, sessionID string, images [
 		// Take a git snapshot before the agent run for session diff tracking.
 		s.takeSessionSnapshot()
 
-		resp := runner.Run(runCtx, agent, history, s.eventHandler, recorder, s.todoStore, s.tracer, nil)
+		resp := runner.Run(runCtx, agent, history, s.eventHandler, recorder, s.todoStore, s.env.GoalStore, s.tracer, s.tokenUsage)
 		if resp != "" {
 			s.mu.Lock()
 			s.history = append(s.history, &schema.Message{Role: schema.Assistant, Content: resp})
@@ -768,25 +793,21 @@ func (s *Server) handleNewSession(w http.ResponseWriter, r *http.Request) {
 	// to avoid deadlock: todoStore.Update → OnUpdate → s.mu.RLock.
 	var updateTodos bool
 	var todoItems []tools.TodoItem
+	var resuming bool
+	var goalSnap *session.GoalSnapshot
 	if req.SessionID != "" {
+		resuming = true
 		// Resuming: load prior conversation into history so the agent has context.
 		entries, _ := session.LoadSession(req.SessionID)
-		// Reconstruct full message history (including tool calls/results).
-		s.history = session.ReconstructHistory(entries)
-		// Restore todos from the last snapshot in the session.
-		if s.todoStore != nil {
-			var lastTodos []session.TodoSnapshotItem
-			for _, e := range entries {
-				if e.Type == session.EntryTodoSnapshot {
-					lastTodos = e.Todos
-				}
-			}
-			if len(lastTodos) > 0 {
-				updateTodos = true
-				todoItems = make([]tools.TodoItem, len(lastTodos))
-				for i, t := range lastTodos {
-					todoItems[i] = tools.TodoItem{ID: t.ID, Title: t.Title, Status: tools.TodoStatus(t.Status)}
-				}
+		// Reconstruct full state (message history, todos, goal).
+		st := session.ReconstructState(entries)
+		s.history = st.History
+		goalSnap = st.Goal
+		if s.todoStore != nil && len(st.Todos) > 0 {
+			updateTodos = true
+			todoItems = make([]tools.TodoItem, len(st.Todos))
+			for i, t := range st.Todos {
+				todoItems[i] = tools.TodoItem{ID: t.ID, Title: t.Title, Status: tools.TodoStatus(t.Status)}
 			}
 		}
 	} else {
@@ -801,6 +822,21 @@ func (s *Server) handleNewSession(w http.ResponseWriter, r *http.Request) {
 	// Apply todo updates outside the lock to avoid deadlock with OnUpdate callback.
 	if updateTodos && s.todoStore != nil {
 		s.todoStore.Update(todoItems)
+	}
+
+	// Apply the session's goal state outside the lock. Restore is silent (no
+	// OnUpdate, so nothing is re-recorded into the session file); broadcast
+	// the new state to clients explicitly. A brand-new session always resets
+	// the store so a goal from the previous session does not leak across.
+	if s.env != nil && s.env.GoalStore != nil {
+		if resuming {
+			s.env.GoalStore.RestoreFromSnapshot(goalSnap)
+		} else {
+			s.env.GoalStore.Restore(nil)
+		}
+		if s.handler != nil {
+			s.handler.Emit("goal_update", s.env.GoalStore.Get())
+		}
 	}
 
 	// Notify clients. When resuming an existing session, do NOT broadcast session_reset
@@ -991,6 +1027,55 @@ func (s *Server) handleGetTodos(w http.ResponseWriter, r *http.Request) {
 	}
 	items := s.todoStore.Items()
 	writeJSON(w, http.StatusOK, items)
+}
+
+// handleGetGoal returns the current session goal (or null when none is set).
+func (s *Server) handleGetGoal(w http.ResponseWriter, _ *http.Request) {
+	if s.env == nil || s.env.GoalStore == nil {
+		writeJSON(w, http.StatusOK, nil)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.env.GoalStore.Get())
+}
+
+// handleSetGoal sets (or replaces) the session goal. Unless start=false, it also
+// kicks off an agent run so work begins immediately.
+func (s *Server) handleSetGoal(w http.ResponseWriter, r *http.Request) {
+	if s.env == nil || s.env.GoalStore == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "goals not available"})
+		return
+	}
+	var req struct {
+		Objective string `json:"objective"`
+		Start     *bool  `json:"start,omitempty"` // default true
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	objective, err := tools.ValidateGoalObjective(req.Objective)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	g := s.env.GoalStore.Set(objective)
+
+	if req.Start == nil || *req.Start {
+		// Start working immediately when idle; if busy, the continuation guard
+		// will pick the goal up after the current run finishes.
+		if s.running.CompareAndSwap(false, true) {
+			s.submitMessage(tools.GoalKickoffPrompt(objective), s.mode, "", "", nil)
+		}
+	}
+	writeJSON(w, http.StatusOK, g)
+}
+
+// handleClearGoal removes the session goal.
+func (s *Server) handleClearGoal(w http.ResponseWriter, _ *http.Request) {
+	if s.env != nil && s.env.GoalStore != nil {
+		s.env.GoalStore.Clear()
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "cleared"})
 }
 
 func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -803,7 +803,8 @@ func (s *Server) handleNewSession(w http.ResponseWriter, r *http.Request) {
 		st := session.ReconstructState(entries)
 		s.history = st.History
 		goalSnap = st.Goal
-		if s.todoStore != nil && len(st.Todos) > 0 {
+		// Always update (an empty list clears leftovers from the previous session).
+		if s.todoStore != nil {
 			updateTodos = true
 			todoItems = make([]tools.TodoItem, len(st.Todos))
 			for i, t := range st.Todos {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -8,6 +8,7 @@ import ChatMessageVue from '@/components/ChatMessage.vue'
 import ToolCallCard from '@/components/ToolCallCard.vue'
 import ApprovalBanner from '@/components/ApprovalBanner.vue'
 import TodoPanel from '@/components/TodoPanel.vue'
+import GoalBanner from '@/components/GoalBanner.vue'
 import ChatInput from '@/components/ChatInput.vue'
 import Sidebar from '@/components/Sidebar.vue'
 import SettingsDialog from '@/components/SettingsDialog.vue'
@@ -61,6 +62,7 @@ const { connected } = useWebSocket({
   onTokenUpdate: (data) => { store.tokenInfo = data },
   onAgentDone: (data) => store.agentDone(data?.error),
   onTodoUpdate: () => store.fetchTodos(),
+  onGoalUpdate: (data) => { store.goal = data },
   onApprovalRequest: (data) => store.addApprovalRequest(data),
   onSessionReset: () => store.clearChat(),
   onModelChanged: (data) => {
@@ -143,6 +145,7 @@ onMounted(async () => {
   }
   store.fetchConfig()
   store.fetchTodos()
+  store.fetchGoal()
   store.fetchModels()
   store.fetchModelState()
   store.fetchSessions()
@@ -193,6 +196,7 @@ function onSetupComplete() {
   // Now load everything
   store.fetchConfig()
   store.fetchTodos()
+  store.fetchGoal()
   store.fetchModels()
   store.fetchModelState()
   store.fetchSessions()
@@ -320,6 +324,7 @@ function startResize(e: MouseEvent) {
         </transition>
 
         <TodoPanel />
+        <GoalBanner />
         <ChatInput />
       </div>
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -186,6 +186,7 @@ async function onProjectSwitched() {
   await store.fetchHealth()
   store.clearChat()
   store.fetchTodos()
+  store.fetchGoal()
   store.fetchSessions()
   // Restore the current session for the new project
   await store.restoreCurrentSession()

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -302,7 +302,7 @@ watch(() => store.isRunning, (running) => {
           <textarea
             ref="textarea"
             v-model="input"
-            :placeholder="store.isRunning ? 'Agent is working…' : 'Ask JCODE, @agent, or /command'"
+            :placeholder="store.isRunning ? 'Agent is working…' : store.goalArmed ? 'Describe the goal — the agent pursues it until verifiably complete' : 'Ask JCODE, @agent, or /command'"
             rows="1"
             :disabled="store.isRunning"
             @keydown="handleKeyDown"
@@ -362,6 +362,16 @@ watch(() => store.isRunning, (running) => {
                 </button>
               </div>
             </div>
+
+            <!-- Goal toggle: arm the prompt box so the next message sets the session goal -->
+            <button
+              class="tool-btn dropdown-btn"
+              :class="{ highlighted: store.goalArmed }"
+              :title="store.goal ? 'Setting a new goal replaces the current one' : 'Next message becomes the session goal'"
+              @click="store.goalArmed = !store.goalArmed"
+            >
+              🎯 Goal
+            </button>
 
             <!-- Model selector -->
             <div class="relative">

--- a/web/src/components/GoalBanner.vue
+++ b/web/src/components/GoalBanner.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useChatStore } from '@/stores/chat'
+
+const store = useChatStore()
+
+const goal = computed(() => store.goal)
+
+const statusColor = computed(() => {
+  switch (goal.value?.status) {
+    case 'complete':
+      return 'var(--color-success-fg)'
+    case 'blocked':
+      return 'var(--color-destructive)'
+    default:
+      return 'var(--color-primary)'
+  }
+})
+
+const tokensLabel = computed(() => {
+  if (!goal.value) return ''
+  const used = goal.value.tokens_used ?? 0
+  if (used <= 0) return ''
+  return used < 1000 ? `${used} tokens` : `${(used / 1000).toFixed(1)}k tokens`
+})
+</script>
+
+<template>
+  <!-- Active goal display. Goals are set from the prompt box (🎯 Goal toggle
+       in the input toolbar, or the /goal command). -->
+  <div
+    v-if="goal"
+    class="mx-3 mt-2 rounded-md border px-3 py-2 flex items-start gap-2"
+    :style="{ borderColor: 'var(--color-border)', backgroundColor: 'var(--color-secondary)' }"
+  >
+    <span class="text-base leading-none" title="Session goal">🎯</span>
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center gap-2">
+        <span class="text-[10px] uppercase tracking-wide font-semibold" :style="{ color: statusColor }">
+          {{ goal.status }}
+        </span>
+        <span v-if="tokensLabel" class="text-[10px]" style="color: var(--color-muted-foreground)">
+          {{ tokensLabel }}
+        </span>
+      </div>
+      <div class="text-xs mt-0.5 break-words" style="color: var(--color-foreground)">
+        {{ goal.objective }}
+      </div>
+    </div>
+    <button
+      class="text-[10px] px-2 py-1 rounded shrink-0 cursor-pointer"
+      style="background-color: var(--color-background); color: var(--color-muted-foreground)"
+      title="Clear goal"
+      @click="store.clearGoal()"
+    >
+      Clear
+    </button>
+  </div>
+</template>

--- a/web/src/composables/api.ts
+++ b/web/src/composables/api.ts
@@ -1,5 +1,5 @@
 // API client for jcode backend
-import type { ModelsResponse, AgentMode, ExecResponse, DiffResponse, MCPListResponse, BrowseResponse, SSHListResponse, SkillInfo, SlashCommandInfo, TodoItem, SessionItem, SessionEntry, FileItem, SetupProvider, SetupModel, ProviderDetail, ModelStateResponse, ChatImage } from '@/types/api'
+import type { ModelsResponse, AgentMode, ExecResponse, DiffResponse, MCPListResponse, BrowseResponse, SSHListResponse, SkillInfo, SlashCommandInfo, TodoItem, Goal, SessionItem, SessionEntry, FileItem, SetupProvider, SetupModel, ProviderDetail, ModelStateResponse, ChatImage } from '@/types/api'
 
 const BASE = ''
 
@@ -39,6 +39,13 @@ export const api = {
     }>('/api/status'),
   config: () => request<{ provider: string; model: string; max_iterations: number }>('/api/config'),
   todos: () => request<TodoItem[]>('/api/todos'),
+  goal: () => request<Goal | null>('/api/goal'),
+  setGoal: (objective: string, start = true) =>
+    request<Goal>('/api/goal', {
+      method: 'POST',
+      body: JSON.stringify({ objective, start }),
+    }),
+  clearGoal: () => request<{ status: string }>('/api/goal', { method: 'DELETE' }),
   sessions: () => request<SessionItem[]>('/api/sessions'),
   session: (id: string) => request<SessionEntry[]>(`/api/sessions/${encodeURIComponent(id)}`),
   deleteSession: (id: string) =>

--- a/web/src/composables/ws.ts
+++ b/web/src/composables/ws.ts
@@ -9,6 +9,7 @@ import type {
   ApprovalRequestData,
   SubagentEventData,
   SubagentProgressData,
+  Goal,
 } from '@/types/api'
 
 type WSHandler = {
@@ -19,6 +20,7 @@ type WSHandler = {
   onTokenUpdate?: (data: TokenUpdateData) => void
   onAgentDone?: (data: AgentDoneData) => void
   onTodoUpdate?: () => void
+  onGoalUpdate?: (data: Goal | null) => void
   onApprovalRequest?: (data: ApprovalRequestData) => void
   onSessionReset?: (data: { session_id: string }) => void
   onModelChanged?: (data: { provider: string; model: string }) => void
@@ -49,6 +51,7 @@ export function useWebSocket(handlers: WSHandler) {
     token_update: (d) => handlers.onTokenUpdate?.(d),
     agent_done: (d) => handlers.onAgentDone?.(d),
     todo_update: () => handlers.onTodoUpdate?.(),
+    goal_update: (d) => handlers.onGoalUpdate?.(d),
     approval_request: (d) => handlers.onApprovalRequest?.(d),
     session_reset: (d) => handlers.onSessionReset?.(d),
     model_changed: (d) => handlers.onModelChanged?.(d),

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -7,6 +7,7 @@ import type {
   ToolCall,
   PendingApproval,
   TodoItem,
+  Goal,
   TokenUpdateData,
   SessionItem,
   AgentMode,
@@ -36,6 +37,10 @@ export const useChatStore = defineStore('chat', () => {
   // --- State ---
   const timeline = ref<TimelineItem[]>([])
   const todos = ref<TodoItem[]>([])
+  const goal = ref<Goal | null>(null)
+  // When armed (toggled from the input toolbar), the next message typed in the
+  // normal prompt box is submitted as the session goal instead of a chat message.
+  const goalArmed = ref(false)
   const sessions = ref<SessionItem[]>([])
   const isRunning = ref(false)
   const tokenInfo = ref<TokenUpdateData | null>(null)
@@ -223,6 +228,42 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   async function sendMessage(text: string, images?: ChatImage[]) {
+    const trimmed = text.trim()
+
+    // Goal-armed mode: the 🎯 toggle in the input toolbar arms the prompt box,
+    // and the next normal message becomes the session goal (slash commands
+    // still behave as commands).
+    if (goalArmed.value && trimmed && !trimmed.startsWith('/')) {
+      goalArmed.value = false
+      addMessage('user', text)
+      await setGoalObjective(trimmed)
+      return
+    }
+
+    // Intercept the /goal slash command so it manages the session goal instead
+    // of being sent to the model as a plain message. Grammar matches TUI/ACP:
+    // "" | "status" reports, "clear" removes, anything else sets the objective.
+    if (trimmed === '/goal' || trimmed.startsWith('/goal ')) {
+      const arg = trimmed.slice('/goal'.length).trim()
+      if (arg === '' || arg === 'status') {
+        await fetchGoal()
+        const g = goal.value
+        addMessage(
+          'system',
+          g ? `🎯 ${g.status} — ${g.objective}` : '🎯 No goal set. Use /goal <objective> to set one.',
+        )
+        return
+      }
+      if (arg === 'clear') {
+        await clearGoal()
+        addMessage('system', '🎯 Goal cleared.')
+        return
+      }
+      addMessage('user', text)
+      await setGoalObjective(arg)
+      return
+    }
+
     addMessage('user', text, undefined, images)
     isRunning.value = true
     streamingText = ''
@@ -305,6 +346,34 @@ export const useChatStore = defineStore('chat', () => {
       todos.value = await api.todos()
     } catch (err) {
       console.error('Failed to fetch todos:', err)
+    }
+  }
+
+  async function fetchGoal() {
+    try {
+      goal.value = await api.goal()
+    } catch (err) {
+      console.error('Failed to fetch goal:', err)
+    }
+  }
+
+  // setGoalObjective sets a new session goal. The backend starts working toward
+  // it immediately, so reflect the running state locally.
+  async function setGoalObjective(objective: string) {
+    try {
+      goal.value = await api.setGoal(objective, true)
+      isRunning.value = true
+    } catch (err: unknown) {
+      addMessage('system', err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  async function clearGoal() {
+    try {
+      await api.clearGoal()
+      goal.value = null
+    } catch (err) {
+      console.error('Failed to clear goal:', err)
     }
   }
 
@@ -700,6 +769,8 @@ export const useChatStore = defineStore('chat', () => {
     // State
     timeline,
     todos,
+    goal,
+    goalArmed,
     sessions,
     isRunning,
     tokenInfo,
@@ -738,6 +809,9 @@ export const useChatStore = defineStore('chat', () => {
     deleteSession,
     newSession,
     fetchTodos,
+    fetchGoal,
+    setGoalObjective,
+    clearGoal,
     fetchConfig,
     fetchHealth,
     fetchModels,

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -450,6 +450,8 @@ export const useChatStore = defineStore('chat', () => {
   function clearChat() {
     timeline.value = []
     todos.value = []
+    goal.value = null
+    goalArmed.value = false
     tokenInfo.value = null
     streamingText = ''
     streamingMsgId = ''
@@ -707,6 +709,9 @@ export const useChatStore = defineStore('chat', () => {
       currentSessionId.value = resp.session_id || uuid
 
       clearChat()
+      // The backend restored the session's goal — refresh explicitly in case
+      // the goal_update WS push is missed.
+      fetchGoal()
 
       // Track pending tool calls by tool_call_id so we can match results
       const pendingToolCalls = new Map<string, ToolCall>()

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -79,6 +79,16 @@ export interface FileItem {
   size: number
 }
 
+export type GoalStatus = 'active' | 'complete' | 'blocked'
+
+export interface Goal {
+  objective: string
+  status: GoalStatus
+  tokens_used: number
+  created_at: number
+  updated_at: number
+}
+
 export interface FileContent {
   path: string
   content: string


### PR DESCRIPTION
## What

Adds a codex-style **session goal**: a persistent objective the agent keeps working toward across turns — auto-continuing when it would otherwise stop — until it verifiably completes it, marks it blocked, or hits the 25-continuation safety cap.

- **Core** (`internal/tools/goal.go`): `Goal`/`GoalStore` (mirrors `TodoStore`, held on `Env`), model-facing tools `goal_set` / `goal_get` / `goal_update`, and the shared `/goal` grammar + helpers (`ParseGoalCommand`, `GoalKickoffPrompt`, `ValidateGoalObjective`, `GoalRecorderHook`, `RestoreFromSnapshot`) used by all three frontends — one parser, one kickoff prompt, one validation rule.
- **Runner** (`internal/runner/runner.go`): after the todo guard, a goal-continuation loop injects `ContinuationPrompt()` while the goal is active. Each continuation appends only the per-turn assistant **delta** to the message list, not the accumulated response, so the context does not grow quadratically across continuations (the pre-existing todo guard had the same pattern and is fixed too).
- **Steering**: reminder middleware injects the active objective into every model call so the agent never loses the goal.
- **Persistence**: `goal_update` session entries; the goal is restored on **every** resume path (TUI `/resume`, CLI `--resume`, ACP `session/load` + `session/resume`, web session switch), and a new web session resets the store so a stale goal cannot leak across sessions and trigger autonomous runs.
- **TUI**: `/goal <objective> | status | clear` plus a 🎯 indicator above the input. Setting a goal mid-run defers to the in-flight run's continuation guard instead of writing to the capacity-1 prompt channel (which could block the Bubble Tea update loop).
- **Web**: `GET/POST/DELETE /api/goal`, `goal_update` WS events, a banner for the active goal, and a **🎯 Goal toggle in the input toolbar** that arms the prompt box — the next message you send becomes the goal (codex-style UX). `/goal …` in the chat box works too.
- **ACP**: `goal` advertised via `available_commands_update`; `status`/`clear` are answered locally from the store without spending an agent run (a status query must not trigger auto-continuation).

## Why

For substantial multi-step work ("make all tests in X pass", "migrate this module"), the agent should drive itself to a verifiable end state instead of returning control after every turn. Completion is checked against real project state (`goal_update` is only to be called with evidence), mirroring codex's thread-goal behavior.

## Notes for review

- **Deliberately no token budget.** Goals are bounded only by the 25-continuation turn cap and user cancellation (Esc / `/goal clear`). `tokens_used` on the goal is informational display only; `RecordTokens` never changes goal status. An earlier iteration had a budget mechanism and it was intentionally removed — counting tokens to gate a goal adds complexity without a meaningful safety benefit beyond the turn cap.
- Web and ACP now pass a `TokenUsage` tracker into `runner.Run` (previously only the TUI did); it feeds the usage display and token-update events.
- Web session resume now goes through `session.ReconstructState` (instead of `ReconstructHistory`), which also makes compacted sessions resume correctly in the web UI, consistent with CLI/ACP.
- Docs: `docs/goal.md` (user guide), `/goal` added to `docs/commands.md`.
- Tests: store lifecycle/usage accounting, shared parser/validation, TUI dispatch (including the set-while-running case), web HTTP handlers (in-process httptest), session state reconstruction. `go test ./...` green; `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session goals via `/goal` across web and terminal: set, view, clear, mark complete/blocked; optional kickoff to start agent continuation (bounded).
  * UI updates: goal banner, goal-armed toggle, token usage and status shown in chat UI.

* **Documentation**
  * Added `/goal` command docs and a full goal usage guide.

* **Tests**
  * Added unit and integration tests covering goal store, tools, TUI, runner, session replay, and web API lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->