### PR TITLE
feat: support 1M-context models and adaptive window-size management

### DIFF
--- a/docs/model-research.md
+++ b/docs/model-research.md
@@ -1,0 +1,134 @@
+# Long-Context Model Research & Window-Size Management
+
+> Last researched: **2026-06-13**. This file is the cached result of a per-provider
+> survey of long-context (≈1M token) models so we don't have to re-research every
+> time the model lineup shifts. Referenced from `internal/model/registry.go` and
+> `internal/model/chatmodel.go`.
+
+## TL;DR — corrections to common assumptions
+
+| Claim | Reality (2026-06) |
+|-------|-------------------|
+| "Kimi K2.7 supports 1M context" | ❌ **256K** (262,144). Moonshot's K2.6 and K2.7-Code are both 256K. |
+| "GLM-5.2 is out with 1M context" | ✅ **Confirmed 2026-06-13.** Official Z.ai DevPack config publishes `contextWindow: 1000000, maxTokens: 131072`. Not on models.dev/aggregators yet → injected via `additionalModels`. (GLM-5/5.1 remain ~200K.) |
+| "MiniMax-M3 is 1M context" | ✅ **Yes, 1,048,576.** But models.dev records only **512K** (the *guaranteed minimum*), which under-sized our window management. Corrected via override. |
+| "DeepSeek-V4-Pro is 1M context" | ✅ **Yes, 1,000,000.** Already correct in the registry. |
+| "Qwen 3.6 Plus is the latest Alibaba flagship" | ⚠️ Superseded — **Qwen 3.7 Max / 3.7 Plus** (both 1M) shipped May–Jun 2026. |
+
+## Per-provider survey
+
+Context = max input window in tokens. Values are from the **models.dev** registry
+(regenerated into `registry_generated.go`) unless noted. "Recommended" = what jcode
+now flags as recommended + default-enabled (see `recommendedModels` in `registry.go`).
+
+### MiniMax
+| Model | Context | Max output | Notes |
+|-------|---------|-----------|-------|
+| **MiniMax-M3** ⭐ | **1,000,000** (advertised; 512K guaranteed min) | 128K | MSA sparse attention, multimodal (text/image/video), released 2026-06-01. models.dev lists 512K → **overridden to 1M** in `contextLimitOverrides`. |
+| MiniMax-M2.7 | 204,800 | — | Prior gen. |
+
+Pricing (M3): ~$0.60/M input, $2.40/M output (models.dev); long-context tier above 512K.
+
+### Moonshot (Kimi)
+| Model | Context | Notes |
+|-------|---------|-------|
+| **kimi-k2.7-code** ⭐ | **262,144** (256K) | Newest coding model, released 2026-06-12, ~30% fewer reasoning tokens than K2.6. **Not** a 1M model. |
+| kimi-k2.6 | 262,144 | Multimodal agentic, released 2026-04-20. |
+
+### Zhipu / Z.ai (GLM)
+| Model | Context | Max output | Notes |
+|-------|---------|-----------|-------|
+| **glm-5.2** ⭐ | **1,000,000** | 131,072 | Released 2026-06-13 to GLM Coding Plan users (Lite/Pro/Max/Team). Official Z.ai DevPack config: `contextWindow: 1000000, maxTokens: 131072`. Full 1M needs the **`glm-5.2[1m]`** variant. Standalone API + MIT open weights "next week". **Not on models.dev yet** → injected via `additionalModels` on `zhipuai`, `zhipuai-coding-plan`, `zai`, `zai-coding-plan`. |
+| glm-5.1 | ~200,000 | 128K | models.dev (zhipuai 200K, alibaba 202,752), released 2026-04. |
+| glm-5 | ~200,000 | — | Released 2026-02-11. |
+
+> GLM-5.2's spec rests on the official Z.ai DevPack page (`docs.z.ai/devpack/latest-model`),
+> not marketing — verified 2026-06-13 across the official dev-letter ("致开发者：GLM-5.2 全量开放",
+> "支持真正可用的 1M 上下文") and 6+ outlets. When models.dev finally lists GLM-5.2, the
+> `additionalModels` merge auto-defers to the official record (skips if already present).
+
+### DeepSeek
+| Model | Context | Notes |
+|-------|---------|-------|
+| **deepseek-v4-pro** ⭐ | **1,000,000** | 1.6T params MoE, CSA+HCA hybrid attention, released 2026-04-24. Genuine 1M. |
+| deepseek-v4-flash | 1,000,000 | Cheaper sibling. |
+
+### Alibaba (Qwen)
+| Model | Context | Notes |
+|-------|---------|-------|
+| **qwen3.7-plus** ⭐ | **1,000,000** | Multimodal agent, released Jun 2026. |
+| **qwen3.7-max** ⭐ | **1,000,000** | Flagship reasoning, released 2026-05-20 (3.6-max was 256K). ~$2.50/$7.50 per M. |
+| qwen3.6-plus | 1,000,000 | Prior gen (still 1M). |
+
+### Frontier (for reference; recommended bumped to current gen)
+| Provider | Recommended (was → now) | Context |
+|----------|------------------------|---------|
+| OpenAI | gpt-4.1 → **gpt-5.5** | ~1,050,000 |
+| Anthropic | claude-sonnet-4-20250514 → **claude-opus-4-8 + claude-sonnet-4-6** | 1,000,000 each |
+| Google | gemini-2.5-pro → **gemini-3.1-pro-preview** | ~1,048,576 |
+
+## How jcode manages the context window
+
+### Resolution — single source of truth
+All window sizing flows through **`model.ResolveContextLimit(reg, cfg, provider, model)`**
+(`internal/model/context_limit.go`). Order, first positive hit wins:
+
+1. **User override** — `config.ContextLimits["provider/model"]`, then `["model"]`
+2. **models.dev registry** — `reg.GetModelContextLimit(...)` (+ hand overrides at init)
+3. **Built-in fallback** — `knownModels` table in `chatmodel.go` (offline safety net)
+4. **`config.DefaultContextLimit`**, else `DefaultContextLimitFallback` (200000)
+
+This replaced 5 copy-pasted `registry → knownModels → 200000` blocks
+(interactive / acp / web / runner), which was why unknown 1M models silently got
+throttled to a 200K window.
+
+### Thresholds derive from the resolved limit
+The middleware stack scales off the resolved limit × a configurable fraction
+(`config.CompactionThreshold()`, default **0.75**):
+
+- **summarization** trigger: `limit × compactThreshold`
+- **reduction** (lighter, earlier tool-output clearing): `limit × (compactThreshold − 0.15)`
+- **compaction** strategy: `limit × compactThreshold`
+- **reminders**: warn at 85% (`internal/prompts/reminders.go`)
+
+Set `compaction.threshold` in config to change when compaction kicks in (was a dead
+config field before — now wired).
+
+### Correcting / teaching a window without code changes
+```jsonc
+// ~/.jcode/config.json
+{
+  "context_limits": {
+    "minimax/MiniMax-M3": 1000000,   // override a specific provider/model
+    "my-1m-model": 1000000           // or a bare model id
+  },
+  "default_context_limit": 200000,   // floor for models we can't identify
+  "compaction": { "threshold": 0.8 } // compact at 80% instead of 75%
+}
+```
+For a fully custom model also add it under `providers.<id>.custom_models` with its
+`context` so it shows up in the picker.
+
+### Built-in overrides that survive regeneration
+`registry_generated.go` is rebuilt from models.dev via `go generate ./internal/model`
+(`script/generate_models.go`) and is **DO NOT EDIT**. Hand-maintained corrections live
+in `registry.go` and re-apply at `init()`:
+
+- `additionalModels` — injects models that shipped before their models.dev record
+  (currently GLM-5.2 on the four first-party Zhipu/Z.ai providers). Merge-only: skipped
+  if the provider already defines that id, so the official record wins once it lands.
+- `contextLimitOverrides` — fixes under-reported windows (currently MiniMax-M3 → 1M).
+- `recommendedModels` — which models get the ⭐ recommended/default-enabled flag.
+
+When refreshing the registry, re-check this doc's table and prune/extend those two
+maps. Model IDs must match the registry exactly or the override is silently ignored
+(guarded by `TestRecommendedFlagshipsAreLongContext`).
+
+## Sources
+- [MiniMax M3 (official)](https://www.minimax.io/models/text/m3), [MarkTechPost](https://www.marktechpost.com/2026/06/01/minimax-releases-minimax-m3-with-msa-architecture-supporting-1m-token-context-native-multimodality-and-agentic-coding/)
+- [Kimi K2.7-Code (MarkTechPost)](https://www.marktechpost.com/2026/06/12/moonshot-ai-releases-kimi-k2-7-code-a-coding-model-reporting-21-8-on-kimi-code-bench-v2-over-k2-6/), [Kimi K2.6 (llm-stats)](https://llm-stats.com/models/kimi-k2.6)
+- [DeepSeek-V4 (HF blog)](https://huggingface.co/blog/deepseekv4), [DeepSeek V4 Pro (Together)](https://www.together.ai/models/deepseek-v4-pro)
+- [Qwen 3.7 Max (MarkTechPost)](https://www.marktechpost.com/2026/05/21/qwen-introduces-qwen3-7-max-a-reasoning-agent-model-with-a-1m-token-context-window/), [Qwen 3.6 Plus (llm-stats)](https://llm-stats.com/models/qwen3.6-plus)
+- [GLM-5 (HF blog)](https://huggingface.co/blog/mlabonne/glm-5), [GLM-5 (llm-stats)](https://llm-stats.com/models/glm-5)
+- GLM-5.2: [Z.ai DevPack config (official)](https://docs.z.ai/devpack/latest-model), [Z.ai announcement (X)](https://x.com/Zai_org/status/2065704919299235870), [系统极客](https://www.sysgeek.cn/glm-5-2-for-glm-coding-plan/), [新浪财经](https://finance.sina.com.cn/tech/roll/2026-06-13/doc-inicfzuq9552659.shtml)
+- Registry data: [models.dev](https://models.dev/api.json)

--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -421,12 +421,11 @@ func (a *acpAgent) buildAgentSession(
 	}
 
 	// Build agent with middlewares
-	contextLimit := registry.GetModelContextLimit(providerName, modelName)
-	if contextLimit <= 0 {
-		contextLimit = internalmodel.GetModelContextLimit(modelName)
-	}
-	if contextLimit <= 0 {
-		contextLimit = 200000
+	contextLimit := internalmodel.ResolveContextLimit(registry, cfg, providerName, modelName)
+	compactThreshold := cfg.CompactionThreshold()
+	reductionThreshold := compactThreshold - 0.15
+	if reductionThreshold < 0.1 {
+		reductionThreshold = compactThreshold * 0.8
 	}
 
 	var handlers []adk.ChatModelAgentMiddleware
@@ -434,7 +433,7 @@ func (a *acpAgent) buildAgentSession(
 	summMw, err := summarization.New(ctx, &summarization.Config{
 		Model: chatModel,
 		Trigger: &summarization.TriggerCondition{
-			ContextTokens: int(float64(contextLimit) * 0.75),
+			ContextTokens: int(float64(contextLimit) * compactThreshold),
 		},
 		TranscriptFilePath: filepath.Join(config.ConfigDir(), "transcript.txt"),
 	})
@@ -447,7 +446,7 @@ func (a *acpAgent) buildAgentSession(
 		Backend:           reductionBackend,
 		RootDir:           filepath.Join(config.ConfigDir(), "reduction"),
 		MaxLengthForTrunc: 50000,
-		MaxTokensForClear: int64(float64(contextLimit) * 0.60),
+		MaxTokensForClear: int64(float64(contextLimit) * reductionThreshold),
 		ReadFileToolName:  "read",
 		ToolConfig: map[string]*reduction.ToolReductionConfig{
 			"read": {SkipClear: true},

--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -157,18 +157,19 @@ func (s *interactiveState) createAgent() (*adk.ChatModelAgent, error) {
 	var handlers []adk.ChatModelAgentMiddleware
 
 	providerName, modelName := s.cfg.GetProviderModel()
-	contextLimit := s.registry.GetModelContextLimit(providerName, modelName)
-	if contextLimit <= 0 {
-		contextLimit = internalmodel.GetModelContextLimit(modelName)
-	}
-	if contextLimit <= 0 {
-		contextLimit = 200000
+	contextLimit := internalmodel.ResolveContextLimit(s.registry, s.cfg, providerName, modelName)
+	// compactThreshold drives summarization + compaction; reductionThreshold (the
+	// lighter, earlier tool-output clearing) sits just below it.
+	compactThreshold := s.cfg.CompactionThreshold()
+	reductionThreshold := compactThreshold - 0.15
+	if reductionThreshold < 0.1 {
+		reductionThreshold = compactThreshold * 0.8
 	}
 
 	summMw, err := summarization.New(s.ctx, &summarization.Config{
 		Model: s.chatModel,
 		Trigger: &summarization.TriggerCondition{
-			ContextTokens: int(float64(contextLimit) * 0.75),
+			ContextTokens: int(float64(contextLimit) * compactThreshold),
 		},
 		TranscriptFilePath: filepath.Join(config.ConfigDir(), "transcript.txt"),
 		Finalize: func(ctx context.Context, originalMsgs []adk.Message, summary adk.Message) ([]adk.Message, error) {
@@ -200,7 +201,7 @@ func (s *interactiveState) createAgent() (*adk.ChatModelAgent, error) {
 		Backend:           reductionBackend,
 		RootDir:           filepath.Join(config.ConfigDir(), "reduction"),
 		MaxLengthForTrunc: 50000,
-		MaxTokensForClear: int64(float64(contextLimit) * 0.60),
+		MaxTokensForClear: int64(float64(contextLimit) * reductionThreshold),
 		ReadFileToolName:  "read",
 		TruncExcludeTools: []string{"ask_user", "load_skill"},
 		ToolConfig: map[string]*reduction.ToolReductionConfig{
@@ -236,7 +237,7 @@ func (s *interactiveState) createAgent() (*adk.ChatModelAgent, error) {
 	}
 
 	// Wire up compaction middleware (per-agent tracker).
-	compactionStrategy := agent.NewThresholdCompactionStrategy(0.75, s.chatModel, 6)
+	compactionStrategy := agent.NewThresholdCompactionStrategy(compactThreshold, s.chatModel, 6)
 	compactionMw := agent.NewCompactionMiddleware(compactionStrategy, contextLimit, s.agentTokenUsage, func(savedTokens int) {
 		if s.agentTokenUsage != nil {
 			s.agentTokenUsage.Reset()

--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -218,10 +218,16 @@ func runWebServer(port int, host string, openBrowser bool) error {
 
 		var handlers []adk.ChatModelAgentMiddleware
 
+		compactThreshold := cfg.CompactionThreshold()
+		reductionThreshold := compactThreshold - 0.15
+		if reductionThreshold < 0.1 {
+			reductionThreshold = compactThreshold * 0.8
+		}
+
 		summMw, err := summarization.New(ctx, &summarization.Config{
 			Model: cm,
 			Trigger: &summarization.TriggerCondition{
-				ContextTokens: int(float64(ctxLimit) * 0.75),
+				ContextTokens: int(float64(ctxLimit) * compactThreshold),
 			},
 			TranscriptFilePath: filepath.Join(config.ConfigDir(), "transcript.txt"),
 		})
@@ -234,7 +240,7 @@ func runWebServer(port int, host string, openBrowser bool) error {
 			Backend:           reductionBackend,
 			RootDir:           filepath.Join(config.ConfigDir(), "reduction"),
 			MaxLengthForTrunc: 50000,
-			MaxTokensForClear: int64(float64(ctxLimit) * 0.60),
+			MaxTokensForClear: int64(float64(ctxLimit) * reductionThreshold),
 			ReadFileToolName:  "read",
 			ToolConfig: map[string]*reduction.ToolReductionConfig{
 				"read": {SkipClear: true},
@@ -292,13 +298,7 @@ func runWebServer(port int, host string, openBrowser bool) error {
 			return nil, fmt.Errorf("create model %s/%s: %w", prov, mod, err)
 		}
 
-		ctxLimit := registry.GetModelContextLimit(prov, mod)
-		if ctxLimit <= 0 {
-			ctxLimit = internalmodel.GetModelContextLimit(mod)
-		}
-		if ctxLimit <= 0 {
-			ctxLimit = 200000
-		}
+		ctxLimit := internalmodel.ResolveContextLimit(registry, currentCfg, prov, mod)
 
 		currentCM = cm
 		currentCtxLimit = ctxLimit

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,6 +114,14 @@ type Config struct {
 	// SmallModel for lightweight tasks (summaries, compaction) in "provider/model" format
 	SmallModel string `json:"small_model,omitempty"`
 
+	// ContextLimits overrides the resolved context window (in tokens) for a model.
+	// Keys may be "provider/model" (preferred) or a bare model id. Use this to teach
+	// jcode the window of a brand-new or custom model the registry doesn't know yet.
+	ContextLimits map[string]int `json:"context_limits,omitempty"`
+	// DefaultContextLimit is the fallback context window (in tokens) assumed when a
+	// model's limit is unknown from the registry and built-in tables. Defaults to 200000.
+	DefaultContextLimit int `json:"default_context_limit,omitempty"`
+
 	// Deprecated: use Model field with "provider/model" format instead.
 	Provider string `json:"provider,omitempty"`
 
@@ -168,6 +176,15 @@ func (c *Config) GetProviderModel() (provider, model string) {
 	}
 	// Legacy fallback
 	return c.Provider, c.Model
+}
+
+// CompactionThreshold returns the configured fraction (0-1) of the context window
+// at which automatic compaction/summarization triggers, or 0.75 when unset/invalid.
+func (c *Config) CompactionThreshold() float64 {
+	if c != nil && c.Compaction != nil && c.Compaction.Threshold > 0 && c.Compaction.Threshold <= 1 {
+		return c.Compaction.Threshold
+	}
+	return 0.75
 }
 
 func splitProviderModel(s string) []string {

--- a/internal/model/chatmodel.go
+++ b/internal/model/chatmodel.go
@@ -460,6 +460,26 @@ var knownModels = map[string]knownModel{
 	"mistral-large":    {128000, 0, 0},
 	"gemini-1.5-pro":   {1000000, 1.25, 5.00},
 	"gemini-1.5-flash": {1000000, 0.075, 0.30},
+	// 2026 long-context flagships (offline fallback when the models.dev registry
+	// is unavailable). Context windows verified against vendor docs / models.dev;
+	// see docs/model-research.md. Pricing left 0 where not confidently known.
+	"MiniMax-M3":             {1000000, 0.60, 2.40},
+	"minimax-m3":             {1000000, 0.60, 2.40},
+	"deepseek-v4-pro":        {1000000, 0, 0},
+	"deepseek-v4-flash":      {1000000, 0, 0},
+	"qwen3.7-max":            {1000000, 2.50, 7.50},
+	"qwen3.7-plus":           {1000000, 0, 0},
+	"qwen3.6-plus":           {1000000, 0, 0},
+	"kimi-k2.6":              {262144, 0, 0},
+	"kimi-k2.7-code":         {262144, 0, 0},
+	"glm-5":                  {200000, 0, 0},
+	"glm-5.1":                {200000, 0, 0},
+	"glm-5.2":                {1000000, 0, 0}, // user-reported 1M; official docs pending
+	"gpt-5.5":                {1050000, 0, 0},
+	"claude-opus-4-8":        {1000000, 0, 0},
+	"claude-sonnet-4-6":      {1000000, 0, 0},
+	"gemini-3.1-pro-preview": {1048576, 0, 0},
+	"gemini-3.5-flash":       {1048576, 0, 0},
 }
 
 // knownModelContextLimits is kept for backward compatibility.

--- a/internal/model/context_limit.go
+++ b/internal/model/context_limit.go
@@ -1,0 +1,45 @@
+package model
+
+import "github.com/cnjack/jcode/internal/config"
+
+// DefaultContextLimitFallback is the conservative context window assumed when a
+// model's true limit cannot be determined from the registry, built-in tables, or
+// user config. Kept deliberately small so unknown models compact early rather than
+// overflowing the provider's real window. Override per-model via config.ContextLimits
+// or globally via config.DefaultContextLimit.
+const DefaultContextLimitFallback = 200000
+
+// ResolveContextLimit determines the effective context window (in tokens) for a
+// provider/model pair. This is the single source of truth for window-size
+// management — all middleware thresholds (compaction, summarization, reduction,
+// reminders) derive from it.
+//
+// Resolution order (first positive hit wins):
+//  1. explicit user override: cfg.ContextLimits["provider/model"], then cfg.ContextLimits["model"]
+//  2. models.dev registry metadata (reg.GetModelContextLimit)
+//  3. built-in knownModels fallback table (GetModelContextLimit)
+//  4. cfg.DefaultContextLimit, else DefaultContextLimitFallback
+//
+// reg and cfg may be nil; the resolver degrades gracefully.
+func ResolveContextLimit(reg *ModelRegistry, cfg *config.Config, providerID, modelID string) int {
+	if cfg != nil && len(cfg.ContextLimits) > 0 {
+		if v, ok := cfg.ContextLimits[providerID+"/"+modelID]; ok && v > 0 {
+			return v
+		}
+		if v, ok := cfg.ContextLimits[modelID]; ok && v > 0 {
+			return v
+		}
+	}
+	if reg != nil {
+		if v := reg.GetModelContextLimit(providerID, modelID); v > 0 {
+			return v
+		}
+	}
+	if v := GetModelContextLimit(modelID); v > 0 {
+		return v
+	}
+	if cfg != nil && cfg.DefaultContextLimit > 0 {
+		return cfg.DefaultContextLimit
+	}
+	return DefaultContextLimitFallback
+}

--- a/internal/model/context_limit_test.go
+++ b/internal/model/context_limit_test.go
@@ -1,0 +1,121 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/cnjack/jcode/internal/config"
+)
+
+func TestResolveContextLimit(t *testing.T) {
+	reg := NewModelRegistry()
+
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		provider string
+		model    string
+		want     int
+	}{
+		{
+			name:     "config override provider/model wins over registry",
+			cfg:      &config.Config{ContextLimits: map[string]int{"minimax/MiniMax-M3": 2_000_000}},
+			provider: "minimax", model: "MiniMax-M3", want: 2_000_000,
+		},
+		{
+			name:     "config override bare model id",
+			cfg:      &config.Config{ContextLimits: map[string]int{"my-model": 333_000}},
+			provider: "custom", model: "my-model", want: 333_000,
+		},
+		{
+			name:     "registry value used (MiniMax-M3 corrected to 1M)",
+			cfg:      nil,
+			provider: "minimax", model: "MiniMax-M3", want: 1_000_000,
+		},
+		{
+			name:     "knownModels fallback when registry misses",
+			cfg:      nil,
+			provider: "unknown-provider", model: "gpt-4o", want: 128_000,
+		},
+		{
+			name:     "cfg.DefaultContextLimit used when everything else misses",
+			cfg:      &config.Config{DefaultContextLimit: 512_000},
+			provider: "nope", model: "totally-unknown-model", want: 512_000,
+		},
+		{
+			name:     "hard fallback when nothing known",
+			cfg:      nil,
+			provider: "nope", model: "totally-unknown-model", want: DefaultContextLimitFallback,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveContextLimit(reg, tt.cfg, tt.provider, tt.model)
+			if got != tt.want {
+				t.Errorf("ResolveContextLimit(%q,%q) = %d, want %d", tt.provider, tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMiniMaxM3ContextOverride guards the headline correction: models.dev records
+// MiniMax-M3 at the 512K guaranteed minimum, but its advertised window is 1M.
+func TestMiniMaxM3ContextOverride(t *testing.T) {
+	reg := NewModelRegistry()
+	for _, prov := range []string{"minimax", "minimax-coding-plan"} {
+		if got := reg.GetModelContextLimit(prov, "MiniMax-M3"); got != 1_000_000 {
+			t.Errorf("%s/MiniMax-M3 context = %d, want 1000000", prov, got)
+		}
+	}
+}
+
+// TestGLM52Injected guards that GLM-5.2 (released before its models.dev record)
+// is merged into the first-party Zhipu/Z.ai providers with a 1M window.
+func TestGLM52Injected(t *testing.T) {
+	reg := NewModelRegistry()
+	for _, prov := range []string{"zhipuai", "zhipuai-coding-plan", "zai", "zai-coding-plan"} {
+		_, m, ok := reg.LookupModel(prov, "glm-5.2")
+		if !ok || m == nil {
+			t.Errorf("%s/glm-5.2 not found", prov)
+			continue
+		}
+		if got := reg.GetModelContextLimit(prov, "glm-5.2"); got != 1_000_000 {
+			t.Errorf("%s/glm-5.2 context = %d, want 1000000", prov, got)
+		}
+		if !m.Recommended || !m.DefaultEnabled {
+			t.Errorf("%s/glm-5.2 should be Recommended + DefaultEnabled", prov)
+		}
+	}
+}
+
+// TestRecommendedFlagshipsAreLongContext checks the recommended flagships exist in
+// the registry and expose large windows, so the resolver doesn't throttle them.
+func TestRecommendedFlagshipsAreLongContext(t *testing.T) {
+	reg := NewModelRegistry()
+	cases := []struct {
+		provider, model string
+		minContext      int
+	}{
+		{"minimax", "MiniMax-M3", 1_000_000},
+		{"deepseek", "deepseek-v4-pro", 1_000_000},
+		{"alibaba-cn", "qwen3.7-plus", 1_000_000},
+		{"anthropic", "claude-opus-4-8", 1_000_000},
+		{"openai", "gpt-5.5", 1_000_000},
+		{"google", "gemini-3.1-pro-preview", 1_000_000},
+		{"zhipuai", "glm-5.2", 1_000_000},
+		{"zai", "glm-5.2", 1_000_000},
+	}
+	for _, c := range cases {
+		_, m, ok := reg.LookupModel(c.provider, c.model)
+		if !ok || m == nil {
+			t.Errorf("recommended model %s/%s not found in registry", c.provider, c.model)
+			continue
+		}
+		if !m.Recommended {
+			t.Errorf("%s/%s should be flagged Recommended", c.provider, c.model)
+		}
+		if got := reg.GetModelContextLimit(c.provider, c.model); got < c.minContext {
+			t.Errorf("%s/%s context = %d, want >= %d", c.provider, c.model, got, c.minContext)
+		}
+	}
+}

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -313,50 +313,113 @@ func sortModels(models []*RegistryModel) {
 
 // recommendedModels defines recommended and default-enabled models per provider.
 // Key: provider ID, Value: map of model ID → true (recommended + default enabled).
+//
+// Curated 2026-06-13 toward the current long-context flagships. See
+// docs/model-research.md for the per-provider context-window survey behind these
+// picks. Model IDs must match the registry exactly or the flag is silently ignored.
 var recommendedModels = map[string]map[string]bool{
+	// GLM-5.2 (1M window) is Zhipu's newest, injected via additionalModels since
+	// it predates its models.dev record. GLM-5.1 stays selectable but unstarred.
 	"zhipuai": {
-		"glm-5.1": true,
-		"glm-5":   true,
+		"glm-5.2": true,
 	},
 	"zhipuai-coding-plan": {
-		"glm-5.1": true,
-		"glm-5":   true,
+		"glm-5.2": true,
 	},
+	"zai": {
+		"glm-5.2": true,
+	},
+	"zai-coding-plan": {
+		"glm-5.2": true,
+	},
+	// DeepSeek-V4-Pro — genuine 1M-token window.
 	"deepseek": {
 		"deepseek-v4-pro": true,
 	},
+	// Qwen 3.7 Plus/Max and DeepSeek-V4-Pro all carry 1M windows on Alibaba's
+	// endpoint; Kimi-K2.6 (256K) rounds out the agentic options.
 	"alibaba-cn": {
-		"qwen3.6-plus":         true,
-		"MiniMax/MiniMax-M2.7": true,
-		"deepseek-v3-2-exp":    true,
-		"kimi-k2.6":            true,
+		"qwen3.7-plus":    true,
+		"qwen3.7-max":     true,
+		"deepseek-v4-pro": true,
+		"kimi-k2.6":       true,
 	},
 	"alibaba-coding-plan-cn": {
-		"qwen3.6-plus": true,
+		"qwen3.7-plus": true,
 	},
+	// Kimi-K2.7-Code is Moonshot's newest coding model (256K window).
 	"moonshotai": {
-		"kimi-k2.6": true,
+		"kimi-k2.7-code": true,
 	},
+	// MiniMax-M3 — 1M-token window (corrected via contextLimitOverrides below).
 	"minimax": {
-		"MiniMax-M2.7": true,
+		"MiniMax-M3": true,
 	},
 	"minimax-coding-plan": {
-		"MiniMax-M2.7": true,
+		"MiniMax-M3": true,
 	},
+	// GPT-5.5 carries a ~1.05M window.
 	"openai": {
-		"gpt-4.1": true,
-		"o4-mini": true,
+		"gpt-5.5": true,
 	},
+	// Claude Opus 4.8 and Sonnet 4.6 both expose 1M-token windows.
 	"anthropic": {
-		"claude-sonnet-4-20250514": true,
+		"claude-opus-4-8":   true,
+		"claude-sonnet-4-6": true,
 	},
+	// Gemini 3.1 Pro — ~1.05M window.
 	"google": {
-		"gemini-2.5-pro": true,
+		"gemini-3.1-pro-preview": true,
 	},
+}
+
+// contextLimitOverrides corrects context windows for built-in models whose
+// models.dev-sourced value understates the model's advertised window. Applied at
+// init() so corrections survive `go generate` regeneration of registry_generated.go.
+// Key: provider ID → model ID → context window (tokens). See docs/model-research.md.
+var contextLimitOverrides = map[string]map[string]int{
+	// MiniMax-M3 advertises a 1M-token window; models.dev records only the
+	// 512K "guaranteed minimum". Use the advertised window for sizing.
+	"minimax":             {"MiniMax-M3": 1_000_000},
+	"minimax-coding-plan": {"MiniMax-M3": 1_000_000},
+}
+
+// glm52Model builds a fresh GLM-5.2 entry. Returns a new object per call so each
+// provider gets its own instance (deep-copied again per ModelRegistry).
+//
+// GLM-5.2 shipped 2026-06-13 to GLM Coding Plan users but isn't on models.dev yet
+// (the standalone API / open weights land later), so it can't come through
+// registry_generated.go. Spec confirmed from the official Z.ai DevPack config
+// ("contextWindow": 1000000, "maxTokens": 131072). The full 1M window requires the
+// "glm-5.2[1m]" variant on the Coding Plan endpoint. See docs/model-research.md.
+func glm52Model() *RegistryModel {
+	return &RegistryModel{
+		ID: "glm-5.2", Name: "GLM-5.2", Family: "glm",
+		Reasoning: true, ToolCall: true, StructuredOutput: true, Temperature: true,
+		OpenWeights: true,
+		ReleaseDate: "2026-06-13", LastUpdated: "2026-06-13",
+		Modalities:     &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+		Limit:          &ModelLimit{Context: 1_000_000, Output: 131_072},
+		DefaultEnabled: true,
+	}
+}
+
+// additionalModels injects models into EXISTING generated providers when a model is
+// released before models.dev publishes it. Applied at init() and MERGED in — an
+// entry is skipped if the provider already defines that model id, so once the
+// official record lands in registry_generated.go it transparently takes over.
+// Key: provider ID → model ID → model. See docs/model-research.md.
+var additionalModels = map[string]map[string]*RegistryModel{
+	"zhipuai":             {"glm-5.2": glm52Model()},
+	"zhipuai-coding-plan": {"glm-5.2": glm52Model()},
+	"zai":                 {"glm-5.2": glm52Model()},
+	"zai-coding-plan":     {"glm-5.2": glm52Model()},
 }
 
 func init() {
 	applyStaticProviders()
+	applyAdditionalModels()
+	applyContextLimitOverrides()
 	applyRecommendedModels()
 }
 
@@ -446,6 +509,48 @@ func applyStaticProviders() {
 		generatedProviders[id] = prov
 	}
 	generatedProviderOrder = append(generatedProviderOrder, staticProviderOrder...)
+}
+
+// applyAdditionalModels merges hand-maintained models into existing generated
+// providers, skipping any model id the provider already defines (so the official
+// models.dev record wins once it lands).
+func applyAdditionalModels() {
+	for provID, models := range additionalModels {
+		prov, ok := generatedProviders[provID]
+		if !ok {
+			continue
+		}
+		if prov.Models == nil {
+			prov.Models = make(map[string]*RegistryModel, len(models))
+		}
+		for modelID, m := range models {
+			if _, exists := prov.Models[modelID]; exists {
+				continue
+			}
+			prov.Models[modelID] = m
+		}
+	}
+}
+
+// applyContextLimitOverrides patches context windows for built-in models whose
+// generated value understates the model's real advertised window.
+func applyContextLimitOverrides() {
+	for provID, models := range contextLimitOverrides {
+		prov, ok := generatedProviders[provID]
+		if !ok {
+			continue
+		}
+		for modelID, ctx := range models {
+			m, ok := prov.Models[modelID]
+			if !ok {
+				continue
+			}
+			if m.Limit == nil {
+				m.Limit = &ModelLimit{}
+			}
+			m.Limit.Context = ctx
+		}
+	}
 }
 
 // applyRecommendedModels sets Recommended and DefaultEnabled on models in the generated registry.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -289,14 +289,7 @@ func modelContextLimit() int {
 	if err != nil {
 		return 0
 	}
-	// Try registry lookup first (provider/model format)
 	provider, modelName := cfg.GetProviderModel()
-	if provider != "" && modelName != "" {
-		registry := internalmodel.NewModelRegistryWithConfig(cfg)
-		if limit := registry.GetModelContextLimit(provider, modelName); limit > 0 {
-			return limit
-		}
-	}
-	// Fall back to hardcoded model limits
-	return internalmodel.GetModelContextLimit(modelName)
+	registry := internalmodel.NewModelRegistryWithConfig(cfg)
+	return internalmodel.ResolveContextLimit(registry, cfg, provider, modelName)
 }


### PR DESCRIPTION
## What & why

Many providers now ship 1M-context models (MiniMax-M3, DeepSeek-V4-Pro, Qwen 3.7, GLM-5.2, GPT-5.5, Claude 4.8, Gemini 3.x). jcode's window-size management couldn't take advantage of them: the `registry → knownModels → 200000` resolution chain was **copy-pasted across 5 call sites** (interactive / acp / web ×2 / runner), so any model the registry didn't know — or **under-reported** — silently fell back to a 200K window, triggering compaction at ~150K and wasting the model's real capacity.

## Window-size management

- **Single source of truth**: new `model.ResolveContextLimit()` replaces all 5 duplicated blocks. Order: config override → models.dev registry → `knownModels` fallback → `config.DefaultContextLimit` → `DefaultContextLimitFallback` (200K).
- **New config knobs** (previously impossible without code changes):
  - `context_limits` — override per `"provider/model"` or bare model id (teach jcode a brand-new/custom model's window)
  - `default_context_limit` — global floor for unidentifiable models
  - `compaction.threshold` — was **dead config**; now wired so summarization / compaction / reduction thresholds scale off a configurable fraction (default 0.75)

## Model registry (hand-maintained, survives `go generate`)

`registry_generated.go` is `DO NOT EDIT` (regenerated from models.dev). Three init-time maps in `registry.go` carry the corrections:

- **`additionalModels`** (new) — merge-injects models that shipped *before* their models.dev record, **skipping any id the provider already defines** so the official record transparently wins once it lands. Used for **GLM-5.2** (released 2026-06-13 to GLM Coding Plan; official Z.ai DevPack config publishes `contextWindow: 1000000, maxTokens: 131072`, full 1M via the `glm-5.2[1m]` variant) on the four first-party Zhipu/Z.ai providers.
- **`contextLimitOverrides`** — corrects **MiniMax-M3** from the 512K "guaranteed minimum" models.dev records to its advertised **1M** window.
- **`recommendedModels`** — refreshed to current 1M flagships: MiniMax-M3, deepseek-v4-pro, qwen3.7-plus/max, kimi-k2.7-code, gpt-5.5, claude-opus-4-8 / sonnet-4-6, gemini-3.1-pro-preview, glm-5.2.
- `knownModels` offline fallback table refreshed with the 2026 flagships.

## Docs & tests

- `docs/model-research.md` caches the per-provider context-window survey so this doesn't need re-researching. Includes corrections to common assumptions: **Kimi K2.7 is 256K, not 1M**; GLM-5.2 confirmed 1M from the official Z.ai source.
- `context_limit_test.go` covers the resolution order, the MiniMax-M3 override, GLM-5.2 injection (present + 1M + recommended on all four providers), and that recommended flagships exist with large windows (guards against typo'd ids being silently ignored).

## Reviewer notes

- `go build ./...` clean; **`go test ./...` fully passes**.
- GLM-5.2's **standalone direct API** isn't live yet (only the Coding Plan endpoint) — usable now via `zhipuai-coding-plan` / `zai-coding-plan`; the plain `zhipuai` direct route may 404 until Zhipu finishes the rollout. Source: official Z.ai DevPack config + dev-letter, verified 2026-06-13.
- GLM-5.1's "1M" claim was **not** applied — models.dev lists it at ~200K across all three providers and only a single secondary blog claimed 1M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added model context window override configuration for customized context sizing
  * Extended long-context AI model support with updated defaults and metadata
  * Made token compression thresholds configurable for better control over summarization behavior

* **Documentation**
  * Added comprehensive model research documentation covering long-context capabilities and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->