### PR TITLE
feat(web): interactive ask_user flow + MCP OAuth & settings management

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,6 +218,16 @@ The built-in color theme for the **terminal UI**: `"jcode-dark"` (default), `"mi
 {: .note }
 The web UI has its own theme preference (stored in the browser); the two are independent. Both share the same catalog of built-in themes, generated from a single source (`internal/theme`).
 
+### disabled_skills
+
+A list of skill names to exclude from the agent (slash commands, system-prompt
+descriptions, and the `load_skill` tool). Toggle skills on/off from the web UI
+(**Settings → Skills**); it persists here.
+
+```json
+{ "disabled_skills": ["pptx", "docx"] }
+```
+
 ### channel
 
 Notification channel settings. See [Channels](overview/channels).

--- a/docs/overview/mcp.md
+++ b/docs/overview/mcp.md
@@ -40,7 +40,17 @@ jcode mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
 
 # Specify server type explicitly
 jcode mcp add db -t http http://localhost:3001/mcp
+
+# Add an OAuth-protected HTTP server (opens your browser to authorize)
+jcode mcp add acme https://mcp.acme.com/mcp -t http --oauth
 ```
+
+#### Via the Web UI
+
+Open **Settings → MCP Servers** to add, edit, enable/disable, or delete servers
+with a form (transport, URL/command, headers, OAuth, timeout). Changes take
+effect immediately — no restart. For OAuth servers, click **Log in** to run the
+browser authorization flow.
 
 #### Via Config File
 
@@ -116,6 +126,48 @@ When using `jcode mcp add`, the server type is **auto-detected** from the URL. U
 |---|---|
 | `url` | Server URL |
 | `headers` | Custom HTTP headers (map of key-value pairs) |
+| `timeout_seconds` | Request timeout (default 180) |
+| `disabled` | Exclude from tool loading without deleting |
+| `oauth` | OAuth 2.0 settings (see below) |
+
+## OAuth Authentication
+
+HTTP/SSE servers that sit behind an OAuth 2.0 authorization server (per the
+[MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization))
+are supported. jcode performs **automatic discovery and dynamic client
+registration** (RFC 8414 / 9728 / 7591); if the server does not support dynamic
+registration, set an **OAuth Client ID** (and optional secret) and jcode falls
+back to it.
+
+During login, jcode opens your browser and listens for the redirect on a fixed
+loopback callback — register `http://127.0.0.1:13380/oauth/callback` as the
+redirect URI when configuring a client manually. Tokens are persisted to
+`~/.jcode/oauth/<server>.json` (mode 0600) and refreshed automatically.
+
+```json
+{
+  "mcp_servers": {
+    "acme": {
+      "type": "http",
+      "url": "https://mcp.acme.com/mcp",
+      "oauth": {
+        "enabled": true,
+        "client_id": "optional-manual-fallback",
+        "scopes": ["mcp.read", "mcp.write"]
+      }
+    }
+  }
+}
+```
+
+Log in (or re-authenticate) at any time:
+
+```bash
+jcode mcp login acme        # CLI
+```
+
+From the TUI, `/mcp` lists servers and their status; `/mcp login <name>` starts
+the browser flow. In the web UI, use the **Log in** button on the server row.
 
 ## Loading Status
 
@@ -171,6 +223,10 @@ In unsafe mode (`--unsafe`), MCP tool operations are also auto-approved. Only us
 | Add a server | `jcode mcp add <name> <url-or-command>` |
 | Add with headers | `jcode mcp add <name> <url> --header "Key: Value"` |
 | Add stdio server | `jcode mcp add <name> -- <command> [args...]` |
+| Add OAuth server | `jcode mcp add <name> <url> -t http --oauth` |
+| Authenticate (OAuth) | `jcode mcp login <name>` |
 | List servers | `jcode mcp list` |
+| List / log in (TUI) | `/mcp`, `/mcp login <name>` |
+| Manage (web UI) | Settings → MCP Servers |
 | Check connectivity | `jcode doctor` |
 | View in web UI | `GET /api/mcp` |

--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -251,6 +251,47 @@ func (s *interactiveState) createAgent() (*adk.ChatModelAgent, error) {
 	return agent.NewAgent(s.ctx, s.chatModel, s.toolList, s.systemPrompt, s.approvalState.RequestApproval, middlewares, handlers)
 }
 
+// mcpStatusItems converts internal MCP statuses to TUI status items.
+func mcpStatusItems(internalStatuses []tools.MCPStatus) []tui.MCPStatusItem {
+	items := make([]tui.MCPStatusItem, 0, len(internalStatuses))
+	for _, st := range internalStatuses {
+		errMsg := ""
+		if st.Error != nil {
+			errMsg = st.Error.Error()
+		}
+		items = append(items, tui.MCPStatusItem{
+			Name: st.Name, ToolCount: st.ToolCount, Running: st.Running,
+			ErrMsg: errMsg, NeedsAuth: st.NeedsAuth,
+		})
+	}
+	return items
+}
+
+// reloadMCP reloads MCP servers from the current config, rebuilds the agent
+// tool set in place, and pushes a fresh status to the TUI. Used after an
+// OAuth login or MCP config change so tools become usable without a restart.
+func (s *interactiveState) reloadMCP() {
+	latest, err := config.LoadConfig()
+	if err != nil {
+		config.Logger().Printf("[mcp] reload: config load failed: %v", err)
+		return
+	}
+	s.cfg = latest
+	mcpTools, statuses := tools.LoadMCPTools(s.ctx, latest.MCPServers)
+	s.mcpTools = mcpTools
+	if s.agentMode != tui.ModePlanning {
+		s.toolList = s.buildAllTools()
+		if newAg, err := s.createAgent(); err == nil {
+			s.ag = newAg
+		} else {
+			config.Logger().Printf("[mcp] reload: agent rebuild failed: %v", err)
+		}
+	}
+	if s.p != nil {
+		s.p.Send(tui.MCPStatusMsg{Statuses: mcpStatusItems(statuses)})
+	}
+}
+
 func (s *interactiveState) applyModeSwitch(newMode tui.AgentMode) {
 	s.agentMode = newMode
 	config.Logger().Printf("[plan] mode switch to %d (0=normal, 1=plan)", newMode)
@@ -721,6 +762,7 @@ func (s *interactiveState) runEventLoop(initialHistory []adk.Message, initialRes
 	compactCh := tui.GetCompactChannel()
 	modeSelectCh := tui.GetModeSelectChannel()
 	channelActionCh := tui.GetChannelActionChannel()
+	mcpLoginCh := tui.GetMCPLoginChannel()
 	cancelAgentCh := tui.GetCancelAgentChannel()
 
 	// Background goroutine to handle agent cancellation requests.
@@ -772,8 +814,48 @@ func (s *interactiveState) runEventLoop(initialHistory []adk.Message, initialRes
 
 		case action := <-channelActionCh:
 			s.handleChannelAction(action)
+
+		case name := <-mcpLoginCh:
+			s.handleMCPLogin(name)
 		}
 	}
+}
+
+// handleMCPLogin runs an OAuth login for the named server in the background so
+// the event loop is not blocked while the user completes the browser flow. On
+// success it persists config and hot-reloads MCP tools.
+func (s *interactiveState) handleMCPLogin(name string) {
+	srv := s.cfg.MCPServers[name]
+	if srv == nil {
+		s.p.Send(tui.MCPNoticeMsg{Text: "server not found: " + name})
+		return
+	}
+	if srv.URL == "" || (srv.Type != "http" && srv.Type != "sse") {
+		s.p.Send(tui.MCPNoticeMsg{Text: "OAuth login only applies to http/sse servers"})
+		return
+	}
+	if srv.OAuth == nil {
+		srv.OAuth = &config.MCPOAuthConfig{Enabled: true}
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(s.ctx, 5*time.Minute)
+		defer cancel()
+		err := tools.PerformMCPOAuthLogin(ctx, name, srv, func(authURL string) {
+			s.p.Send(tui.MCPNoticeMsg{Text: "opening browser…"})
+			if err := util.OpenURL(authURL); err != nil {
+				config.Logger().Printf("[mcp] open browser: %v", err)
+			}
+		})
+		if err != nil {
+			s.p.Send(tui.MCPNoticeMsg{Text: "login failed: " + err.Error()})
+			return
+		}
+		if err := config.SaveConfig(s.cfg); err != nil {
+			config.Logger().Printf("[mcp] save config after login: %v", err)
+		}
+		s.p.Send(tui.MCPNoticeMsg{Text: name + " authorized — reloading tools"})
+		s.reloadMCP()
+	}()
 }
 
 // RunInteractive starts the interactive TUI session.
@@ -808,7 +890,7 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 	platform := util.GetSystemInfo()
 	envInfo := util.CollectEnvInfo(pwd)
 
-	skillLoader := skills.NewLoader()
+	skillLoader := skills.NewLoaderWithDisabled(cfg.DisabledSkills)
 	skillLoader.ScanProjectSkills(pwd)
 
 	systemPrompt := prompts.GetSystemPrompt(platform, pwd, "local", envInfo, skillLoader.Descriptions())
@@ -842,15 +924,7 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 	if len(cfg.MCPServers) > 0 {
 		var internalStatuses []tools.MCPStatus
 		mcpTools, internalStatuses = tools.LoadMCPTools(ctx, cfg.MCPServers)
-		for _, st := range internalStatuses {
-			errMsg := ""
-			if st.Error != nil {
-				errMsg = st.Error.Error()
-			}
-			mcpStatuses = append(mcpStatuses, tui.MCPStatusItem{
-				Name: st.Name, ToolCount: st.ToolCount, Running: st.Running, ErrMsg: errMsg,
-			})
-		}
+		mcpStatuses = mcpStatusItems(internalStatuses)
 	}
 
 	planStore := tools.NewPlanStore()

--- a/internal/command/mcp.go
+++ b/internal/command/mcp.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cnjack/jcode/internal/config"
 	"github.com/cnjack/jcode/internal/tools"
+	util "github.com/cnjack/jcode/internal/util"
 )
 
 func NewMCPCmd() *cobra.Command {
@@ -18,17 +19,24 @@ func NewMCPCmd() *cobra.Command {
 		Short:        "Manage MCP servers",
 		SilenceUsage: true,
 	}
-	cmd.AddCommand(newMCPAddCmd(), newMCPListCmd())
+	cmd.AddCommand(newMCPAddCmd(), newMCPListCmd(), newMCPLoginCmd())
 	return cmd
 }
 
+// mcpAddFlags bundles the flags accepted by `mcp add`.
+type mcpAddFlags struct {
+	scope        string
+	srvType      string
+	headers      []string
+	envs         []string
+	oauth        bool
+	clientID     string
+	clientSecret string
+	scopes       []string
+}
+
 func newMCPAddCmd() *cobra.Command {
-	var (
-		scope   string
-		srvType string
-		headers []string
-		envs    []string
-	)
+	var f mcpAddFlags
 
 	cmd := &cobra.Command{
 		Use:          "add <name> <url-or-command> [args...]",
@@ -36,16 +44,41 @@ func newMCPAddCmd() *cobra.Command {
 		Args:         cobra.MinimumNArgs(2),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return handleMCPAdd(args, srvType, headers, envs, scope)
+			return handleMCPAdd(args, &f)
 		},
 	}
 
-	cmd.Flags().StringVarP(&scope, "scope", "s", "user", "Config scope (user)")
-	cmd.Flags().StringVarP(&srvType, "type", "t", "", "Server type: sse, http, or stdio (auto-detect if empty)")
-	cmd.Flags().StringArrayVar(&headers, "header", nil, "HTTP header in 'Key: Value' format (repeatable)")
-	cmd.Flags().StringArrayVar(&envs, "env", nil, "Environment variable in 'KEY=VALUE' format (repeatable)")
+	cmd.Flags().StringVarP(&f.scope, "scope", "s", "user", "Config scope (user)")
+	cmd.Flags().StringVarP(&f.srvType, "type", "t", "", "Server type: sse, http, or stdio (auto-detect if empty)")
+	cmd.Flags().StringArrayVar(&f.headers, "header", nil, "HTTP header in 'Key: Value' format (repeatable)")
+	cmd.Flags().StringArrayVar(&f.envs, "env", nil, "Environment variable in 'KEY=VALUE' format (repeatable)")
+	cmd.Flags().BoolVar(&f.oauth, "oauth", false, "Authenticate via OAuth after adding (http/sse only)")
+	cmd.Flags().StringVar(&f.clientID, "client-id", "", "OAuth client id (manual fallback when dynamic registration is unsupported)")
+	cmd.Flags().StringVar(&f.clientSecret, "client-secret", "", "OAuth client secret (confidential clients)")
+	cmd.Flags().StringArrayVar(&f.scopes, "scope-oauth", nil, "OAuth scope to request (repeatable)")
 
 	return cmd
+}
+
+func newMCPLoginCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:          "login <name>",
+		Short:        "Authenticate an existing http/sse MCP server via OAuth",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return handleMCPLogin(args[0])
+		},
+	}
+}
+
+// mcpLoginBrowser opens the authorization URL in the browser and prints it as a
+// fallback. Used as the onAuthURL callback for CLI OAuth flows.
+func mcpLoginBrowser(authURL string) {
+	fmt.Printf("Opening browser for authorization. If it does not open, visit:\n  %s\n", authURL)
+	if err := util.OpenURL(authURL); err != nil {
+		config.Logger().Printf("[mcp] open browser: %v", err)
+	}
 }
 
 func newMCPListCmd() *cobra.Command {
@@ -59,9 +92,8 @@ func newMCPListCmd() *cobra.Command {
 	}
 }
 
-func handleMCPAdd(args []string, srvType string, headers []string, envs []string, scope string) error {
-	_ = scope // user-level only for now; reserved for future scope support
-	_ = envs  // stored on MCPServer but auto-detect from URL vs command
+func handleMCPAdd(args []string, f *mcpAddFlags) error {
+	_ = f.scope // user-level only for now; reserved for future scope support
 
 	name := args[0]
 	urlOrCmd := args[1]
@@ -69,18 +101,25 @@ func handleMCPAdd(args []string, srvType string, headers []string, envs []string
 
 	srv := &config.MCPServer{}
 
-	// If no explicit type, auto-detect from URL prefix
+	srvType := f.srvType
+	// If no explicit type, auto-detect from URL prefix.
 	if srvType == "" {
-		if strings.HasPrefix(urlOrCmd, "http://") || strings.HasPrefix(urlOrCmd, "https://") {
-			srvType = "sse"
-		} else {
+		switch {
+		case strings.HasPrefix(urlOrCmd, "http://") || strings.HasPrefix(urlOrCmd, "https://"):
+			// OAuth servers use the modern streamable-http transport by default.
+			if f.oauth {
+				srvType = "http"
+			} else {
+				srvType = "sse"
+			}
+		default:
 			srvType = "stdio"
 		}
 	}
 
 	// Parse headers into a map
 	headerMap := make(map[string]string)
-	for _, h := range headers {
+	for _, h := range f.headers {
 		if idx := strings.Index(h, ":"); idx > 0 {
 			key := strings.TrimSpace(h[:idx])
 			val := strings.TrimSpace(h[idx+1:])
@@ -89,14 +128,8 @@ func handleMCPAdd(args []string, srvType string, headers []string, envs []string
 	}
 
 	switch srvType {
-	case "http":
-		srv.Type = "http"
-		srv.URL = urlOrCmd
-		if len(headerMap) > 0 {
-			srv.Headers = headerMap
-		}
-	case "sse":
-		srv.Type = "sse"
+	case "http", "sse":
+		srv.Type = srvType
 		srv.URL = urlOrCmd
 		if len(headerMap) > 0 {
 			srv.Headers = headerMap
@@ -105,11 +138,30 @@ func handleMCPAdd(args []string, srvType string, headers []string, envs []string
 		srv.Type = "stdio"
 		srv.Command = urlOrCmd
 		srv.Args = extraArgs
-		if len(envs) > 0 {
-			srv.Env = envs
+		if len(f.envs) > 0 {
+			srv.Env = f.envs
 		}
 	default:
 		return fmt.Errorf("unknown server type: %s (supported: sse, http, stdio)", srvType)
+	}
+
+	if f.oauth {
+		if srv.Type != "http" && srv.Type != "sse" {
+			return fmt.Errorf("--oauth only applies to http/sse servers")
+		}
+		srv.OAuth = &config.MCPOAuthConfig{
+			Enabled:      true,
+			ClientID:     f.clientID,
+			ClientSecret: f.clientSecret,
+			Scopes:       f.scopes,
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		fmt.Printf("Starting OAuth login for '%s'...\n", name)
+		if err := tools.PerformMCPOAuthLogin(ctx, name, srv, mcpLoginBrowser); err != nil {
+			return fmt.Errorf("oauth login failed: %w", err)
+		}
+		fmt.Println("Authorized.")
 	}
 
 	fmt.Printf("Testing MCP server '%s'...\n", name)
@@ -141,6 +193,37 @@ func handleMCPAdd(args []string, srvType string, headers []string, envs []string
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 	fmt.Printf("MCP server '%s' saved to config\n", name)
+	return nil
+}
+
+// handleMCPLogin runs the OAuth authorization flow for an existing http/sse
+// server and persists the (possibly dynamically registered) client + token.
+func handleMCPLogin(name string) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	srv := cfg.MCPServers[name]
+	if srv == nil {
+		return fmt.Errorf("MCP server %q not found", name)
+	}
+	if srv.URL == "" || (srv.Type != "http" && srv.Type != "sse") {
+		return fmt.Errorf("OAuth login only applies to http/sse servers")
+	}
+	if srv.OAuth == nil {
+		srv.OAuth = &config.MCPOAuthConfig{Enabled: true}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	fmt.Printf("Starting OAuth login for '%s'...\n", name)
+	if err := tools.PerformMCPOAuthLogin(ctx, name, srv, mcpLoginBrowser); err != nil {
+		return fmt.Errorf("oauth login failed: %w", err)
+	}
+	if err := config.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+	fmt.Printf("MCP server '%s' authorized\n", name)
 	return nil
 }
 

--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -75,7 +75,7 @@ func runWebServer(port int, host string, openBrowser bool) error {
 	platform := util.GetSystemInfo()
 	envInfo := util.CollectEnvInfo(pwd)
 
-	skillLoader := skills.NewLoader()
+	skillLoader := skills.NewLoaderWithDisabled(cfg.DisabledSkills)
 	skillLoader.ScanProjectSkills(pwd)
 
 	systemPrompt := prompts.GetSystemPrompt(platform, pwd, "local", envInfo, skillLoader.Descriptions())
@@ -101,10 +101,22 @@ func runWebServer(port int, host string, openBrowser bool) error {
 	// updates).
 	agentTokenUsage := &internalmodel.TokenUsage{}
 
-	// Load MCP tools.
+	// Load MCP tools. mcpTools is reassigned by reloadMCPTools (below) so the
+	// agent picks up server add/edit/delete/login without a restart — the
+	// buildAllTools closure reads this variable on each agent rebuild.
 	var mcpTools []tool.BaseTool
+	var initialMCPStatuses []tools.MCPStatus
 	if len(cfg.MCPServers) > 0 {
-		mcpTools, _ = tools.LoadMCPTools(ctx, cfg.MCPServers)
+		mcpTools, initialMCPStatuses = tools.LoadMCPTools(ctx, cfg.MCPServers)
+	}
+
+	// reloadMCPTools re-establishes connections from the given server map and
+	// swaps in the fresh tool set. The Server rebuilds the agent afterwards and
+	// uses the returned statuses for the management UI.
+	reloadMCPTools := func(servers map[string]*config.MCPServer) ([]tools.MCPStatus, error) {
+		nt, statuses := tools.LoadMCPTools(ctx, servers)
+		mcpTools = nt
+		return statuses, nil
 	}
 
 	planStore := tools.NewPlanStore()
@@ -183,7 +195,7 @@ func runWebServer(port int, host string, openBrowser bool) error {
 				},
 			}),
 			tools.NewAskUserTool(&tools.AskUserDeps{
-				ResponseCh: make(chan tools.AskUserResponse, 1),
+				BatchRequestFn: webHandler.RequestAskUser,
 			}),
 			skills.NewLoadSkillTool(skillLoader),
 		}
@@ -200,7 +212,7 @@ func runWebServer(port int, host string, openBrowser bool) error {
 			env.NewGrepTool(),
 			env.NewTodoWriteTool(), env.NewTodoReadTool(),
 			tools.NewAskUserTool(&tools.AskUserDeps{
-				ResponseCh: make(chan tools.AskUserResponse, 1),
+				BatchRequestFn: webHandler.RequestAskUser,
 			}),
 		}
 	}
@@ -360,31 +372,33 @@ func runWebServer(port int, host string, openBrowser bool) error {
 	}
 
 	srv := web.NewServer(&web.ServerConfig{
-		Port:           port,
-		Host:           host,
-		OpenBrowser:    openBrowser,
-		Pwd:            pwd,
-		Version:        Version,
-		Agent:          ag,
-		CreateAgent:    createAgent,
-		RebuildForMode: rebuildForMode,
-		InitialMode:    startupMode.String(),
-		SwitchProject:  switchProject,
-		TodoStore:      env.TodoStore,
-		Recorder:       rec,
-		Tracer:         langfuseTracer,
-		Env:            env,
-		ProviderName:   providerName,
-		ModelName:      modelName,
-		Config:         cfg,
-		Registry:       registry,
-		ApprovalState:  approvalState,
-		SkillLoader:    skillLoader,
-		WechatClient:   wechatClient,
-		WebHandler:     webHandler,
-		EventHandler:   finalHandler,
-		NeedsSetup:     needsSetup,
-		TokenUsage:     agentTokenUsage,
+		Port:               port,
+		Host:               host,
+		OpenBrowser:        openBrowser,
+		Pwd:                pwd,
+		Version:            Version,
+		Agent:              ag,
+		CreateAgent:        createAgent,
+		RebuildForMode:     rebuildForMode,
+		InitialMode:        startupMode.String(),
+		SwitchProject:      switchProject,
+		TodoStore:          env.TodoStore,
+		Recorder:           rec,
+		Tracer:             langfuseTracer,
+		Env:                env,
+		ProviderName:       providerName,
+		ModelName:          modelName,
+		Config:             cfg,
+		Registry:           registry,
+		ApprovalState:      approvalState,
+		SkillLoader:        skillLoader,
+		ReloadMCP:          reloadMCPTools,
+		InitialMCPStatuses: initialMCPStatuses,
+		WechatClient:       wechatClient,
+		WebHandler:         webHandler,
+		EventHandler:       finalHandler,
+		NeedsSetup:         needsSetup,
+		TokenUsage:         agentTokenUsage,
 	})
 
 	// Set handler for approval routing.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,30 @@ type MCPServer struct {
 	Env     []string          `json:"env,omitempty"`
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
+	// TimeoutSeconds is the request timeout for HTTP/SSE transports. 0 → default (180s).
+	TimeoutSeconds int `json:"timeout_seconds,omitempty"`
+	// Disabled, when true, excludes this server from tool loading without deleting it.
+	Disabled bool `json:"disabled,omitempty"`
+	// OAuth configures OAuth 2.0 authorization for HTTP/SSE transports (MCP
+	// authorization spec). When nil, only static Headers are used.
+	OAuth *MCPOAuthConfig `json:"oauth,omitempty"`
+}
+
+// MCPOAuthConfig holds OAuth 2.0 settings for an MCP server. Tokens are NOT
+// stored here — they live in ~/.jcode/oauth/<server>.json. ClientID/ClientSecret
+// are the manual fallback used when the authorization server does not support
+// dynamic client registration (RFC 7591).
+type MCPOAuthConfig struct {
+	// Enabled turns on the OAuth bearer-token flow for this server.
+	Enabled bool `json:"enabled,omitempty"`
+	// ClientID is the OAuth client id. Empty → attempt dynamic registration.
+	ClientID string `json:"client_id,omitempty"`
+	// ClientSecret is set for confidential clients (manual fallback).
+	ClientSecret string `json:"client_secret,omitempty"`
+	// Scopes is the list of OAuth scopes to request.
+	Scopes []string `json:"scopes,omitempty"`
+	// AuthServerMetadataURL optionally overrides automatic metadata discovery.
+	AuthServerMetadataURL string `json:"auth_server_metadata_url,omitempty"`
 }
 
 // LangfuseConfig holds Langfuse telemetry credentials.
@@ -155,6 +179,10 @@ type Config struct {
 
 	// DisabledProviders lists provider IDs to exclude from registry
 	DisabledProviders []string `json:"disabled_providers,omitempty"`
+
+	// DisabledSkills lists skill names to exclude from the agent (slash commands,
+	// system-prompt descriptions, and the load_skill tool).
+	DisabledSkills []string `json:"disabled_skills,omitempty"`
 }
 
 // TeamConfig controls agent team behavior.

--- a/internal/handler/web.go
+++ b/internal/handler/web.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/cnjack/jcode/internal/tools"
 )
 
 // WebEvent is an event sent from the agent to web clients.
@@ -258,6 +260,12 @@ type WebApprovalRequestData struct {
 	IsExternal bool   `json:"is_external"`
 }
 
+// WebAskUserRequestData carries an ask_user question request to web clients.
+type WebAskUserRequestData struct {
+	ID        string                  `json:"id"`
+	Questions []tools.AskUserQuestion `json:"questions"`
+}
+
 // WebHandler implements AgentEventHandler by sending events to web clients
 // through a channel-based event broker.
 type WebHandler struct {
@@ -266,6 +274,17 @@ type WebHandler struct {
 	mu              sync.Mutex
 	approvalCounter int
 	pendingApproval map[string]chan ApprovalResponse
+
+	askUserMu      sync.Mutex
+	askUserCounter int
+	pendingAskUser map[string]*pendingAskUser
+}
+
+// pendingAskUser pairs a question's response channel with the request payload so
+// the latter can be re-surfaced to a (re)connecting client via /api/ask/pending.
+type pendingAskUser struct {
+	ch   chan tools.AskUserBatchResponse
+	data WebAskUserRequestData
 }
 
 // NewWebHandler creates a handler that sends events to the given channel.
@@ -273,6 +292,7 @@ func NewWebHandler() *WebHandler {
 	return &WebHandler{
 		eventCh:         make(chan WebEvent, 256),
 		pendingApproval: make(map[string]chan ApprovalResponse),
+		pendingAskUser:  make(map[string]*pendingAskUser),
 	}
 }
 
@@ -421,6 +441,71 @@ func (h *WebHandler) ResolveApproval(id string, approved, approveAll bool) error
 	default:
 		return fmt.Errorf("approval %q already resolved", id)
 	}
+}
+
+// --- Ask-user flow ---
+
+// RequestAskUser emits the question(s) to web clients and blocks until the user
+// answers (via the /api/ask endpoint → ResolveAskUser) or the context is
+// cancelled. It mirrors RequestApproval: a per-request id keys a one-shot
+// response channel so the API handler can route the answer back. This is wired
+// into the ask_user tool's BatchRequestFn for the web frontend.
+func (h *WebHandler) RequestAskUser(ctx context.Context, questions []tools.AskUserQuestion) (tools.AskUserBatchResponse, error) {
+	data := WebAskUserRequestData{Questions: questions}
+	h.askUserMu.Lock()
+	h.askUserCounter++
+	data.ID = fmt.Sprintf("ask_%d", h.askUserCounter)
+	respCh := make(chan tools.AskUserBatchResponse, 1)
+	h.pendingAskUser[data.ID] = &pendingAskUser{ch: respCh, data: data}
+	h.askUserMu.Unlock()
+
+	defer func() {
+		h.askUserMu.Lock()
+		delete(h.pendingAskUser, data.ID)
+		h.askUserMu.Unlock()
+	}()
+
+	h.emit("ask_user_request", data)
+
+	select {
+	case resp := <-respCh:
+		return resp, nil
+	case <-ctx.Done():
+		return tools.AskUserBatchResponse{}, ctx.Err()
+	}
+}
+
+// ResolveAskUser delivers the user's answers to a pending ask_user request.
+// Called by the API handler when the frontend submits answers.
+func (h *WebHandler) ResolveAskUser(id string, resp tools.AskUserBatchResponse) error {
+	h.askUserMu.Lock()
+	p, ok := h.pendingAskUser[id]
+	h.askUserMu.Unlock()
+
+	if !ok {
+		return fmt.Errorf("no pending ask_user with id %q", id)
+	}
+
+	select {
+	case p.ch <- resp:
+		return nil
+	default:
+		return fmt.Errorf("ask_user %q already resolved", id)
+	}
+}
+
+// PendingAskUserRequests returns the still-unanswered ask_user requests so a
+// reloaded/reconnecting client can re-surface the question (the ask_user_request
+// WS event is fire-once and ephemeral). Without this, a page refresh while a
+// question is pending would leave the agent blocked with no way to answer.
+func (h *WebHandler) PendingAskUserRequests() []WebAskUserRequestData {
+	h.askUserMu.Lock()
+	defer h.askUserMu.Unlock()
+	out := make([]WebAskUserRequestData, 0, len(h.pendingAskUser))
+	for _, p := range h.pendingAskUser {
+		out = append(out, p.data)
+	}
+	return out
 }
 
 // MarshalEvent marshals a WebEvent to JSON bytes.

--- a/internal/handler/web_test.go
+++ b/internal/handler/web_test.go
@@ -2,8 +2,11 @@ package handler
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/cnjack/jcode/internal/tools"
 )
 
 // TestWebHandler_ResolveApprovalOnceVsAll covers the P0 fix: the web approval
@@ -54,5 +57,80 @@ func TestWebHandler_ResolveApprovalOnceVsAll(t *testing.T) {
 	}
 	if r := run(true); !r.Approved || r.Mode != ModeAuto {
 		t.Errorf("approve all: expected {Approved:true, Mode:Auto}, got %+v", r)
+	}
+}
+
+// TestWebHandler_AskUserRoundTrip exercises the full web ask_user loop through
+// the real tool: the tool's BatchRequestFn blocks on RequestAskUser, the
+// handler emits ask_user_request with a generated id, and ResolveAskUser
+// (what POST /api/ask calls) unblocks the tool with the user's answer. This is
+// the path that previously hung — the web tool was wired with a dead channel.
+func TestWebHandler_AskUserRoundTrip(t *testing.T) {
+	h := NewWebHandler()
+	tool := tools.NewAskUserTool(&tools.AskUserDeps{
+		BatchRequestFn: h.RequestAskUser,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resultCh := make(chan string, 1)
+	go func() {
+		out, err := tool.InvokableRun(ctx,
+			`{"questions":[{"question":"Which feature?","header":"feature","options":[{"label":"Single","description":"one"},{"label":"Multi","description":"many"}]}]}`)
+		if err != nil {
+			t.Errorf("InvokableRun failed: %v", err)
+		}
+		resultCh <- out
+	}()
+
+	// Capture the emitted request to learn the generated id + normalized questions.
+	var ev WebEvent
+	select {
+	case ev = <-h.Events():
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for ask_user_request event")
+	}
+	if ev.Event != "ask_user_request" {
+		t.Fatalf("expected ask_user_request event, got %q", ev.Event)
+	}
+	data, ok := ev.Data.(WebAskUserRequestData)
+	if !ok {
+		t.Fatalf("expected WebAskUserRequestData, got %T", ev.Data)
+	}
+	if len(data.Questions) != 1 || data.Questions[0].Question != "Which feature?" {
+		t.Fatalf("unexpected questions payload: %+v", data.Questions)
+	}
+
+	// While in flight, the question must be re-surfaceable (page-reload recovery).
+	pending := h.PendingAskUserRequests()
+	if len(pending) != 1 || pending[0].ID != data.ID {
+		t.Fatalf("expected 1 pending ask_user with id %q, got %+v", data.ID, pending)
+	}
+
+	// Resolve as the API handler would.
+	if err := h.ResolveAskUser(data.ID, tools.AskUserBatchResponse{
+		Answers: []tools.AskUserAnswer{{QuestionHeader: "feature", Answer: "Single"}},
+	}); err != nil {
+		t.Fatalf("ResolveAskUser(%q): %v", data.ID, err)
+	}
+
+	select {
+	case out := <-resultCh:
+		if !strings.Contains(out, "Single") {
+			t.Errorf("expected tool result to contain the answer, got %q", out)
+		}
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for tool result (the hang this fix addresses)")
+	}
+
+	// Once answered, the request is cleared from the pending set.
+	if pending := h.PendingAskUserRequests(); len(pending) != 0 {
+		t.Errorf("expected no pending ask_user after answer, got %+v", pending)
+	}
+
+	// A second resolve for the now-cleared id must report no pending request.
+	if err := h.ResolveAskUser(data.ID, tools.AskUserBatchResponse{}); err == nil {
+		t.Errorf("expected error resolving an already-answered ask_user id")
 	}
 }

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -25,8 +25,9 @@ type Skill struct {
 
 // Loader discovers and caches skills from built-in embeds and user directories.
 type Loader struct {
-	mu     sync.RWMutex
-	skills map[string]*Skill
+	mu       sync.RWMutex
+	skills   map[string]*Skill
+	disabled map[string]bool // skill names hidden from the agent
 }
 
 //go:embed builtin
@@ -35,13 +36,41 @@ var builtinFS embed.FS
 // NewLoader creates a Loader pre-populated with built-in skills, then scans
 // the user skills directories (~/.agents/skills/ and ~/.jcode/skills/) for additional skills.
 func NewLoader() *Loader {
+	return NewLoaderWithDisabled(nil)
+}
+
+// NewLoaderWithDisabled creates a Loader with the given skill names disabled.
+// Disabled skills are excluded from the system-prompt descriptions, slash
+// commands, and the load_skill tool, but remain visible via All() for management UIs.
+func NewLoaderWithDisabled(disabled []string) *Loader {
 	l := &Loader{
-		skills: make(map[string]*Skill),
+		skills:   make(map[string]*Skill),
+		disabled: make(map[string]bool, len(disabled)),
+	}
+	for _, name := range disabled {
+		l.disabled[name] = true
 	}
 	l.loadBuiltin()
 	l.ScanAgentsSkills()
 	l.ScanUserSkills()
 	return l
+}
+
+// SetDisabled replaces the set of disabled skill names.
+func (l *Loader) SetDisabled(disabled []string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.disabled = make(map[string]bool, len(disabled))
+	for _, name := range disabled {
+		l.disabled[name] = true
+	}
+}
+
+// IsEnabled reports whether the named skill is active (not disabled).
+func (l *Loader) IsEnabled(name string) bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return !l.disabled[name]
 }
 
 // loadBuiltin reads embedded SKILL.md files from the builtin/ directory.
@@ -187,6 +216,9 @@ func (l *Loader) Descriptions() string {
 	}
 	var sb strings.Builder
 	for _, sk := range skills {
+		if !l.IsEnabled(sk.Name) {
+			continue
+		}
 		slash := ""
 		if sk.Slash != "" {
 			slash = fmt.Sprintf(" (%s)", sk.Slash)
@@ -200,7 +232,7 @@ func (l *Loader) Descriptions() string {
 // into tool_result (Layer 2 — on-demand, full content).
 func (l *Loader) GetContent(name string) string {
 	sk := l.Get(name)
-	if sk == nil {
+	if sk == nil || !l.IsEnabled(name) {
 		return fmt.Sprintf("Error: Unknown skill '%s'. Available skills:\n%s", name, l.Descriptions())
 	}
 	return fmt.Sprintf("<skill name=%q description=%q>\n%s\n</skill>", sk.Name, sk.Description, sk.Body)
@@ -215,6 +247,10 @@ func (l *Loader) SlashCommands() []*Skill {
 	defer l.mu.RUnlock()
 	var result []*Skill
 	for _, sk := range l.skills {
+		if l.disabled[sk.Name] {
+			// User-disabled via config/UI.
+			continue
+		}
 		switch {
 		case sk.Slash == "false":
 			// Explicitly disabled.

--- a/internal/tools/ask_user.go
+++ b/internal/tools/ask_user.go
@@ -49,6 +49,13 @@ type AskUserDeps struct {
 	ResponseCh      <-chan AskUserResponse                  // receives user answer
 	BatchNotifyFn   func(questions []AskUserQuestion)       // sends batch questions to TUI
 	BatchResponseCh <-chan AskUserBatchResponse             // receives batch answers
+
+	// BatchRequestFn, when set, blocks until the user answers the given
+	// questions and returns the structured response. It takes precedence over
+	// the notify/channel pair above. This is the model the web frontend uses: a
+	// single blocking call (emit a WS event + await the answer POST) instead of
+	// a fire-and-forget notify plus a shared response channel.
+	BatchRequestFn func(ctx context.Context, questions []AskUserQuestion) (AskUserBatchResponse, error)
 }
 
 type askUserOption struct {
@@ -151,6 +158,21 @@ func (t *askUserTool) runSingle(ctx context.Context, question string, options []
 
 	config.Logger().Printf("[ask_user] question: %q, options: %d", question, len(labels))
 
+	// Blocking-request path (web): convert to a single-element batch.
+	if t.deps.BatchRequestFn != nil {
+		q := AskUserQuestion{Question: question}
+		for _, opt := range options {
+			if opt.Label != "" {
+				q.Options = append(q.Options, AskUserOption{Label: opt.Label})
+			}
+		}
+		resp, err := t.deps.BatchRequestFn(ctx, []AskUserQuestion{q})
+		if err != nil {
+			return "ask_user cancelled: " + err.Error(), nil
+		}
+		return formatBatchResponse([]AskUserQuestion{q}, resp)
+	}
+
 	if t.deps.NotifyFn != nil {
 		t.deps.NotifyFn(question, labels)
 	}
@@ -200,6 +222,15 @@ func (t *askUserTool) runBatch(ctx context.Context, questions []AskUserQuestion)
 	}
 
 	config.Logger().Printf("[ask_user] batch: %d questions", len(questions))
+
+	// Blocking-request path (web): emit + await a single answer payload.
+	if t.deps.BatchRequestFn != nil {
+		resp, err := t.deps.BatchRequestFn(ctx, questions)
+		if err != nil {
+			return "ask_user cancelled: " + err.Error(), nil
+		}
+		return formatBatchResponse(questions, resp)
+	}
 
 	// Use batch channels if available, otherwise fall back to single-question mode
 	if t.deps.BatchNotifyFn != nil && t.deps.BatchResponseCh != nil {

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -7,8 +7,6 @@ import (
 	mcpp "github.com/cloudwego/eino-ext/components/tool/mcp"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cnjack/jcode/internal/config"
-	"github.com/mark3labs/mcp-go/client"
-	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -17,6 +15,9 @@ type MCPStatus struct {
 	ToolCount int
 	Error     error
 	Running   bool
+	// NeedsAuth is true when the server returned an OAuth authorization
+	// challenge — the user must log in before tools become available.
+	NeedsAuth bool
 }
 
 // LoadMCPTools establishes connections to configured MCP servers and fetches their tools.
@@ -25,36 +26,13 @@ func LoadMCPTools(ctx context.Context, mcpConfig map[string]*config.MCPServer) (
 	var statuses []MCPStatus
 
 	for name, srv := range mcpConfig {
-		if srv == nil {
+		if srv == nil || srv.Disabled {
 			continue
 		}
 
 		status := MCPStatus{Name: name, Running: false}
 
-		var cli *client.Client
-		var err error
-
-		switch {
-		case srv.Type == "http":
-			var opts []transport.StreamableHTTPCOption
-			if len(srv.Headers) > 0 {
-				opts = append(opts, transport.WithHTTPHeaders(srv.Headers))
-			}
-			cli, err = client.NewStreamableHttpClient(srv.URL, opts...)
-		case srv.URL != "" || srv.Type == "sse":
-			var opts []transport.ClientOption
-			if len(srv.Headers) > 0 {
-				opts = append(opts, transport.WithHeaders(srv.Headers))
-			}
-			cli, err = client.NewSSEMCPClient(srv.URL, opts...)
-		case srv.Command != "" || srv.Type == "stdio":
-			cli, err = client.NewStdioMCPClient(srv.Command, srv.Env, srv.Args...)
-		default:
-			status.Error = fmt.Errorf("invalid config: missing url or command")
-			statuses = append(statuses, status)
-			continue
-		}
-
+		cli, err := buildMCPClient(name, srv)
 		if err != nil {
 			status.Error = fmt.Errorf("client create failed: %w", err)
 			statuses = append(statuses, status)
@@ -62,7 +40,12 @@ func LoadMCPTools(ctx context.Context, mcpConfig map[string]*config.MCPServer) (
 		}
 
 		if err := cli.Start(ctx); err != nil {
-			status.Error = fmt.Errorf("start failed: %w", err)
+			if isMCPAuthError(err) {
+				status.NeedsAuth = true
+				status.Error = fmt.Errorf("authorization required — run login")
+			} else {
+				status.Error = fmt.Errorf("start failed: %w", err)
+			}
 			statuses = append(statuses, status)
 			continue
 		}
@@ -75,7 +58,12 @@ func LoadMCPTools(ctx context.Context, mcpConfig map[string]*config.MCPServer) (
 		}
 
 		if _, err := cli.Initialize(ctx, initReq); err != nil {
-			status.Error = fmt.Errorf("init failed: %w", err)
+			if isMCPAuthError(err) {
+				status.NeedsAuth = true
+				status.Error = fmt.Errorf("authorization required — run login")
+			} else {
+				status.Error = fmt.Errorf("init failed: %w", err)
+			}
 			statuses = append(statuses, status)
 			continue
 		}

--- a/internal/tools/mcp_manager.go
+++ b/internal/tools/mcp_manager.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cnjack/jcode/internal/config"
 	"github.com/mark3labs/mcp-go/client"
-	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -206,27 +205,8 @@ func (m *MCPManager) Connect(ctx context.Context, name string, cfg *config.MCPSe
 // doConnect performs the low-level create → start → init → discover sequence.
 func (m *MCPManager) doConnect(ctx context.Context, conn *MCPConnection) error {
 	cfg := conn.Config
-	var cli *client.Client
-	var err error
 
-	switch {
-	case cfg.Type == "http":
-		var opts []transport.StreamableHTTPCOption
-		if len(cfg.Headers) > 0 {
-			opts = append(opts, transport.WithHTTPHeaders(cfg.Headers))
-		}
-		cli, err = client.NewStreamableHttpClient(cfg.URL, opts...)
-	case cfg.URL != "" || cfg.Type == "sse":
-		var opts []transport.ClientOption
-		if len(cfg.Headers) > 0 {
-			opts = append(opts, transport.WithHeaders(cfg.Headers))
-		}
-		cli, err = client.NewSSEMCPClient(cfg.URL, opts...)
-	case cfg.Command != "" || cfg.Type == "stdio":
-		cli, err = client.NewStdioMCPClient(cfg.Command, cfg.Env, cfg.Args...)
-	default:
-		return fmt.Errorf("invalid config: missing url or command")
-	}
+	cli, err := buildMCPClient(conn.Name, cfg)
 	if err != nil {
 		return fmt.Errorf("client create: %w", err)
 	}

--- a/internal/tools/mcp_oauth.go
+++ b/internal/tools/mcp_oauth.go
@@ -1,0 +1,370 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cnjack/jcode/internal/config"
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+)
+
+// ---------------------------------------------------------------------------
+// MCP OAuth: persistent token store + interactive login driver.
+//
+// The mark3labs/mcp-go library implements the full OAuth flow (RFC 8414/9728
+// metadata discovery, RFC 7591 dynamic client registration, PKCE, token
+// refresh). We provide a file-backed transport.TokenStore so tokens survive
+// restarts, and a thin driver that runs the authorization-code flow against a
+// fixed loopback callback port and guides the user through the browser.
+// ---------------------------------------------------------------------------
+
+const (
+	// mcpOAuthCallbackAddr is the fixed loopback address the OAuth redirect
+	// lands on. The matching redirect URI is documentable so users can
+	// pre-register it when an authorization server does not support dynamic
+	// client registration.
+	mcpOAuthCallbackAddr = "127.0.0.1:13380"
+	mcpOAuthRedirectURI  = "http://127.0.0.1:13380/oauth/callback"
+)
+
+// ErrOAuthNeedsClientID indicates the authorization server does not support
+// dynamic client registration and no client_id was configured. The caller
+// should prompt the user to supply an OAuth Client ID (and optionally secret).
+var ErrOAuthNeedsClientID = errors.New("dynamic client registration unavailable; set an OAuth Client ID")
+
+// MCPOAuthDir returns the directory where MCP OAuth tokens are persisted.
+func MCPOAuthDir() string {
+	return filepath.Join(config.ConfigDir(), "oauth")
+}
+
+// sanitizeServerName makes a config server name safe to use as a filename.
+func sanitizeServerName(name string) string {
+	r := strings.NewReplacer("/", "_", "\\", "_", ":", "_", "..", "_")
+	return r.Replace(name)
+}
+
+func mcpTokenPath(name string) string {
+	return filepath.Join(MCPOAuthDir(), sanitizeServerName(name)+".json")
+}
+
+// mcpFileTokenStore is a file-backed transport.TokenStore scoped to one server.
+type mcpFileTokenStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewMCPTokenStore returns a transport.TokenStore that persists the token for
+// the named server at ~/.jcode/oauth/<server>.json.
+func NewMCPTokenStore(serverName string) transport.TokenStore {
+	return &mcpFileTokenStore{path: mcpTokenPath(serverName)}
+}
+
+// GetToken returns the persisted token, or transport.ErrNoToken if none exists.
+func (s *mcpFileTokenStore) GetToken(ctx context.Context) (*transport.Token, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, transport.ErrNoToken
+		}
+		return nil, err
+	}
+	var tok transport.Token
+	if err := json.Unmarshal(data, &tok); err != nil {
+		return nil, fmt.Errorf("mcp oauth: decode token: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return nil, transport.ErrNoToken
+	}
+	return &tok, nil
+}
+
+// SaveToken persists the token with 0600 permissions.
+func (s *mcpFileTokenStore) SaveToken(ctx context.Context, token *transport.Token) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(token)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.path, data, 0o600)
+}
+
+// HasMCPOAuthToken reports whether a (non-empty) token is stored for the server.
+func HasMCPOAuthToken(serverName string) bool {
+	data, err := os.ReadFile(mcpTokenPath(serverName))
+	if err != nil {
+		return false
+	}
+	var tok transport.Token
+	if err := json.Unmarshal(data, &tok); err != nil {
+		return false
+	}
+	return tok.AccessToken != ""
+}
+
+// DeleteMCPOAuthToken removes the persisted token for a server (no error if absent).
+func DeleteMCPOAuthToken(serverName string) error {
+	err := os.Remove(mcpTokenPath(serverName))
+	if err != nil && os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// Client construction (shared by LoadMCPTools and MCPManager)
+// ---------------------------------------------------------------------------
+
+// mcpUsesOAuth reports whether a server should be connected via the OAuth
+// transport: either OAuth is explicitly enabled, or a token already exists.
+func mcpUsesOAuth(name string, srv *config.MCPServer) bool {
+	return (srv.OAuth != nil && srv.OAuth.Enabled) || HasMCPOAuthToken(name)
+}
+
+// mcpTimeout returns the configured request timeout, or 0 to use the library default.
+func mcpTimeout(srv *config.MCPServer) time.Duration {
+	if srv.TimeoutSeconds > 0 {
+		return time.Duration(srv.TimeoutSeconds) * time.Second
+	}
+	return 0
+}
+
+func mcpOAuthConfig(name string, srv *config.MCPServer) transport.OAuthConfig {
+	oa := srv.OAuth
+	if oa == nil {
+		oa = &config.MCPOAuthConfig{}
+	}
+	return transport.OAuthConfig{
+		ClientID:              oa.ClientID,
+		ClientSecret:          oa.ClientSecret,
+		RedirectURI:           mcpOAuthRedirectURI,
+		Scopes:                oa.Scopes,
+		TokenStore:            NewMCPTokenStore(name),
+		PKCEEnabled:           true,
+		AuthServerMetadataURL: oa.AuthServerMetadataURL,
+	}
+}
+
+// buildMCPClient constructs an MCP client for a server config, selecting the
+// transport (stdio / streamable-http / SSE) and wiring OAuth + timeout +
+// headers as appropriate.
+func buildMCPClient(name string, srv *config.MCPServer) (*client.Client, error) {
+	switch {
+	case srv.Type == "http":
+		var opts []transport.StreamableHTTPCOption
+		if len(srv.Headers) > 0 {
+			opts = append(opts, transport.WithHTTPHeaders(srv.Headers))
+		}
+		if d := mcpTimeout(srv); d > 0 {
+			opts = append(opts, transport.WithHTTPTimeout(d))
+		}
+		if mcpUsesOAuth(name, srv) {
+			return client.NewOAuthStreamableHttpClient(srv.URL, mcpOAuthConfig(name, srv), opts...)
+		}
+		return client.NewStreamableHttpClient(srv.URL, opts...)
+	case srv.URL != "" || srv.Type == "sse":
+		var opts []transport.ClientOption
+		if len(srv.Headers) > 0 {
+			opts = append(opts, transport.WithHeaders(srv.Headers))
+		}
+		if d := mcpTimeout(srv); d > 0 {
+			opts = append(opts, transport.WithEndpointTimeout(d))
+		}
+		if mcpUsesOAuth(name, srv) {
+			return client.NewOAuthSSEClient(srv.URL, mcpOAuthConfig(name, srv), opts...)
+		}
+		return client.NewSSEMCPClient(srv.URL, opts...)
+	case srv.Command != "" || srv.Type == "stdio":
+		return client.NewStdioMCPClient(srv.Command, srv.Env, srv.Args...)
+	default:
+		return nil, fmt.Errorf("invalid config: missing url or command")
+	}
+}
+
+// isMCPAuthError reports whether an error indicates the server requires OAuth
+// authorization (a 401 challenge or the library's auth-required sentinel).
+func isMCPAuthError(err error) bool {
+	return client.IsOAuthAuthorizationRequiredError(err) || client.IsAuthorizationRequiredError(err)
+}
+
+// ---------------------------------------------------------------------------
+// Login driver
+// ---------------------------------------------------------------------------
+
+type oauthCallbackResult struct {
+	code  string
+	state string
+	err   string
+}
+
+// PerformMCPOAuthLogin runs the OAuth 2.0 authorization-code flow for an
+// HTTP/SSE MCP server: it discovers the authorization server, dynamically
+// registers a client (falling back to a configured client_id/secret when
+// registration is unsupported), opens a fixed loopback callback, and exchanges
+// the returned code for a token persisted via NewMCPTokenStore.
+//
+// onAuthURL is invoked with the authorization URL once it is built — the caller
+// is responsible for opening a browser and/or displaying the URL to the user.
+//
+// On success it mutates srv.OAuth (Enabled, and ClientID/ClientSecret when
+// obtained via dynamic registration); the caller must persist the config.
+// ctx should carry a timeout (the flow blocks waiting for the browser callback).
+func PerformMCPOAuthLogin(ctx context.Context, name string, srv *config.MCPServer, onAuthURL func(url string)) error {
+	if srv == nil {
+		return fmt.Errorf("mcp oauth: nil server config")
+	}
+	if srv.URL == "" {
+		return fmt.Errorf("mcp oauth: server %q has no URL (OAuth only applies to http/sse transports)", name)
+	}
+	if srv.OAuth == nil {
+		srv.OAuth = &config.MCPOAuthConfig{}
+	}
+
+	oauthCfg := transport.OAuthConfig{
+		ClientID:              srv.OAuth.ClientID,
+		ClientSecret:          srv.OAuth.ClientSecret,
+		RedirectURI:           mcpOAuthRedirectURI,
+		Scopes:                srv.OAuth.Scopes,
+		TokenStore:            NewMCPTokenStore(name),
+		PKCEEnabled:           true,
+		AuthServerMetadataURL: srv.OAuth.AuthServerMetadataURL,
+	}
+	h := transport.NewOAuthHandler(oauthCfg)
+	h.SetBaseURL(srv.URL)
+
+	// Start the loopback callback server before opening the browser.
+	cbChan := make(chan oauthCallbackResult, 1)
+	cbServer, err := startMCPCallbackServer(cbChan)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cbServer.Close() }()
+
+	verifier, err := transport.GenerateCodeVerifier()
+	if err != nil {
+		return fmt.Errorf("mcp oauth: generate code verifier: %w", err)
+	}
+	challenge := transport.GenerateCodeChallenge(verifier)
+	state, err := transport.GenerateState()
+	if err != nil {
+		return fmt.Errorf("mcp oauth: generate state: %w", err)
+	}
+
+	// Dynamic client registration (RFC 7591), with manual fallback. When a
+	// client_id is already configured, GetClientID() != "" and we skip
+	// registration entirely (the manual/fallback path).
+	if h.GetClientID() == "" {
+		if regErr := h.RegisterClient(ctx, "jcode"); regErr != nil {
+			return fmt.Errorf("%w: %v", ErrOAuthNeedsClientID, regErr)
+		}
+	}
+
+	authURL, err := h.GetAuthorizationURL(ctx, state, challenge)
+	if err != nil {
+		return fmt.Errorf("mcp oauth: build authorization URL: %w", err)
+	}
+	if onAuthURL != nil {
+		onAuthURL(authURL)
+	}
+
+	select {
+	case res := <-cbChan:
+		if res.err != "" {
+			return fmt.Errorf("mcp oauth: authorization denied: %s", res.err)
+		}
+		if res.state != state {
+			return fmt.Errorf("mcp oauth: state mismatch (possible CSRF)")
+		}
+		if res.code == "" {
+			return fmt.Errorf("mcp oauth: no authorization code returned")
+		}
+		if err := h.ProcessAuthorizationResponse(ctx, res.code, res.state, verifier); err != nil {
+			return fmt.Errorf("mcp oauth: token exchange failed: %w", err)
+		}
+	case <-ctx.Done():
+		return fmt.Errorf("mcp oauth: timed out waiting for browser authorization: %w", ctx.Err())
+	}
+
+	// Persist what we learned so reconnect uses the same (possibly dynamically
+	// registered) client and re-attaches the bearer token.
+	srv.OAuth.Enabled = true
+	if id := h.GetClientID(); id != "" {
+		srv.OAuth.ClientID = id
+	}
+	if sec := h.GetClientSecret(); sec != "" {
+		srv.OAuth.ClientSecret = sec
+	}
+	config.Logger().Printf("[mcp oauth] %q: authorization successful", name)
+	return nil
+}
+
+// startMCPCallbackServer binds the fixed loopback callback port and serves the
+// OAuth redirect. The first request's query params are delivered on ch.
+func startMCPCallbackServer(ch chan<- oauthCallbackResult) (*http.Server, error) {
+	ln, err := net.Listen("tcp", mcpOAuthCallbackAddr)
+	if err != nil {
+		return nil, fmt.Errorf("mcp oauth: cannot bind callback %s (another login in progress?): %w", mcpOAuthCallbackAddr, err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/callback", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		res := oauthCallbackResult{
+			code:  q.Get("code"),
+			state: q.Get("state"),
+			err:   q.Get("error"),
+		}
+		if desc := q.Get("error_description"); desc != "" && res.err != "" {
+			res.err = res.err + ": " + desc
+		}
+		select {
+		case ch <- res:
+		default:
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if res.err != "" {
+			_, _ = w.Write([]byte(callbackHTML("Authorization failed", res.err)))
+			return
+		}
+		_, _ = w.Write([]byte(callbackHTML("Authorization successful", "You can close this window and return to jcode.")))
+	})
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		if serveErr := srv.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			config.Logger().Printf("[mcp oauth] callback server error: %v", serveErr)
+		}
+	}()
+	return srv, nil
+}
+
+func callbackHTML(title, msg string) string {
+	return `<!doctype html><html><head><meta charset="utf-8"><title>` + title + `</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;background:#111;color:#eee;display:flex;
+align-items:center;justify-content:center;height:100vh;margin:0}div{text-align:center}h1{color:#FF8400}</style></head>
+<body><div><h1>` + title + `</h1><p>` + msg + `</p><script>setTimeout(function(){window.close()},1500)</script></div></body></html>`
+}

--- a/internal/tools/mcp_oauth_test.go
+++ b/internal/tools/mcp_oauth_test.go
@@ -1,0 +1,109 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cnjack/jcode/internal/config"
+	"github.com/mark3labs/mcp-go/client/transport"
+)
+
+func TestMCPFileTokenStore(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+
+	store := NewMCPTokenStore("acme")
+
+	// No token yet → ErrNoToken.
+	if _, err := store.GetToken(ctx); !errors.Is(err, transport.ErrNoToken) {
+		t.Fatalf("expected ErrNoToken, got %v", err)
+	}
+	if HasMCPOAuthToken("acme") {
+		t.Fatal("expected HasMCPOAuthToken=false before save")
+	}
+
+	tok := &transport.Token{
+		AccessToken:  "tok_abc",
+		TokenType:    "Bearer",
+		RefreshToken: "ref_xyz",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}
+	if err := store.SaveToken(ctx, tok); err != nil {
+		t.Fatalf("SaveToken: %v", err)
+	}
+
+	got, err := store.GetToken(ctx)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if got.AccessToken != "tok_abc" || got.RefreshToken != "ref_xyz" {
+		t.Fatalf("token round-trip mismatch: %+v", got)
+	}
+	if !HasMCPOAuthToken("acme") {
+		t.Fatal("expected HasMCPOAuthToken=true after save")
+	}
+
+	if err := DeleteMCPOAuthToken("acme"); err != nil {
+		t.Fatalf("DeleteMCPOAuthToken: %v", err)
+	}
+	if HasMCPOAuthToken("acme") {
+		t.Fatal("expected HasMCPOAuthToken=false after delete")
+	}
+	// Deleting a missing token is a no-op.
+	if err := DeleteMCPOAuthToken("acme"); err != nil {
+		t.Fatalf("DeleteMCPOAuthToken (missing): %v", err)
+	}
+}
+
+// TestPerformMCPOAuthLoginManualFallback verifies that when the authorization
+// server advertises no dynamic client registration endpoint and no client_id is
+// configured, the login driver returns ErrOAuthNeedsClientID so callers can
+// prompt for a manual client id.
+func TestPerformMCPOAuthLoginManualFallback(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// The driver binds a fixed loopback callback port; if it is unavailable
+	// (busy or sandbox-restricted) skip rather than fail spuriously.
+	if ln, err := net.Listen("tcp", mcpOAuthCallbackAddr); err != nil {
+		t.Skipf("cannot bind %s: %v", mcpOAuthCallbackAddr, err)
+	} else {
+		_ = ln.Close()
+	}
+
+	// Authorization server metadata WITHOUT a registration_endpoint.
+	var baseURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer": "` + baseURL + `",
+			"authorization_endpoint": "` + baseURL + `/authorize",
+			"token_endpoint": "` + baseURL + `/token"
+		}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	baseURL = ts.URL
+
+	srv := &config.MCPServer{
+		Type: "http",
+		URL:  ts.URL + "/mcp",
+		OAuth: &config.MCPOAuthConfig{
+			Enabled:               true,
+			AuthServerMetadataURL: ts.URL + "/.well-known/oauth-authorization-server",
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := PerformMCPOAuthLogin(ctx, "acme", srv, nil)
+	if !errors.Is(err, ErrOAuthNeedsClientID) {
+		t.Fatalf("expected ErrOAuthNeedsClientID, got %v", err)
+	}
+}

--- a/internal/tui/input_views.go
+++ b/internal/tui/input_views.go
@@ -31,6 +31,7 @@ func (m Model) getAllCommands() []commandSuggestion {
 		{"/goal", "Set a persistent objective (auto-continues)"},
 		{"/bg", "List background tasks"},
 		{"/channel", "Manage channels (WeChat etc.)"},
+		{"/mcp", "List MCP servers / log in (/mcp login <name>)"},
 		{"/help", "Show keyboard shortcuts"},
 	}
 	for _, sc := range m.skillSlashCommands {

--- a/internal/tui/mcp_command.go
+++ b/internal/tui/mcp_command.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// handleMCPInput handles the /mcp slash command. Without arguments it lists
+// configured MCP servers and their connection status; "/mcp login <name>"
+// triggers an OAuth login flow on the main goroutine (which opens the browser).
+func (m *Model) handleMCPInput(prompt string, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	m.textarea.SetValue("")
+	fields := strings.Fields(prompt)
+
+	// /mcp login <name>
+	if len(fields) >= 2 && fields[1] == "login" {
+		if len(fields) < 3 {
+			m.lines = append(m.lines, textLine("  Usage: /mcp login <server-name>"))
+			m.refreshViewport()
+			return m, tea.Batch(cmds...)
+		}
+		name := fields[2]
+		RequestMCPLogin(name)
+		m.lines = append(m.lines, textLine(fmt.Sprintf("  %s Starting OAuth login for %s — your browser will open…",
+			toolLabelStyle.Render("🔐 MCP:"), toolNameStyle.Render(name))))
+		m.refreshViewport()
+		return m, tea.Batch(cmds...)
+	}
+
+	// /mcp — list servers + status.
+	if len(m.mcpStatuses) == 0 {
+		m.lines = append(m.lines, textLine("  No MCP servers connected. Add one with: jcode mcp add <name> <url>"))
+		m.refreshViewport()
+		return m, tea.Batch(cmds...)
+	}
+
+	m.lines = append(m.lines, textLine(toolLabelStyle.Render("🔌 MCP servers:")))
+	for _, st := range m.mcpStatuses {
+		var status string
+		switch {
+		case st.NeedsAuth:
+			status = "needs login → /mcp login " + st.Name
+		case st.Running:
+			status = fmt.Sprintf("connected · %d tool(s)", st.ToolCount)
+		case st.ErrMsg != "":
+			status = "error: " + st.ErrMsg
+		default:
+			status = "configured"
+		}
+		m.lines = append(m.lines, textLine(fmt.Sprintf("  %s — %s", toolNameStyle.Render(st.Name), status)))
+	}
+	m.refreshViewport()
+	return m, tea.Batch(cmds...)
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -204,6 +204,9 @@ type MCPStatusItem struct {
 	ToolCount int
 	Running   bool
 	ErrMsg    string
+	// NeedsAuth is true when the server requires OAuth login before its tools
+	// become available (use /mcp to log in).
+	NeedsAuth bool
 }
 
 type MCPStatusMsg struct {
@@ -377,6 +380,29 @@ var channelActionCh = make(chan ChannelAction, 1)
 // GetChannelActionChannel returns the channel for channel action events.
 func GetChannelActionChannel() <-chan ChannelAction {
 	return channelActionCh
+}
+
+// mcpLoginCh carries an MCP server name from the TUI to the main goroutine to
+// start an OAuth login flow.
+var mcpLoginCh = make(chan string, 1)
+
+// GetMCPLoginChannel returns the channel for MCP OAuth login requests.
+func GetMCPLoginChannel() <-chan string {
+	return mcpLoginCh
+}
+
+// RequestMCPLogin asks the main goroutine to begin OAuth login for a server.
+func RequestMCPLogin(name string) {
+	select {
+	case mcpLoginCh <- name:
+	default:
+	}
+}
+
+// MCPNoticeMsg is sent from the main goroutine to surface an MCP status line
+// (login progress, errors) in the TUI transcript.
+type MCPNoticeMsg struct {
+	Text string
 }
 
 // ChannelStateMsg is sent from the main goroutine to update channel state display in TUI.

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -847,6 +847,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 						return m.handleChannelInput(cmds)
 					}
 
+					if prompt == "/mcp" || strings.HasPrefix(prompt, "/mcp ") {
+						return m.handleMCPInput(prompt, cmds)
+					}
+
 					if prompt == "/help" {
 						m.showingHelp = true
 						m.helpScroll = 0
@@ -1186,6 +1190,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 	case MCPStatusMsg:
 		m.mcpStatuses = msg.Statuses
 		m.invalidateSidebarCache()
+		m.refreshViewport()
+
+	case MCPNoticeMsg:
+		m.lines = append(m.lines, textLine("  "+toolLabelStyle.Render("🔐 MCP:")+" "+msg.Text))
 		m.refreshViewport()
 
 	case ChannelStateMsg:

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,8 +2,25 @@ package utils
 
 import (
 	"os"
+	"os/exec"
 	"runtime"
 )
+
+// OpenURL opens the given URL in the user's default browser. It returns the
+// error from launching the platform-specific opener (the command is started,
+// not waited on).
+func OpenURL(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", "", url)
+	default: // linux, freebsd, etc.
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}
 
 func GetWorkDir() string {
 	// try to get the current working directory

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,11 +13,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/schema"
@@ -32,6 +33,7 @@ import (
 	"github.com/cnjack/jcode/internal/skills"
 	"github.com/cnjack/jcode/internal/telemetry"
 	"github.com/cnjack/jcode/internal/tools"
+	utils "github.com/cnjack/jcode/internal/util"
 )
 
 // Server is the jcode web server.
@@ -87,8 +89,17 @@ type Server struct {
 	// skillLoader provides skill listing for slash commands.
 	skillLoader *skills.Loader
 
-	// disabledMCP tracks MCP servers that have been disabled via the UI.
-	disabledMCP map[string]bool
+	// reloadMCP re-establishes MCP connections from the given server map and
+	// swaps in the fresh tool set (the agent is rebuilt by the caller). nil
+	// when MCP hot-reload is unavailable. Returns per-server statuses.
+	reloadMCP func(servers map[string]*config.MCPServer) ([]tools.MCPStatus, error)
+
+	// mcpStatuses is the most recent per-server connection status, used by the
+	// management UI. Guarded by mu.
+	mcpStatuses map[string]tools.MCPStatus
+
+	// mcpLogins tracks in-progress/finished OAuth logins per server name. Guarded by mu.
+	mcpLogins map[string]*mcpLoginState
 
 	// sessionSnapshot holds the git tree hash at the start of an agent run,
 	// used to compute session-scoped diffs (agent changes only).
@@ -113,31 +124,33 @@ type Server struct {
 
 // ServerConfig holds the configuration for creating a new Server.
 type ServerConfig struct {
-	Port           int
-	Host           string
-	OpenBrowser    bool
-	Pwd            string
-	Version        string
-	Agent          *adk.ChatModelAgent
-	CreateAgent    func(providerName, modelName string) (*adk.ChatModelAgent, error)
-	RebuildForMode func(planMode bool) (*adk.ChatModelAgent, error)
-	InitialMode    string // unified startup mode string ("ask"/"plan"/"autopilot")
-	SwitchProject  func(newPwd string) (*adk.ChatModelAgent, *session.Recorder, error)
-	TodoStore      *tools.TodoStore
-	Recorder       *session.Recorder
-	Tracer         *telemetry.LangfuseTracer
-	Env            *tools.Env
-	ProviderName   string
-	ModelName      string
-	Config         *config.Config
-	Registry       *model.ModelRegistry
-	ApprovalState  *runner.ApprovalState
-	SkillLoader    *skills.Loader
-	WechatClient   channel.Channel           // optional WeChat channel
-	WebHandler     *handler.WebHandler       // optional: pre-created handler for sharing with tools
-	EventHandler   handler.AgentEventHandler // optional: handler for runner (e.g. NotifyingHandler)
-	NeedsSetup     bool                      // true when no providers are configured (setup mode)
-	TokenUsage     *model.TokenUsage         // optional: shared token tracker (created when nil)
+	Port               int
+	Host               string
+	OpenBrowser        bool
+	Pwd                string
+	Version            string
+	Agent              *adk.ChatModelAgent
+	CreateAgent        func(providerName, modelName string) (*adk.ChatModelAgent, error)
+	RebuildForMode     func(planMode bool) (*adk.ChatModelAgent, error)
+	InitialMode        string // unified startup mode string ("ask"/"plan"/"autopilot")
+	SwitchProject      func(newPwd string) (*adk.ChatModelAgent, *session.Recorder, error)
+	TodoStore          *tools.TodoStore
+	Recorder           *session.Recorder
+	Tracer             *telemetry.LangfuseTracer
+	Env                *tools.Env
+	ProviderName       string
+	ModelName          string
+	Config             *config.Config
+	Registry           *model.ModelRegistry
+	ApprovalState      *runner.ApprovalState
+	SkillLoader        *skills.Loader
+	ReloadMCP          func(servers map[string]*config.MCPServer) ([]tools.MCPStatus, error) // optional: hot-reload MCP tools
+	InitialMCPStatuses []tools.MCPStatus                                                     // statuses from the startup MCP load
+	WechatClient       channel.Channel                                                       // optional WeChat channel
+	WebHandler         *handler.WebHandler                                                   // optional: pre-created handler for sharing with tools
+	EventHandler       handler.AgentEventHandler                                             // optional: handler for runner (e.g. NotifyingHandler)
+	NeedsSetup         bool                                                                  // true when no providers are configured (setup mode)
+	TokenUsage         *model.TokenUsage                                                     // optional: shared token tracker (created when nil)
 }
 
 // NewServer creates a new web server.
@@ -174,7 +187,9 @@ func NewServer(cfg *ServerConfig) *Server {
 		ptyMgr:         newPTYManager(),
 		approvalState:  cfg.ApprovalState,
 		skillLoader:    cfg.SkillLoader,
-		disabledMCP:    make(map[string]bool),
+		reloadMCP:      cfg.ReloadMCP,
+		mcpStatuses:    make(map[string]tools.MCPStatus),
+		mcpLogins:      make(map[string]*mcpLoginState),
 		wechatClient:   cfg.WechatClient,
 		eventHandler:   eh,
 		needsSetup:     cfg.NeedsSetup,
@@ -182,6 +197,9 @@ func NewServer(cfg *ServerConfig) *Server {
 	}
 	if s.tokenUsage == nil {
 		s.tokenUsage = &model.TokenUsage{}
+	}
+	for _, st := range cfg.InitialMCPStatuses {
+		s.mcpStatuses[st.Name] = st
 	}
 
 	// Wire TodoStore → session recording.
@@ -245,6 +263,8 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("POST /api/goal", s.handleSetGoal)
 	mux.HandleFunc("DELETE /api/goal", s.handleClearGoal)
 	mux.HandleFunc("POST /api/approval", s.handleApproval)
+	mux.HandleFunc("POST /api/ask", s.handleAskUser)
+	mux.HandleFunc("GET /api/ask/pending", s.handlePendingAskUser)
 	mux.HandleFunc("GET /api/files", s.handleListFiles)
 	mux.HandleFunc("GET /api/files/content", s.handleReadFile)
 	mux.HandleFunc("GET /api/status", s.handleStatus)
@@ -254,9 +274,15 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("POST /api/exec", s.handleExec)
 	mux.HandleFunc("GET /api/diff", s.handleDiff)
 	mux.HandleFunc("GET /api/mcp", s.handleListMCP)
+	mux.HandleFunc("POST /api/mcp/servers", s.handleCreateMCP)
+	mux.HandleFunc("PUT /api/mcp/servers/{name}", s.handleUpdateMCP)
+	mux.HandleFunc("DELETE /api/mcp/servers/{name}", s.handleDeleteMCP)
 	mux.HandleFunc("POST /api/mcp/{name}/toggle", s.handleToggleMCP)
+	mux.HandleFunc("POST /api/mcp/{name}/login", s.handleMCPLogin)
+	mux.HandleFunc("GET /api/mcp/{name}/login/status", s.handleMCPLoginStatus)
 	mux.HandleFunc("GET /api/ssh", s.handleListSSH)
 	mux.HandleFunc("GET /api/skills", s.handleListSkills)
+	mux.HandleFunc("POST /api/skills/{name}/toggle", s.handleToggleSkill)
 	mux.HandleFunc("GET /api/slash-commands", s.handleSlashCommands)
 	mux.HandleFunc("GET /api/browse", s.handleBrowse)
 	mux.HandleFunc("POST /api/project/switch", s.handleSwitchProject)
@@ -1101,6 +1127,49 @@ func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// handleAskUser resolves a pending ask_user request with the user's answers,
+// routed back to the blocked tool via WebHandler.ResolveAskUser. The "answers"
+// array is parallel to the questions the frontend received in ask_user_request:
+// each carries the question header plus either a free-text answer or selected
+// option labels.
+func (s *Server) handleAskUser(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ID      string `json:"id"`
+		Answers []struct {
+			QuestionHeader string   `json:"question_header"`
+			Answer         string   `json:"answer"`
+			Selected       []string `json:"selected"`
+		} `json:"answers"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+
+	resp := tools.AskUserBatchResponse{}
+	for _, a := range req.Answers {
+		resp.Answers = append(resp.Answers, tools.AskUserAnswer{
+			QuestionHeader: a.QuestionHeader,
+			Answer:         a.Answer,
+			Selected:       a.Selected,
+		})
+	}
+
+	if err := s.handler.ResolveAskUser(req.ID, resp); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handlePendingAskUser returns ask_user questions still awaiting an answer.
+// The frontend pulls this after rebuilding the timeline (page reload / session
+// resume) so an in-flight question is re-attached to its tool card instead of
+// leaving the agent blocked forever.
+func (s *Server) handlePendingAskUser(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.handler.PendingAskUserRequests())
+}
+
 func (s *Server) handleListFiles(w http.ResponseWriter, r *http.Request) {
 	dir := r.URL.Query().Get("path")
 	if dir == "" {
@@ -1424,31 +1493,278 @@ func (s *Server) handleSessionDiff(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
+// mcpLoginState tracks an in-progress or finished OAuth login for a server.
+type mcpLoginState struct {
+	Status  string `json:"status"` // pending | authorized | error | needs_client_id
+	AuthURL string `json:"auth_url,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// mcpServerView is the JSON shape returned for one MCP server in the list and
+// CRUD responses — enough for the management UI's status badges and edit form.
+type mcpServerView struct {
+	Name    string            `json:"name"`
+	Type    string            `json:"type"`
+	URL     string            `json:"url,omitempty"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     []string          `json:"env,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Timeout int               `json:"timeout,omitempty"`
+	Enabled bool              `json:"enabled"`
+	OAuth   bool              `json:"oauth"`    // OAuth enabled for this server
+	HasAuth bool              `json:"has_auth"` // a token is stored
+	Status  string            `json:"status"`   // connected | needs_auth | error | disabled | configured
+	Error   string            `json:"error,omitempty"`
+}
+
+// mcpServerReq is the request body for creating/updating an MCP server.
+type mcpServerReq struct {
+	Name    string            `json:"name"`
+	Type    string            `json:"type"` // local|stdio|http|sse
+	URL     string            `json:"url"`
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+	Env     []string          `json:"env"`
+	Headers map[string]string `json:"headers"`
+	Timeout int               `json:"timeout"`
+	OAuth   *struct {
+		Enabled      bool     `json:"enabled"`
+		ClientID     string   `json:"client_id"`
+		ClientSecret string   `json:"client_secret"`
+		Scopes       []string `json:"scopes"`
+	} `json:"oauth"`
+}
+
+// serverFromReq builds a config.MCPServer from a request body, normalizing the
+// transport ("local" → "stdio") and preserving any existing OAuth token state.
+func serverFromReq(req *mcpServerReq) (*config.MCPServer, error) {
+	srv := &config.MCPServer{
+		Headers:        req.Headers,
+		TimeoutSeconds: req.Timeout,
+	}
+	t := req.Type
+	if t == "local" {
+		t = "stdio"
+	}
+	switch t {
+	case "http", "sse":
+		if req.URL == "" {
+			return nil, fmt.Errorf("url is required for %s servers", t)
+		}
+		srv.Type = t
+		srv.URL = req.URL
+	case "stdio", "":
+		if req.Command == "" {
+			return nil, fmt.Errorf("command is required for local servers")
+		}
+		srv.Type = "stdio"
+		srv.Command = req.Command
+		srv.Args = req.Args
+		srv.Env = req.Env
+	default:
+		return nil, fmt.Errorf("unknown server type %q (use local, http, or sse)", req.Type)
+	}
+	if req.OAuth != nil && (req.OAuth.Enabled || req.OAuth.ClientID != "" || len(req.OAuth.Scopes) > 0) {
+		srv.OAuth = &config.MCPOAuthConfig{
+			Enabled:      req.OAuth.Enabled || req.OAuth.ClientID != "",
+			ClientID:     req.OAuth.ClientID,
+			ClientSecret: req.OAuth.ClientSecret,
+			Scopes:       req.OAuth.Scopes,
+		}
+	}
+	return srv, nil
+}
+
+// reloadMCPAndRebuild reconnects MCP servers from the current config and
+// rebuilds the live agent so new tools take effect without a restart.
+func (s *Server) reloadMCPAndRebuild() error {
+	if s.reloadMCP != nil {
+		s.mu.RLock()
+		servers := s.cfg.MCPServers
+		s.mu.RUnlock()
+		statuses, err := s.reloadMCP(servers)
+		if err != nil {
+			return err
+		}
+		s.mu.Lock()
+		s.mcpStatuses = make(map[string]tools.MCPStatus, len(statuses))
+		for _, st := range statuses {
+			s.mcpStatuses[st.Name] = st
+		}
+		s.mu.Unlock()
+	}
+	if s.createAgent != nil && !s.needsSetup {
+		s.mu.RLock()
+		prov, mod := s.providerName, s.modelName
+		s.mu.RUnlock()
+		ag, err := s.createAgent(prov, mod)
+		if err != nil {
+			return err
+		}
+		s.mu.Lock()
+		s.agent = ag
+		s.mu.Unlock()
+	}
+	return nil
+}
+
+// mcpServerStatus derives the UI status string for a server from its config and
+// last-known connection status.
+func (s *Server) mcpServerStatus(name string, srv *config.MCPServer) (status, errMsg string) {
+	if srv.Disabled {
+		return "disabled", ""
+	}
+	st, ok := s.mcpStatuses[name]
+	switch {
+	case !ok:
+		return "configured", ""
+	case st.NeedsAuth:
+		return "needs_auth", ""
+	case st.Running:
+		return "connected", ""
+	case st.Error != nil:
+		return "error", st.Error.Error()
+	default:
+		return "configured", ""
+	}
+}
+
 func (s *Server) handleListMCP(w http.ResponseWriter, r *http.Request) {
-	if s.cfg == nil || s.cfg.MCPServers == nil {
-		writeJSON(w, http.StatusOK, map[string]any{"servers": map[string]any{}})
-		return
-	}
-
-	type mcpInfo struct {
-		Type    string `json:"type"`
-		Command string `json:"command,omitempty"`
-		URL     string `json:"url,omitempty"`
-		Status  string `json:"status"`
-		Enabled bool   `json:"enabled"`
-	}
-
-	servers := make(map[string]mcpInfo)
-	for name, srv := range s.cfg.MCPServers {
-		servers[name] = mcpInfo{
-			Type:    srv.Type,
-			Command: srv.Command,
-			URL:     srv.URL,
-			Status:  "configured",
-			Enabled: !s.disabledMCP[name],
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	servers := make(map[string]mcpServerView)
+	if s.cfg != nil {
+		for name, srv := range s.cfg.MCPServers {
+			status, errMsg := s.mcpServerStatus(name, srv)
+			servers[name] = mcpServerView{
+				Name:    name,
+				Type:    srv.Type,
+				URL:     srv.URL,
+				Command: srv.Command,
+				Args:    srv.Args,
+				Env:     srv.Env,
+				Headers: srv.Headers,
+				Timeout: srv.TimeoutSeconds,
+				Enabled: !srv.Disabled,
+				OAuth:   srv.OAuth != nil && srv.OAuth.Enabled,
+				HasAuth: tools.HasMCPOAuthToken(name),
+				Status:  status,
+				Error:   errMsg,
+			}
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"servers": servers})
+}
+
+func (s *Server) handleCreateMCP(w http.ResponseWriter, r *http.Request) {
+	var req mcpServerReq
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<18)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	if req.Name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	srv, err := serverFromReq(&req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	s.mu.Lock()
+	if s.cfg.MCPServers == nil {
+		s.cfg.MCPServers = make(map[string]*config.MCPServer)
+	}
+	if _, exists := s.cfg.MCPServers[req.Name]; exists {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "a server with that name already exists"})
+		return
+	}
+	s.cfg.MCPServers[req.Name] = srv
+	if err := config.SaveConfig(s.cfg); err != nil {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.mu.Unlock()
+
+	if err := s.reloadMCPAndRebuild(); err != nil {
+		config.Logger().Printf("[web] mcp create reload failed: %v", err)
+	}
+	s.wsBroker.Broadcast(WSEvent{Type: "mcp_changed", Data: map[string]string{"name": req.Name}})
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "name": req.Name})
+}
+
+func (s *Server) handleUpdateMCP(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	var req mcpServerReq
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<18)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	srv, err := serverFromReq(&req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	s.mu.Lock()
+	existing, ok := s.cfg.MCPServers[name]
+	if !ok {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "server not found"})
+		return
+	}
+	// Preserve disabled flag and any already-obtained OAuth client id/secret so
+	// editing other fields doesn't drop a working registration.
+	srv.Disabled = existing.Disabled
+	if srv.OAuth != nil && existing.OAuth != nil {
+		if srv.OAuth.ClientID == "" {
+			srv.OAuth.ClientID = existing.OAuth.ClientID
+		}
+		if srv.OAuth.ClientSecret == "" {
+			srv.OAuth.ClientSecret = existing.OAuth.ClientSecret
+		}
+	}
+	s.cfg.MCPServers[name] = srv
+	if err := config.SaveConfig(s.cfg); err != nil {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.mu.Unlock()
+
+	if err := s.reloadMCPAndRebuild(); err != nil {
+		config.Logger().Printf("[web] mcp update reload failed: %v", err)
+	}
+	s.wsBroker.Broadcast(WSEvent{Type: "mcp_changed", Data: map[string]string{"name": name}})
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "name": name})
+}
+
+func (s *Server) handleDeleteMCP(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	s.mu.Lock()
+	if _, ok := s.cfg.MCPServers[name]; !ok {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "server not found"})
+		return
+	}
+	delete(s.cfg.MCPServers, name)
+	delete(s.mcpStatuses, name)
+	delete(s.mcpLogins, name)
+	if err := config.SaveConfig(s.cfg); err != nil {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.mu.Unlock()
+
+	_ = tools.DeleteMCPOAuthToken(name)
+	if err := s.reloadMCPAndRebuild(); err != nil {
+		config.Logger().Printf("[web] mcp delete reload failed: %v", err)
+	}
+	s.wsBroker.Broadcast(WSEvent{Type: "mcp_changed", Data: map[string]string{"name": name}})
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
 }
 
 func (s *Server) handleToggleMCP(w http.ResponseWriter, r *http.Request) {
@@ -1457,7 +1773,6 @@ func (s *Server) handleToggleMCP(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
 		return
 	}
-
 	var req struct {
 		Enabled bool `json:"enabled"`
 	}
@@ -1465,19 +1780,126 @@ func (s *Server) handleToggleMCP(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
 		return
 	}
+	s.mu.Lock()
+	srv, ok := s.cfg.MCPServers[name]
+	if !ok {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "server not found"})
+		return
+	}
+	srv.Disabled = !req.Enabled
+	if err := config.SaveConfig(s.cfg); err != nil {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.mu.Unlock()
 
-	if s.cfg == nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "no config loaded"})
+	if err := s.reloadMCPAndRebuild(); err != nil {
+		config.Logger().Printf("[web] mcp toggle reload failed: %v", err)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "name": name, "enabled": req.Enabled})
+}
+
+// handleMCPLogin starts the OAuth authorization flow for an HTTP/SSE server in
+// the background and opens the user's browser. Progress is polled via
+// handleMCPLoginStatus.
+func (s *Server) handleMCPLogin(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	s.mu.Lock()
+	srv, ok := s.cfg.MCPServers[name]
+	if !ok {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "server not found"})
+		return
+	}
+	if srv.URL == "" || (srv.Type != "http" && srv.Type != "sse") {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "OAuth login only applies to http/sse servers"})
+		return
+	}
+	if existing := s.mcpLogins[name]; existing != nil && existing.Status == "pending" {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "a login is already in progress"})
+		return
+	}
+	if srv.OAuth == nil {
+		srv.OAuth = &config.MCPOAuthConfig{Enabled: true}
+	}
+	s.mcpLogins[name] = &mcpLoginState{Status: "pending"}
+	s.mu.Unlock()
+
+	go s.runMCPLogin(name)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "pending"})
+}
+
+func (s *Server) setMCPLogin(name, status, msg string) {
+	s.mu.Lock()
+	st := s.mcpLogins[name]
+	if st == nil {
+		st = &mcpLoginState{}
+		s.mcpLogins[name] = st
+	}
+	st.Status = status
+	st.Message = msg
+	s.mu.Unlock()
+}
+
+func (s *Server) runMCPLogin(name string) {
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Minute)
+	defer cancel()
+
+	s.mu.RLock()
+	srv := s.cfg.MCPServers[name]
+	s.mu.RUnlock()
+	if srv == nil {
+		s.setMCPLogin(name, "error", "server not found")
 		return
 	}
 
-	if req.Enabled {
-		delete(s.disabledMCP, name)
-	} else {
-		s.disabledMCP[name] = true
+	err := tools.PerformMCPOAuthLogin(ctx, name, srv, func(authURL string) {
+		s.mu.Lock()
+		if st := s.mcpLogins[name]; st != nil {
+			st.AuthURL = authURL
+		}
+		s.mu.Unlock()
+		s.wsBroker.Broadcast(WSEvent{Type: "mcp_login", Data: map[string]string{"name": name, "auth_url": authURL}})
+		openBrowser(authURL)
+	})
+	if err != nil {
+		status := "error"
+		if errors.Is(err, tools.ErrOAuthNeedsClientID) {
+			status = "needs_client_id"
+		}
+		s.setMCPLogin(name, status, err.Error())
+		config.Logger().Printf("[web] mcp login %q failed: %v", name, err)
+		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "name": name, "enabled": req.Enabled})
+	// Persist the (possibly dynamically registered) client id and enabled flag.
+	s.mu.Lock()
+	if saveErr := config.SaveConfig(s.cfg); saveErr != nil {
+		config.Logger().Printf("[web] mcp login %q: save config failed: %v", name, saveErr)
+	}
+	s.mu.Unlock()
+
+	if reErr := s.reloadMCPAndRebuild(); reErr != nil {
+		config.Logger().Printf("[web] mcp login %q: reload failed: %v", name, reErr)
+	}
+	s.setMCPLogin(name, "authorized", "")
+	s.wsBroker.Broadcast(WSEvent{Type: "mcp_changed", Data: map[string]string{"name": name}})
+}
+
+func (s *Server) handleMCPLoginStatus(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	s.mu.RLock()
+	st := s.mcpLogins[name]
+	s.mu.RUnlock()
+	if st == nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "idle"})
+		return
+	}
+	writeJSON(w, http.StatusOK, st)
 }
 
 func (s *Server) handleBrowse(w http.ResponseWriter, r *http.Request) {
@@ -1791,15 +2213,25 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 		Name        string `json:"name"`
 		Description string `json:"description"`
 		Slash       string `json:"slash"`
+		Builtin     bool   `json:"builtin"`
+		Source      string `json:"source"` // builtin | local
+		Enabled     bool   `json:"enabled"`
 	}
 
 	var items []skillItem
 	if s.skillLoader != nil {
-		for _, sk := range s.skillLoader.SlashCommands() {
+		for _, sk := range s.skillLoader.All() {
+			source := "local"
+			if sk.Builtin {
+				source = "builtin"
+			}
 			items = append(items, skillItem{
 				Name:        sk.Name,
 				Description: sk.Description,
 				Slash:       sk.Slash,
+				Builtin:     sk.Builtin,
+				Source:      source,
+				Enabled:     s.skillLoader.IsEnabled(sk.Name),
 			})
 		}
 	}
@@ -1807,6 +2239,66 @@ func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
 		items = []skillItem{}
 	}
 	writeJSON(w, http.StatusOK, items)
+}
+
+// handleToggleSkill enables/disables a skill, persisting to config and updating
+// the loader + agent so the change takes effect immediately.
+func (s *Server) handleToggleSkill(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	var req struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	if s.skillLoader == nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "skills unavailable"})
+		return
+	}
+
+	s.mu.Lock()
+	// Rebuild the disabled set from config.
+	disabled := make(map[string]bool, len(s.cfg.DisabledSkills))
+	for _, n := range s.cfg.DisabledSkills {
+		disabled[n] = true
+	}
+	if req.Enabled {
+		delete(disabled, name)
+	} else {
+		disabled[name] = true
+	}
+	list := make([]string, 0, len(disabled))
+	for n := range disabled {
+		list = append(list, n)
+	}
+	sort.Strings(list)
+	s.cfg.DisabledSkills = list
+	if err := config.SaveConfig(s.cfg); err != nil {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	s.mu.Unlock()
+
+	s.skillLoader.SetDisabled(list)
+	// Rebuild the agent so the system prompt (skill descriptions) and load_skill
+	// tool reflect the change on the next run.
+	if s.createAgent != nil && !s.needsSetup {
+		s.mu.RLock()
+		prov, mod := s.providerName, s.modelName
+		s.mu.RUnlock()
+		if ag, err := s.createAgent(prov, mod); err == nil {
+			s.mu.Lock()
+			s.agent = ag
+			s.mu.Unlock()
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "name": name, "enabled": req.Enabled})
 }
 
 // handleSlashCommands returns skill slash commands for the web frontend
@@ -2304,16 +2796,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 
 // openBrowser opens the given URL in the user's default browser.
 func openBrowser(url string) {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", url)
-	default: // linux, freebsd, etc.
-		cmd = exec.Command("xdg-open", url)
-	}
-	if err := cmd.Start(); err != nil {
+	if err := utils.OpenURL(url); err != nil {
 		config.Logger().Printf("[web] failed to open browser: %v", err)
 	}
 }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -64,6 +64,7 @@ const { connected } = useWebSocket({
   onTodoUpdate: () => store.fetchTodos(),
   onGoalUpdate: (data) => { store.goal = data },
   onApprovalRequest: (data) => store.addApprovalRequest(data),
+  onAskUserRequest: (data) => store.attachAskUserRequest(data.id, data.questions),
   onSessionReset: () => store.clearChat(),
   onModelChanged: (data) => {
     store.providerName = data.provider
@@ -168,6 +169,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   document.removeEventListener('keydown', handleGlobalKeydown)
+  if (runTimer) clearInterval(runTimer)
 })
 
 function openFile() {
@@ -195,8 +197,20 @@ function togglePanel(panel: 'terminal' | 'files' | 'changes' | 'plan') {
 // seize the panel, and one-shot per run so a manual close is respected for the
 // rest of that run. A new run re-arms the one-shot.
 const planAutoOpened = ref(false)
+// Elapsed-time counter for the "Thinking…" footer; ticks once per second while
+// the agent runs, resets on each new run. Appears in the UI only after 2s.
+const elapsed = ref(0)
+let runTimer: ReturnType<typeof setInterval> | null = null
 watch(() => store.isRunning, (running) => {
-  if (running) planAutoOpened.value = false
+  if (running) {
+    planAutoOpened.value = false
+    elapsed.value = 0
+    if (runTimer) clearInterval(runTimer)
+    runTimer = setInterval(() => { elapsed.value++ }, 1000)
+  } else if (runTimer) {
+    clearInterval(runTimer)
+    runTimer = null
+  }
 })
 watch(() => store.todos.length, (len) => {
   if (len > 0 && store.isRunning && !planAutoOpened.value && !rightPanelOpen.value) {
@@ -319,12 +333,38 @@ function startResize(e: MouseEvent) {
               <ApprovalBanner v-else-if="item.kind === 'approval'" :approval="item.data" class="animate-fade-up" />
             </template>
 
-            <!-- Typing indicator -->
-            <div v-if="store.isRunning && store.timeline.length === 0" class="flex gap-1.5 py-5 pl-1">
-              <span class="w-2 h-2 rounded-full" style="background: var(--color-primary); opacity: 0.6; animation: dot-pulse 1.4s ease-in-out infinite; animation-delay: 0ms" />
-              <span class="w-2 h-2 rounded-full" style="background: var(--color-primary); opacity: 0.6; animation: dot-pulse 1.4s ease-in-out infinite; animation-delay: 160ms" />
-              <span class="w-2 h-2 rounded-full" style="background: var(--color-primary); opacity: 0.6; animation: dot-pulse 1.4s ease-in-out infinite; animation-delay: 320ms" />
-            </div>
+            <!-- Thinking footer: single source of truth for "agent is working".
+                 Trails the last timeline item, rides existing auto-scroll, and
+                 stays visible the whole run (initial wait AND while content
+                 accumulates) — not only when the timeline is empty. -->
+            <transition
+              enter-active-class="transition-opacity duration-300 ease-out"
+              enter-from-class="opacity-0"
+              enter-to-class="opacity-100"
+              leave-active-class="transition-opacity duration-150 ease-in"
+              leave-from-class="opacity-100"
+              leave-to-class="opacity-0"
+            >
+              <div
+                v-if="store.isRunning"
+                class="flex items-center gap-2.5 py-3 pl-9 select-none"
+                role="status"
+                aria-live="polite"
+                aria-label="Thinking"
+              >
+                <span class="flex gap-1" aria-hidden="true">
+                  <span class="w-1.5 h-1.5 rounded-full animate-dot-pulse" style="background: var(--color-primary); animation-delay: 0ms" />
+                  <span class="w-1.5 h-1.5 rounded-full animate-dot-pulse" style="background: var(--color-primary); animation-delay: 160ms" />
+                  <span class="w-1.5 h-1.5 rounded-full animate-dot-pulse" style="background: var(--color-primary); animation-delay: 320ms" />
+                </span>
+                <span class="thinking-label text-[13px]" style="font-family: var(--font-sans)">Thinking…</span>
+                <span
+                  v-if="elapsed >= 2"
+                  class="text-xs tabular-nums"
+                  style="font-family: var(--font-mono); color: var(--color-muted-foreground); opacity: 0.6"
+                >{{ elapsed }}s</span>
+              </div>
+            </transition>
           </div>
         </div>
 

--- a/web/src/components/ApprovalBanner.vue
+++ b/web/src/components/ApprovalBanner.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import type { PendingApproval } from '@/types/api'
 import { useChatStore } from '@/stores/chat'
 
@@ -7,6 +8,7 @@ defineProps<{
 }>()
 
 const store = useChatStore()
+const showArgs = ref(false)
 
 function formatArgs(args: string): string {
   try {
@@ -18,45 +20,148 @@ function formatArgs(args: string): string {
 </script>
 
 <template>
-  <div class="my-2 rounded-md border px-4 py-3 flex items-start gap-3 animate-fade-in"
+  <!-- ─── RESOLVED — dissolves into the borderless tool-row stream ─── -->
+  <div
+    v-if="approval.resolved"
+    class="pl-9 animate-fade-up"
+  >
+    <div class="flex items-center gap-1.5 py-1">
+      <!-- Shield glyph carries the resolved state (success / destructive) -->
+      <svg
+        class="w-3.5 h-3.5 shrink-0"
+        :style="{ color: approval.approved ? 'var(--color-success-fg)' : 'var(--color-destructive)' }"
+        viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"
+      >
+        <path v-if="approval.approved" fill-rule="evenodd" d="M10 1.5l6 2.2v4.8c0 4-2.6 7.6-6 8.5-3.4-.9-6-4.5-6-8.5V3.7l6-2.2zm2.78 6.16a.75.75 0 00-1.06-1.06L9 9.32 8.28 8.6a.75.75 0 10-1.06 1.06l1.25 1.25a.75.75 0 001.06 0l3.25-3.25z" clip-rule="evenodd" />
+        <path v-else fill-rule="evenodd" d="M10 1.5l6 2.2v4.8c0 4-2.6 7.6-6 8.5-3.4-.9-6-4.5-6-8.5V3.7l6-2.2zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
+      </svg>
+      <span class="text-xs font-mono truncate min-w-0" style="color: var(--color-muted-foreground)">{{ approval.tool_name }}</span>
+      <span
+        class="text-[10px] shrink-0"
+        :style="{ color: approval.approved ? 'var(--color-success-fg)' : 'var(--color-error-fg)' }"
+      >{{ approval.approved ? 'Allowed' : 'Denied' }}</span>
+      <span v-if="approval.is_external" class="text-[10px] shrink-0" style="color: var(--color-muted-foreground)">· external</span>
+    </div>
+  </div>
+
+  <!-- ─── PENDING — a real decision card: surface + 1px border + 3px breathing left accent bar ─── -->
+  <div
+    v-else
+    class="relative my-2 overflow-hidden animate-fade-up"
     :style="{
-      borderColor: approval.resolved
-        ? approval.approved ? 'var(--color-success-bg)' : 'var(--color-error-bg)'
-        : 'var(--color-warning-bg)',
-      backgroundColor: approval.resolved
-        ? approval.approved ? 'var(--color-success-bg)' : 'var(--color-error-bg)'
-        : 'var(--color-warning-bg)',
-    }">
-    <div class="flex-1 min-w-0">
-      <div class="text-xs mb-1 font-medium" style="color: var(--color-muted-foreground)">Approval required</div>
-      <div class="font-mono text-xs" style="color: var(--color-foreground)">{{ approval.tool_name }}</div>
-      <pre class="text-[10px] mt-1 max-h-12 overflow-hidden whitespace-pre-wrap font-mono" style="color: var(--color-muted-foreground)">{{ formatArgs(approval.tool_args) }}</pre>
-      <div v-if="approval.is_external" class="text-[10px] mt-1 font-medium" style="color: var(--color-warning-fg)">External path</div>
+      borderRadius: 'var(--radius-lg)',
+      background: 'var(--color-surface)',
+      border: '1px solid var(--color-border)',
+      boxShadow: 'var(--shadow-sm)',
+    }"
+  >
+    <!-- Left accent bar — the only chromatic signal, replacing the old full flood -->
+    <span
+      class="approval-accent absolute left-0 top-0 bottom-0"
+      style="width: 3px; background: var(--color-warning-fg)"
+      aria-hidden="true"
+    />
+
+    <div class="flex items-start gap-3 pl-4 pr-3 py-3">
+      <div class="flex-1 min-w-0">
+        <!-- Header: shield-lock glyph + label + external chip + args toggle -->
+        <div class="flex items-center gap-1.5 mb-1.5">
+          <svg
+            class="w-3.5 h-3.5 shrink-0"
+            style="color: var(--color-warning-fg)"
+            viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"
+          >
+            <path fill-rule="evenodd" d="M10 1.5l6 2.2v4.8c0 4-2.6 7.6-6 8.5-3.4-.9-6-4.5-6-8.5V3.7l6-2.2zM9 9V6.5a1 1 0 112 0V9h.5a.75.75 0 01.75.75v3a.75.75 0 01-.75.75h-3a.75.75 0 01-.75-.75v-3A.75.75 0 018.5 9H9z" clip-rule="evenodd" />
+          </svg>
+          <span class="text-xs font-medium" style="color: var(--color-foreground)">Approval needed</span>
+          <span
+            v-if="approval.is_external"
+            class="ml-1 px-1.5 py-0.5 text-[10px] font-medium shrink-0"
+            :style="{
+              borderRadius: 'var(--radius-pill)',
+              background: 'color-mix(in srgb, var(--color-warning-fg) 14%, transparent)',
+              color: 'var(--color-warning-fg)',
+            }"
+          >external path</span>
+          <button
+            type="button"
+            class="ml-auto shrink-0 inline-flex items-center cursor-pointer hover:opacity-70 transition-opacity"
+            :aria-expanded="showArgs"
+            aria-label="Toggle arguments"
+            @click="showArgs = !showArgs"
+          >
+            <svg
+              class="w-3.5 h-3.5 transition-transform"
+              :class="{ 'rotate-180': showArgs }"
+              style="color: var(--color-muted-foreground)"
+              viewBox="0 0 20 20" fill="currentColor"
+            >
+              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- Tool name -->
+        <div class="font-mono text-xs truncate" style="color: var(--color-foreground)">{{ approval.tool_name }}</div>
+
+        <!-- Collapsible args (collapsed by default; keeps the resting height tight) -->
+        <pre
+          v-if="showArgs"
+          class="text-[10px] mt-1.5 max-h-32 overflow-auto whitespace-pre-wrap font-mono leading-relaxed"
+          style="color: var(--color-muted-foreground)"
+        >{{ formatArgs(approval.tool_args) }}</pre>
+      </div>
+
+      <!-- Buttons: clear 3-tier hierarchy (primary / ghost / quiet) -->
+      <div class="flex gap-1.5 shrink-0 self-end">
+        <button
+          type="button"
+          class="px-3.5 py-1.5 text-xs rounded-md text-white transition-colors cursor-pointer font-medium shadow-sm"
+          style="background-color: var(--color-primary)"
+          @click="store.resolveApproval(approval.id, true, false)"
+        >
+          Allow once
+        </button>
+        <button
+          type="button"
+          class="px-3.5 py-1.5 text-xs rounded-md transition-colors cursor-pointer font-medium"
+          style="background-color: transparent; color: var(--color-foreground); border: 1px solid var(--color-border)"
+          title="Approve this and auto-approve the rest of the session"
+          @click="store.resolveApproval(approval.id, true, true)"
+        >
+          Allow all
+        </button>
+        <button
+          type="button"
+          class="approval-deny px-3 py-1.5 text-xs rounded-md transition-colors cursor-pointer font-medium"
+          style="background-color: transparent; color: var(--color-muted-foreground)"
+          @click="store.resolveApproval(approval.id, false)"
+        >
+          Deny
+        </button>
+      </div>
     </div>
-    <div v-if="!approval.resolved" class="flex gap-1.5 shrink-0">
-      <button
-        class="px-3.5 py-1.5 text-xs rounded-md text-white transition-colors cursor-pointer font-medium shadow-sm"
-        style="background-color: var(--color-primary)"
-        @click="store.resolveApproval(approval.id, true, false)">
-        Allow once
-      </button>
-      <button
-        class="px-3.5 py-1.5 text-xs rounded-md transition-colors cursor-pointer font-medium"
-        style="background-color: var(--color-secondary); color: var(--color-foreground)"
-        title="Approve this and auto-approve the rest of the session"
-        @click="store.resolveApproval(approval.id, true, true)">
-        Allow all
-      </button>
-      <button
-        class="px-3.5 py-1.5 text-xs rounded-md transition-colors cursor-pointer font-medium"
-        style="background-color: var(--color-secondary); color: var(--color-muted-foreground)"
-        @click="store.resolveApproval(approval.id, false)">
-        Deny
-      </button>
-    </div>
-    <span v-else class="text-xs shrink-0 font-medium"
-      :style="{ color: approval.approved ? 'var(--color-success-fg)' : 'var(--color-destructive)' }">
-      {{ approval.approved ? 'Allowed' : 'Denied' }}
-    </span>
   </div>
 </template>
+
+<style scoped>
+/* Subtle attention pulse on the accent bar — opacity-only, no glow flood. */
+@keyframes accent-breathe {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+.approval-accent {
+  animation: accent-breathe 2.4s ease-in-out infinite;
+}
+
+/* Deny stays quiet until hovered, then leans toward destructive —
+   available, never equated with approval. */
+.approval-deny:hover {
+  color: var(--color-destructive) !important;
+  background-color: var(--color-muted) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .approval-accent { animation: none !important; }
+}
+</style>

--- a/web/src/components/AskUserCard.vue
+++ b/web/src/components/AskUserCard.vue
@@ -1,0 +1,295 @@
+<script setup lang="ts">
+import { ref, computed, reactive, watch, onUnmounted } from 'vue'
+import type { ToolCall, AskUserQuestion, AskUserAnswer } from '@/types/api'
+import { useChatStore } from '@/stores/chat'
+
+defineOptions({ name: 'AskUserCard' })
+
+const props = defineProps<{
+  tool: ToolCall
+}>()
+
+const store = useChatStore()
+const collapsed = ref(false)
+// Locally remembered answers, set on submit/skip so the resolved view shows the
+// choice immediately during the brief gap before the tool_result event lands.
+const submitted = ref<string[] | null>(null)
+
+// ─── Questions: prefer the backend-normalized list, else parse the tool args ───
+const questions = computed<AskUserQuestion[]>(() => {
+  if (props.tool.askUserQuestions?.length) return props.tool.askUserQuestions
+  try {
+    const parsed = JSON.parse(props.tool.args || '{}')
+    if (Array.isArray(parsed.questions) && parsed.questions.length) {
+      return parsed.questions as AskUserQuestion[]
+    }
+    // Legacy single-question form: { question, options:[{label}] }
+    if (parsed.question) {
+      return [{
+        question: parsed.question,
+        options: Array.isArray(parsed.options)
+          ? parsed.options.map((o: { label: string }) => ({ label: o.label }))
+          : undefined,
+      }]
+    }
+  } catch { /* ignore */ }
+  return []
+})
+
+// Pending = there is a live request id and the tool has not resolved yet.
+const isPending = computed(() =>
+  !!props.tool.askUserId && props.tool.status === 'running' && !props.tool.output,
+)
+
+const title = computed(() => questions.value[0]?.question || 'Asking')
+
+// ─── Answer state (per question index) ───
+const selections = reactive<Record<number, string[]>>({})
+const freeText = reactive<Record<number, string>>({})
+
+function isSelected(qi: number, label: string): boolean {
+  return (selections[qi] || []).includes(label)
+}
+
+function toggleOption(qi: number, label: string, multi: boolean) {
+  const cur = selections[qi] || []
+  if (multi) {
+    selections[qi] = cur.includes(label) ? cur.filter((l) => l !== label) : [...cur, label]
+  } else {
+    // Single-select: replace, and clear any "Other" free text.
+    selections[qi] = cur.includes(label) ? [] : [label]
+    freeText[qi] = ''
+  }
+}
+
+function onFreeTextInput(qi: number, multi: boolean) {
+  // Typing a custom answer clears option selection for single-select.
+  if (!multi && freeText[qi]) selections[qi] = []
+}
+
+function buildAnswers(): AskUserAnswer[] {
+  return questions.value.map((q, qi) => {
+    const header = q.header || ''
+    const text = (freeText[qi] || '').trim()
+    const picked = selections[qi] || []
+    if (q.multi_select) {
+      const selected = [...picked]
+      if (text) selected.push(text)
+      return { question_header: header, answer: '', selected }
+    }
+    if (text) return { question_header: header, answer: text }
+    return { question_header: header, answer: picked[0] || '' }
+  })
+}
+
+function submit() {
+  if (!props.tool.askUserId) return
+  const answers = buildAnswers()
+  submitted.value = answers.map((a) => a.answer || (a.selected || []).join(', '))
+  store.submitAskUser(props.tool.askUserId, answers)
+}
+
+function skip() {
+  if (!props.tool.askUserId) return
+  submitted.value = []
+  store.submitAskUser(props.tool.askUserId, [])
+}
+
+// Submit is allowed once every question has either a selection or free text.
+const canSubmit = computed(() =>
+  questions.value.every((q, qi) =>
+    (selections[qi] && selections[qi].length > 0) || (freeText[qi] || '').trim() !== '',
+  ),
+)
+
+// ─── Keyboard: digit keys select options for the common single-question case ───
+function onKeydown(e: KeyboardEvent) {
+  if (!isPending.value || collapsed.value || questions.value.length !== 1) return
+  const target = e.target as HTMLElement | null
+  if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return
+  const q = questions.value[0]
+  if (!q?.options?.length) return
+  const n = parseInt(e.key, 10)
+  if (!Number.isNaN(n) && n >= 1 && n <= q.options.length) {
+    e.preventDefault()
+    toggleOption(0, q.options[n - 1]!.label, !!q.multi_select)
+  } else if (e.key === 'Enter' && canSubmit.value) {
+    e.preventDefault()
+    submit()
+  }
+}
+// Only listen while this card is the live, pending one — resolved/replay cards
+// (and there can be many in a long session) must not each hold a global listener.
+watch(isPending, (pending) => {
+  if (pending) window.addEventListener('keydown', onKeydown)
+  else window.removeEventListener('keydown', onKeydown)
+}, { immediate: true })
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+
+// ─── Resolved / replay display: extract the chosen answers from tool output ───
+const resolvedAnswers = computed<string[]>(() => {
+  const out = props.tool.output || ''
+  // No output yet (just submitted, awaiting tool_result) → show local choice.
+  if (!out) return submitted.value ?? []
+  // Backend "no answer" sentinels (skip / cancelled) → render the empty state
+  // for the whole card, not as a fake answer mapped onto the first question.
+  if (/^The user did not provide (an answer|any answers)\.?$/.test(out.trim())) return []
+  if (out.startsWith('ask_user cancelled')) return []
+  // Multi-question JSON form: { answers: [{question_header, answer, selected}] }
+  try {
+    const parsed = JSON.parse(out)
+    if (Array.isArray(parsed.answers)) {
+      return parsed.answers.map((a: { answer?: string; selected?: string[] }) =>
+        a.answer || (a.selected || []).join(', '),
+      )
+    }
+  } catch { /* not JSON */ }
+  // Single-question plain form: "User's answer: X"
+  const m = out.match(/^User's answer:\s*([\s\S]*)$/)
+  if (m) return [m[1]!.trim()]
+  return [out.trim()]
+})
+</script>
+
+<template>
+  <div class="my-1.5">
+    <!-- Collapsed: one-line summary (matches the inline "Asking …" affordance) -->
+    <button
+      v-if="collapsed"
+      class="w-full flex items-center gap-1.5 pl-0 pr-1 py-1 text-left cursor-pointer hover:opacity-70 transition-opacity"
+      style="background: transparent"
+      @click="collapsed = false"
+    >
+      <span class="text-xs font-medium" style="color: var(--color-muted-foreground)">Asking</span>
+      <span v-if="questions[0]?.header" class="text-xs font-mono" style="color: var(--color-primary)">{{ questions[0].header }}</span>
+      <span class="text-xs font-mono truncate" style="color: var(--color-muted-foreground)">{{ title }}</span>
+      <svg class="w-3 h-3 shrink-0" style="color: var(--color-muted-foreground)" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+      </svg>
+    </button>
+
+    <!-- Expanded card -->
+    <div
+      v-else
+      class="overflow-hidden mr-2"
+      :style="{ borderRadius: 'var(--radius-xl)', border: '1px solid var(--color-border)', background: 'var(--color-surface)' }"
+    >
+      <!-- Header -->
+      <div class="flex items-center gap-2 px-3.5 py-2.5" :style="{ borderBottom: '1px solid var(--color-border)' }">
+        <span
+          class="w-1.5 h-1.5 rounded-full shrink-0"
+          :class="{ 'animate-pulse': isPending }"
+          :style="{ background: isPending ? 'var(--color-primary)' : 'var(--color-muted-foreground)' }"
+        />
+        <span class="text-sm font-medium flex-1 min-w-0 truncate" style="color: var(--color-foreground)">{{ title }}</span>
+        <button class="shrink-0 cursor-pointer hover:opacity-70" title="Collapse" @click="collapsed = true">
+          <svg class="w-3.5 h-3.5 rotate-180" style="color: var(--color-muted-foreground)" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+          </svg>
+        </button>
+        <button v-if="isPending" class="shrink-0 cursor-pointer hover:opacity-70" title="Skip" @click="skip">
+          <svg class="w-3.5 h-3.5" style="color: var(--color-muted-foreground)" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- ════ Interactive (pending) ════ -->
+      <div v-if="isPending" class="px-2.5 py-2">
+        <div v-for="(q, qi) in questions" :key="qi" :class="{ 'mt-2 pt-2': qi > 0 }" :style="qi > 0 ? 'border-top: 1px solid var(--color-border)' : ''">
+          <!-- Question text (when multiple questions, each gets its own label) -->
+          <div v-if="questions.length > 1" class="px-1 pb-1.5 text-xs font-medium" style="color: var(--color-foreground)">{{ q.question }}</div>
+
+          <!-- Options -->
+          <button
+            v-for="(opt, oi) in q.options"
+            :key="oi"
+            class="ask-opt w-full flex items-center gap-3 px-3 py-2 text-left cursor-pointer rounded-lg"
+            :class="{ 'ask-opt-selected': isSelected(qi, opt.label) }"
+            :style="{ border: isSelected(qi, opt.label) ? '1px solid var(--color-primary)' : '1px solid transparent' }"
+            @click="toggleOption(qi, opt.label, !!q.multi_select)"
+          >
+            <span
+              v-if="q.multi_select"
+              class="w-4 h-4 rounded shrink-0 flex items-center justify-center text-[10px]"
+              :style="{
+                border: '1.5px solid ' + (isSelected(qi, opt.label) ? 'var(--color-primary)' : 'var(--color-border)'),
+                background: isSelected(qi, opt.label) ? 'var(--color-primary)' : 'transparent',
+                color: 'white',
+              }"
+            >{{ isSelected(qi, opt.label) ? '✓' : '' }}</span>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm" style="color: var(--color-foreground)">{{ opt.label }}</div>
+              <div v-if="opt.description" class="text-xs mt-0.5" style="color: var(--color-muted-foreground)">{{ opt.description }}</div>
+            </div>
+            <span
+              class="shrink-0 text-[10px] font-mono tabular-nums w-4 text-center rounded"
+              style="color: var(--color-muted-foreground)"
+            >{{ oi + 1 }}</span>
+          </button>
+
+          <!-- Free-form "Other" input -->
+          <div class="mt-1 px-1">
+            <div v-if="q.options?.length" class="px-2 pt-1 pb-0.5 text-sm" style="color: var(--color-foreground)">Other</div>
+            <input
+              v-model="freeText[qi]"
+              type="text"
+              placeholder="Type your own answer here"
+              class="w-full px-2.5 py-1.5 text-sm rounded-lg outline-none"
+              :style="{ background: 'var(--color-background)', border: '1px solid var(--color-border)', color: 'var(--color-foreground)' }"
+              @input="onFreeTextInput(qi, !!q.multi_select)"
+              @keydown.enter.prevent="canSubmit && submit()"
+            />
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="flex items-center justify-end gap-2 px-1 pt-2.5 pb-0.5">
+          <button
+            class="px-3 py-1.5 text-xs rounded-md cursor-pointer transition-colors"
+            style="color: var(--color-muted-foreground)"
+            @click="skip"
+          >Skip</button>
+          <button
+            class="px-3.5 py-1.5 text-xs rounded-md font-medium transition-opacity flex items-center gap-1.5"
+            :class="canSubmit ? 'cursor-pointer' : 'cursor-not-allowed opacity-40'"
+            :style="{ background: 'var(--color-primary)', color: 'white' }"
+            :disabled="!canSubmit"
+            @click="submit"
+          >
+            <span>Submit</span>
+            <span class="text-[10px] opacity-80">↵</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- ════ Resolved / replay ════ -->
+      <div v-else class="px-3.5 py-2.5 space-y-2">
+        <template v-if="resolvedAnswers.length">
+          <div v-for="(q, qi) in questions" :key="qi">
+            <div v-if="questions.length > 1" class="text-xs" style="color: var(--color-muted-foreground)">{{ q.question }}</div>
+            <div class="text-sm flex items-baseline gap-1.5">
+              <span class="shrink-0 text-[10px]" style="color: var(--color-primary)">▸</span>
+              <span style="color: var(--color-foreground)">{{ resolvedAnswers[qi] || '—' }}</span>
+            </div>
+          </div>
+        </template>
+        <div v-else class="text-xs italic" style="color: var(--color-muted-foreground)">No answer recorded</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ask-opt {
+  background: transparent;
+  transition: background 0.12s ease;
+}
+.ask-opt:hover {
+  background: var(--color-muted);
+}
+.ask-opt-selected,
+.ask-opt-selected:hover {
+  background: color-mix(in srgb, var(--color-primary), transparent 88%);
+}
+</style>

--- a/web/src/components/SettingsDialog.vue
+++ b/web/src/components/SettingsDialog.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, reactive, computed, watch, nextTick, onUnmounted } from 'vue'
 import { useChatStore } from '@/stores/chat'
 import { useTheme } from '@/composables/useTheme'
 import { api } from '@/composables/api'
-import type { MCPServerInfo, SSHAlias, SetupProvider, SetupModel, ProviderDetail } from '@/types/api'
+import type { MCPServerInfo, MCPServerRequest, SkillInfo, SSHAlias, SetupProvider, SetupModel, ProviderDetail } from '@/types/api'
 import QRCode from 'qrcode'
 import {
   Dialog,
@@ -25,7 +25,7 @@ const store = useChatStore()
 const { themeChoice, setTheme, themes } = useTheme()
 const darkThemes = computed(() => themes.filter((t) => t.appearance === 'dark'))
 const lightThemes = computed(() => themes.filter((t) => t.appearance === 'light'))
-const activeTab = ref<'general' | 'appearance' | 'providers' | 'mcp' | 'ssh' | 'channels' | 'shortcuts'>('general')
+const activeTab = ref<'general' | 'appearance' | 'providers' | 'mcp' | 'skills' | 'ssh' | 'channels' | 'shortcuts'>('general')
 const mcpServers = ref<Record<string, MCPServerInfo>>({})
 const sshAliases = ref<SSHAlias[]>([])
 const sshCurrent = ref('local')
@@ -54,12 +54,10 @@ const deleteConfirmId = ref('')
 
 watch(() => props.open, async (isOpen) => {
   if (isOpen) {
-    mcpLoading.value = true
-    try {
-      const result = await api.mcpList()
-      mcpServers.value = result.servers
-    } catch { /* ignore */ }
-    mcpLoading.value = false
+    mcpEditing.value = null
+    mcpLoginMessage.value = ''
+    await loadMCP()
+    loadSkills()
 
     try {
       const sshData = await api.sshList()
@@ -82,8 +80,19 @@ watch(() => props.open, async (isOpen) => {
     showAddProvider.value = false
     addError.value = ''
     deleteConfirmId.value = ''
+    mcpEditing.value = null
+    stopLoginPoll()
   }
 })
+
+async function loadMCP() {
+  mcpLoading.value = true
+  try {
+    const result = await api.mcpList()
+    mcpServers.value = result.servers
+  } catch { /* ignore */ }
+  mcpLoading.value = false
+}
 
 async function toggleMCP(name: string, enabled: boolean) {
   try {
@@ -91,6 +100,7 @@ async function toggleMCP(name: string, enabled: boolean) {
     if (mcpServers.value[name]) {
       mcpServers.value[name].enabled = enabled
     }
+    await loadMCP()
   } catch (err) {
     console.error('Failed to toggle MCP server:', err)
   }
@@ -98,6 +108,232 @@ async function toggleMCP(name: string, enabled: boolean) {
 
 function serverIcon(type: string) {
   return type === 'sse' || type === 'http' ? '🌐' : '⚡'
+}
+
+function mcpStatusLabel(info: MCPServerInfo): string {
+  if (!info.enabled) return 'Disabled'
+  switch (info.status) {
+    case 'connected': return 'Connected'
+    case 'needs_auth': return 'Login required'
+    case 'error': return 'Error'
+    default: return 'Configured'
+  }
+}
+
+function mcpStatusColor(info: MCPServerInfo): string {
+  if (!info.enabled) return 'var(--color-muted-foreground)'
+  switch (info.status) {
+    case 'connected': return 'var(--color-success-fg)'
+    case 'needs_auth': return 'var(--color-warning-fg)'
+    case 'error': return 'var(--color-error-fg)'
+    default: return 'var(--color-muted-foreground)'
+  }
+}
+
+// --- MCP server add/edit form ---
+interface MCPHeaderRow { key: string; value: string }
+interface MCPForm {
+  name: string
+  transport: 'local' | 'http' | 'sse'
+  url: string
+  command: string
+  argsText: string
+  headers: MCPHeaderRow[]
+  timeout: string
+  oauthEnabled: boolean
+  clientId: string
+  clientSecret: string
+  scopesText: string
+}
+
+// mcpEditing: null = no form, '' = adding new, otherwise the server name being edited.
+const mcpEditing = ref<string | null>(null)
+const mcpSaving = ref(false)
+const mcpFormError = ref('')
+const mcpForm = reactive<MCPForm>({
+  name: '', transport: 'http', url: '', command: '', argsText: '',
+  headers: [], timeout: '', oauthEnabled: false, clientId: '', clientSecret: '', scopesText: '',
+})
+
+function resetMCPForm() {
+  mcpForm.name = ''
+  mcpForm.transport = 'http'
+  mcpForm.url = ''
+  mcpForm.command = ''
+  mcpForm.argsText = ''
+  mcpForm.headers = []
+  mcpForm.timeout = ''
+  mcpForm.oauthEnabled = false
+  mcpForm.clientId = ''
+  mcpForm.clientSecret = ''
+  mcpForm.scopesText = ''
+  mcpFormError.value = ''
+}
+
+function openAddMCP() {
+  resetMCPForm()
+  mcpEditing.value = ''
+}
+
+function openEditMCP(info: MCPServerInfo) {
+  resetMCPForm()
+  mcpForm.name = info.name
+  mcpForm.transport = (info.type === 'stdio' || info.type === '') ? 'local' : (info.type as 'http' | 'sse')
+  mcpForm.url = info.url ?? ''
+  mcpForm.command = info.command ?? ''
+  mcpForm.argsText = (info.args ?? []).join(' ')
+  mcpForm.headers = Object.entries(info.headers ?? {}).map(([key, value]) => ({ key, value }))
+  mcpForm.timeout = info.timeout ? String(info.timeout) : ''
+  mcpForm.oauthEnabled = info.oauth
+  mcpEditing.value = info.name
+}
+
+function cancelMCPEdit() {
+  mcpEditing.value = null
+  mcpFormError.value = ''
+}
+
+function addHeaderRow() {
+  mcpForm.headers.push({ key: '', value: '' })
+}
+
+function removeHeaderRow(i: number) {
+  mcpForm.headers.splice(i, 1)
+}
+
+function buildMCPRequest(): MCPServerRequest {
+  const headers: Record<string, string> = {}
+  for (const h of mcpForm.headers) {
+    if (h.key.trim()) headers[h.key.trim()] = h.value
+  }
+  const req: MCPServerRequest = {
+    name: mcpForm.name.trim(),
+    type: mcpForm.transport,
+  }
+  if (mcpForm.transport === 'local') {
+    req.command = mcpForm.command.trim()
+    req.args = mcpForm.argsText.trim() ? mcpForm.argsText.trim().split(/\s+/) : undefined
+  } else {
+    req.url = mcpForm.url.trim()
+    if (Object.keys(headers).length) req.headers = headers
+    if (mcpForm.timeout.trim()) req.timeout = Number(mcpForm.timeout)
+    if (mcpForm.oauthEnabled || mcpForm.clientId.trim()) {
+      req.oauth = {
+        enabled: true,
+        client_id: mcpForm.clientId.trim() || undefined,
+        client_secret: mcpForm.clientSecret.trim() || undefined,
+        scopes: mcpForm.scopesText.trim() ? mcpForm.scopesText.trim().split(/\s+/) : undefined,
+      }
+    }
+  }
+  return req
+}
+
+async function saveMCP() {
+  mcpFormError.value = ''
+  if (!mcpForm.name.trim()) { mcpFormError.value = 'Server name is required'; return }
+  if (mcpForm.transport === 'local' && !mcpForm.command.trim()) { mcpFormError.value = 'Command is required'; return }
+  if (mcpForm.transport !== 'local' && !mcpForm.url.trim()) { mcpFormError.value = 'URL is required'; return }
+  mcpSaving.value = true
+  try {
+    const req = buildMCPRequest()
+    if (mcpEditing.value) {
+      await api.mcpUpdate(mcpEditing.value, req)
+    } else {
+      await api.mcpCreate(req)
+    }
+    mcpEditing.value = null
+    await loadMCP()
+  } catch (err) {
+    mcpFormError.value = err instanceof Error ? err.message : 'Failed to save'
+  }
+  mcpSaving.value = false
+}
+
+async function deleteMCP(name: string) {
+  try {
+    await api.mcpDelete(name)
+    await loadMCP()
+  } catch (err) {
+    console.error('Failed to delete MCP server:', err)
+  }
+}
+
+// --- MCP OAuth login ---
+const mcpLoginBusy = ref('')      // server name currently logging in
+const mcpLoginMessage = ref('')   // status text shown under the row
+let loginPollTimer: ReturnType<typeof setInterval> | null = null
+
+function stopLoginPoll() {
+  if (loginPollTimer) { clearInterval(loginPollTimer); loginPollTimer = null }
+}
+
+async function loginMCP(name: string) {
+  mcpLoginBusy.value = name
+  mcpLoginMessage.value = 'Opening browser — complete authorization, then return here…'
+  try {
+    await api.mcpLogin(name)
+  } catch (err) {
+    mcpLoginMessage.value = err instanceof Error ? err.message : 'Login failed'
+    mcpLoginBusy.value = ''
+    return
+  }
+  stopLoginPoll()
+  loginPollTimer = setInterval(async () => {
+    try {
+      const st = await api.mcpLoginStatus(name)
+      if (st.status === 'authorized') {
+        stopLoginPoll()
+        mcpLoginBusy.value = ''
+        mcpLoginMessage.value = ''
+        await loadMCP()
+      } else if (st.status === 'error') {
+        stopLoginPoll()
+        mcpLoginBusy.value = ''
+        mcpLoginMessage.value = st.message || 'Login failed'
+      } else if (st.status === 'needs_client_id') {
+        stopLoginPoll()
+        mcpLoginBusy.value = ''
+        mcpLoginMessage.value = 'This server does not support automatic registration. Edit it and set an OAuth Client ID, then log in again.'
+      }
+    } catch { /* keep polling */ }
+  }, 1500)
+}
+
+onUnmounted(stopLoginPoll)
+
+// --- Skills ---
+const skills = ref<SkillInfo[]>([])
+const skillsLoading = ref(false)
+const skillFilter = ref<'all' | 'local' | 'builtin'>('all')
+const skillSearch = ref('')
+
+const filteredSkills = computed(() => {
+  const q = skillSearch.value.trim().toLowerCase()
+  return skills.value.filter((s) => {
+    if (skillFilter.value === 'builtin' && !s.builtin) return false
+    if (skillFilter.value === 'local' && s.builtin) return false
+    if (q && !s.name.toLowerCase().includes(q) && !(s.description ?? '').toLowerCase().includes(q)) return false
+    return true
+  })
+})
+
+async function loadSkills() {
+  skillsLoading.value = true
+  try {
+    skills.value = await api.skillsList()
+  } catch { /* ignore */ }
+  skillsLoading.value = false
+}
+
+async function toggleSkill(name: string, enabled: boolean) {
+  try {
+    await api.skillToggle(name, enabled)
+    const sk = skills.value.find((s) => s.name === name)
+    if (sk) sk.enabled = enabled
+  } catch (err) {
+    console.error('Failed to toggle skill:', err)
+  }
 }
 
 const shortcuts = [
@@ -175,9 +411,24 @@ const tabLabel: Record<string, string> = {
   appearance: 'Appearance',
   providers: 'Providers',
   mcp: 'MCP Servers',
+  skills: 'Skills',
   ssh: 'SSH',
   channels: 'Channels',
   shortcuts: 'Shortcuts',
+}
+
+// Monochrome 20×20 stroke icons (inner SVG only) for the nav rail + empty
+// states. Rendered via v-html into an <svg stroke="currentColor" fill="none">
+// so they inherit the element's color/weight.
+const iconFor: Record<string, string> = {
+  general: '<line x1="3" y1="6.5" x2="17" y2="6.5" stroke-linecap="round"/><line x1="3" y1="13.5" x2="17" y2="13.5" stroke-linecap="round"/><circle cx="13" cy="6.5" r="2.1"/><circle cx="7" cy="13.5" r="2.1"/>',
+  appearance: '<circle cx="10" cy="10" r="3.2"/><path d="M10 2.5v2M10 15.5v2M2.5 10h2M15.5 10h2M4.9 4.9l1.4 1.4M13.7 13.7l1.4 1.4M15.1 4.9l-1.4 1.4M6.3 13.7l-1.4 1.4" stroke-linecap="round"/>',
+  providers: '<rect x="6" y="6" width="8" height="8" rx="1.5"/><path d="M8.5 3v3M11.5 3v3M8.5 14v3M11.5 14v3M3 8.5h3M3 11.5h3M14 8.5h3M14 11.5h3" stroke-linecap="round"/>',
+  mcp: '<rect x="3.5" y="4" width="13" height="5" rx="1.5"/><rect x="3.5" y="11" width="13" height="5" rx="1.5"/><path d="M6 6.5h0M6 13.5h0" stroke-linecap="round" stroke-width="2"/>',
+  skills: '<path d="M10 3l1.6 4.4L16 9l-4.4 1.6L10 15l-1.6-4.4L4 9l4.4-1.6z" stroke-linejoin="round"/>',
+  ssh: '<rect x="3" y="4.5" width="14" height="11" rx="1.8"/><path d="M6.5 8.5l2 2-2 2M10.8 12.5h3" stroke-linecap="round" stroke-linejoin="round"/>',
+  channels: '<path d="M7 8.5a3 3 0 016 0c0 2.6 1.2 3.6 1.8 4.2H5.2C5.8 12.1 7 11.1 7 8.5z" stroke-linejoin="round"/><path d="M8.6 15a1.6 1.6 0 002.8 0" stroke-linecap="round"/>',
+  shortcuts: '<rect x="3" y="6" width="14" height="8" rx="1.8"/><path d="M6 9.2h0M9 9.2h0M12 9.2h0M6 11.6h6" stroke-linecap="round" stroke-width="2"/>',
 }
 
 async function startAddProvider() {
@@ -257,42 +508,62 @@ const addProviderInfo = () => addProviderList.value.find(p => p.id === addSelect
         leave="ease-in duration-100"
         leave-from="opacity-100"
         leave-to="opacity-0">
-        <div class="fixed inset-0 bg-black/40 backdrop-blur-sm" style="background: rgba(0,0,0,0.4)" />
+        <div class="fixed inset-0" style="background: rgba(8,8,8,0.5); backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px)" />
       </TransitionChild>
 
-      <div class="fixed inset-0 flex items-start justify-center pt-16 px-4">
+      <div class="fixed inset-0 flex items-center justify-center p-4 sm:p-6">
         <TransitionChild
           enter="ease-out duration-150"
-          enter-from="opacity-0 translate-y-2"
-          enter-to="opacity-100 translate-y-0"
+          enter-from="opacity-0 scale-[0.98] translate-y-1"
+          enter-to="opacity-100 scale-100 translate-y-0"
           leave="ease-in duration-100"
-          leave-from="opacity-100 translate-y-0"
-          leave-to="opacity-0 translate-y-2">
-          <DialogPanel class="w-2xl rounded shadow-2xl overflow-hidden" style="background-color: var(--color-surface); border: 1px solid var(--color-border)">
-            <div class="px-5 pt-5 pb-3" style="border-bottom: 1px solid var(--color-border)">
-              <DialogTitle class="text-sm font-semibold" style="font-family: var(--font-sans); color: var(--color-foreground)">Settings</DialogTitle>
+          leave-from="opacity-100 scale-100 translate-y-0"
+          leave-to="opacity-0 scale-[0.98] translate-y-1">
+          <!-- Fixed footprint: h-[min(...)] (NOT max-h) so the panel never resizes or re-centers between tabs. -->
+          <DialogPanel
+            class="flex flex-col w-[min(880px,94vw)] h-[min(620px,86vh)] overflow-hidden"
+            style="border-radius: var(--radius-xl); background-color: var(--color-surface); border: 1px solid var(--color-border); box-shadow: var(--shadow-lg)"
+          >
+            <!-- Header -->
+            <div class="flex items-center gap-2.5 px-5 h-14 shrink-0" style="border-bottom: 1px solid var(--color-border); background-color: var(--color-sidebar-bg)">
+              <span class="w-[5px] h-[5px] rounded-[1px]" style="background-color: var(--color-primary)" />
+              <DialogTitle class="text-[13px] font-semibold tracking-tight" style="font-family: var(--font-sans); color: var(--color-foreground)">Settings</DialogTitle>
+              <button
+                class="ml-auto grid place-items-center w-7 h-7 rounded-md transition-colors cursor-pointer hover:bg-[var(--color-secondary)]"
+                style="color: var(--color-muted-foreground)"
+                aria-label="Close"
+                @click="emit('close')"
+              >
+                <svg class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M5 5l10 10M15 5L5 15" stroke-linecap="round" />
+                </svg>
+              </button>
             </div>
 
-            <div class="flex h-105">
-              <!-- Left sidebar -->
-              <nav class="w-40 py-2 shrink-0" style="border-right: 1px solid var(--color-border)">
+            <!-- Body: nav rail + single scrolling content column. min-h-0 on both levels is required for the scroll fix. -->
+            <div class="flex flex-1 min-h-0">
+              <!-- Nav rail -->
+              <nav class="shrink-0 w-[200px] py-2 px-2 overflow-y-auto flex flex-col gap-0.5" style="border-right: 1px solid var(--color-border); background-color: var(--color-sidebar-bg)">
                 <button
-                  v-for="tab in (['general', 'appearance', 'providers', 'mcp', 'ssh', 'channels', 'shortcuts'] as const)"
+                  v-for="tab in (['general', 'appearance', 'providers', 'mcp', 'skills', 'ssh', 'channels', 'shortcuts'] as const)"
                   :key="tab"
-                  class="w-full px-4 py-2 text-left text-xs transition-colors cursor-pointer"
+                  class="group relative w-full flex items-center gap-2.5 h-8 pl-2.5 pr-2 text-left text-[13px] cursor-pointer transition-colors duration-[var(--duration-fast)] hover:bg-[var(--color-secondary)]"
                   :style="activeTab === tab
-                    ? { color: 'var(--color-primary)', backgroundColor: 'rgba(255,132,0,0.1)', fontWeight: '500' }
-                    : { color: 'var(--color-muted-foreground)' }"
+                    ? { borderRadius: 'var(--radius-md)', color: 'var(--color-foreground)', backgroundColor: 'var(--color-secondary)', fontWeight: '500' }
+                    : { borderRadius: 'var(--radius-md)', color: 'var(--color-muted-foreground)', backgroundColor: 'transparent' }"
                   @click="activeTab = tab"
                 >
-                  {{ tabLabel[tab] }}
+                  <span v-if="activeTab === tab" class="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-4 rounded-full" style="background-color: var(--color-primary)" />
+                  <svg class="w-3.5 h-3.5 shrink-0" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" v-html="iconFor[tab]" />
+                  <span class="truncate">{{ tabLabel[tab] }}</span>
                 </button>
               </nav>
 
-              <!-- Right content -->
-              <div class="flex-1 overflow-y-auto p-5">
+              <!-- Content frame (surface). Only the inner div scrolls. -->
+              <div class="flex-1 min-w-0 flex flex-col min-h-0" style="background-color: var(--color-surface)">
+                <div class="flex-1 min-h-0 overflow-y-auto px-6 py-5">
                 <!-- General tab -->
-                <div v-if="activeTab === 'general'" class="space-y-4">
+                <div v-if="activeTab === 'general'" class="space-y-5">
                   <div class="flex items-center gap-2">
                     <span
                       class="w-2 h-2 rounded-full"
@@ -345,8 +616,8 @@ const addProviderInfo = () => addProviderList.value.find(p => p.id === addSelect
                 </div>
 
                 <!-- Appearance tab -->
-                <div v-if="activeTab === 'appearance'" class="space-y-4">
-                  <div class="text-[10px] uppercase tracking-wider font-medium" style="color: var(--color-muted-foreground)">Theme</div>
+                <div v-if="activeTab === 'appearance'" class="space-y-5">
+                  <h3 class="text-[13px] font-semibold tracking-tight" style="color: var(--color-foreground)">Theme</h3>
 
                   <!-- System (follow OS) -->
                   <button
@@ -433,14 +704,17 @@ const addProviderInfo = () => addProviderList.value.find(p => p.id === addSelect
 
                 <!-- Providers tab -->
                 <div v-if="activeTab === 'providers'">
-                  <div class="flex items-center justify-between mb-3">
-                    <div class="text-[10px] uppercase tracking-wider font-medium" style="color: var(--color-muted-foreground)">Providers</div>
+                  <div class="flex items-center justify-between mb-4">
+                    <div class="flex items-baseline gap-2">
+                      <h3 class="text-[13px] font-semibold tracking-tight" style="color: var(--color-foreground)">Providers</h3>
+                      <span class="text-[11px] font-mono" style="color: var(--color-muted-foreground)">{{ configuredProviders.length }}</span>
+                    </div>
                     <button
-                      class="px-2 py-1 text-[10px] text-white rounded-md cursor-pointer transition-colors font-medium"
-                      style="background-color: var(--color-primary)"
+                      class="h-7 px-2.5 text-[11px] font-medium rounded-md cursor-pointer transition-colors hover:bg-[rgba(255,132,0,0.16)]"
+                      style="color: var(--color-primary); background-color: rgba(255,132,0,0.1)"
                       @click="startAddProvider"
                     >
-                      + Add Provider
+                      + Add provider
                     </button>
                   </div>
 
@@ -512,10 +786,13 @@ const addProviderInfo = () => addProviderList.value.find(p => p.id === addSelect
                   </div>
 
                   <!-- Provider list -->
-                  <div v-if="configuredProviders.length === 0" class="text-center py-6">
-                    <div class="text-xs mb-1" style="color: var(--color-muted-foreground)">No providers configured</div>
-                    <div class="text-[10px]" style="color: var(--color-muted-foreground)">
-                      Click "Add Provider" above to get started.
+                  <div v-if="configuredProviders.length === 0" class="flex flex-col items-center justify-center text-center py-12 gap-2.5">
+                    <div class="w-9 h-9 grid place-items-center rounded-lg" style="background-color: var(--color-secondary); color: var(--color-muted-foreground)">
+                      <svg class="w-4 h-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" v-html="iconFor.providers" />
+                    </div>
+                    <div class="text-[13px] font-medium" style="color: var(--color-foreground)">No providers configured</div>
+                    <div class="text-[11px] leading-relaxed max-w-[240px]" style="color: var(--color-muted-foreground)">
+                      Add one with the <span class="font-mono">Add&nbsp;provider</span> button above to get started.
                     </div>
                   </div>
                   <div v-else class="space-y-2">
@@ -559,43 +836,288 @@ const addProviderInfo = () => addProviderList.value.find(p => p.id === addSelect
 
                 <!-- MCP Servers tab -->
                 <div v-if="activeTab === 'mcp'">
-                  <div class="text-[10px] uppercase tracking-wider mb-3 font-medium" style="color: var(--color-muted-foreground)">MCP Servers</div>
+                  <div class="flex items-center justify-between mb-4">
+                    <div class="flex items-baseline gap-2">
+                      <h3 class="text-[13px] font-semibold tracking-tight" style="color: var(--color-foreground)">MCP Servers</h3>
+                      <span class="text-[11px] font-mono" style="color: var(--color-muted-foreground)">{{ Object.keys(mcpServers).length }}</span>
+                    </div>
+                    <button
+                      v-if="mcpEditing === null"
+                      class="h-7 px-2.5 text-[11px] font-medium rounded-md cursor-pointer transition-colors hover:bg-[rgba(255,132,0,0.16)]"
+                      style="color: var(--color-primary); background-color: rgba(255,132,0,0.1)"
+                      @click="openAddMCP"
+                    >+ Add server</button>
+                  </div>
+
+                  <!-- Add / Edit form -->
+                  <div v-if="mcpEditing !== null" class="space-y-3 mb-2 p-3 rounded-md" style="border: 1px solid var(--color-border)">
+                    <div class="text-xs font-medium" style="color: var(--color-foreground)">{{ mcpEditing ? 'Edit server' : 'Add server' }}</div>
+
+                    <div>
+                      <div class="text-[10px] uppercase tracking-wider mb-1 font-medium" style="color: var(--color-muted-foreground)">Server name</div>
+                      <input
+                        v-model="mcpForm.name"
+                        :disabled="!!mcpEditing"
+                        type="text"
+                        placeholder="my-server"
+                        class="w-full px-2.5 py-1.5 text-xs rounded-md outline-none"
+                        style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)"
+                      />
+                    </div>
+
+                    <div>
+                      <div class="text-[10px] uppercase tracking-wider mb-1 font-medium" style="color: var(--color-muted-foreground)">Transport</div>
+                      <div class="inline-flex rounded-md overflow-hidden" style="border: 1px solid var(--color-border)">
+                        <button
+                          v-for="t in (['local', 'http', 'sse'] as const)"
+                          :key="t"
+                          class="px-3 py-1 text-[11px] cursor-pointer transition-colors"
+                          :style="mcpForm.transport === t
+                            ? { backgroundColor: 'var(--color-primary)', color: '#fff' }
+                            : { color: 'var(--color-muted-foreground)' }"
+                          @click="mcpForm.transport = t"
+                        >{{ t === 'local' ? 'Local' : t.toUpperCase() }}</button>
+                      </div>
+                    </div>
+
+                    <!-- HTTP / SSE fields -->
+                    <template v-if="mcpForm.transport !== 'local'">
+                      <div>
+                        <div class="text-[10px] uppercase tracking-wider mb-1 font-medium" style="color: var(--color-muted-foreground)">URL</div>
+                        <input
+                          v-model="mcpForm.url"
+                          type="text"
+                          placeholder="https://api.example.com/mcp"
+                          class="w-full px-2.5 py-1.5 text-xs font-mono rounded-md outline-none"
+                          style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)"
+                        />
+                      </div>
+
+                      <div>
+                        <div class="flex items-center justify-between mb-1">
+                          <div class="text-[10px] uppercase tracking-wider font-medium" style="color: var(--color-muted-foreground)">Headers</div>
+                          <button class="text-[11px] cursor-pointer" style="color: var(--color-primary)" @click="addHeaderRow">+ Add header</button>
+                        </div>
+                        <div v-for="(h, i) in mcpForm.headers" :key="i" class="flex gap-2 mb-1.5">
+                          <input v-model="h.key" type="text" placeholder="Key" class="flex-1 px-2 py-1 text-[11px] font-mono rounded-md outline-none" style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)" />
+                          <input v-model="h.value" type="text" placeholder="Value" class="flex-1 px-2 py-1 text-[11px] font-mono rounded-md outline-none" style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)" />
+                          <button class="px-2 text-xs cursor-pointer" style="color: var(--color-muted-foreground)" @click="removeHeaderRow(i)">✕</button>
+                        </div>
+                      </div>
+
+                      <label class="flex items-center gap-2 cursor-pointer">
+                        <input v-model="mcpForm.oauthEnabled" type="checkbox" />
+                        <span class="text-xs" style="color: var(--color-foreground)">Use OAuth (log in after saving)</span>
+                      </label>
+
+                      <div v-if="mcpForm.oauthEnabled" class="space-y-2 pl-1">
+                        <div>
+                          <div class="text-[10px] uppercase tracking-wider mb-1 font-medium" style="color: var(--color-muted-foreground)">OAuth Client ID</div>
+                          <input
+                            v-model="mcpForm.clientId"
+                            type="text"
+                            placeholder="Optional — leave blank to auto-register"
+                            class="w-full px-2.5 py-1.5 text-xs font-mono rounded-md outline-none"
+                            style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)"
+                          />
+                        </div>
+                        <div>
+                          <div class="text-[10px] uppercase tracking-wider mb-1 font-medium" style="color: var(--color-muted-foreground)">OAuth Client Secret</div>
+                          <input
+                            v-model="mcpForm.clientSecret"
+                            type="password"
+                            placeholder="Optional (confidential clients)"
+                            class="w-full px-2.5 py-1.5 text-xs font-mono rounded-md outline-none"
+                            style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)"
+                          />
+                        </div>
+                        <div>
+                          <div class="text-[10px] uppercase tracking-wider mb-1 font-medium" style="color: var(--color-muted-foreground)">Scopes</div>
+                          <input
+                            v-model="mcpForm.scopesText"
+                            type="text"
+                            placeholder="space-separated, optional"
+                            class="w-full px-2.5 py-1.5 text-xs font-mono rounded-md outline-none"
+                            style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)"
+                          />
+                        </div>
+                      </div>
+
+                      <div>
+                        <div class="text-[10px] uppercase tracking-wider mb-1 font-medium" style="color: var(--color-muted-foreground)">Timeout (seconds)</div>
+                        <input
+                          v-model="mcpForm.timeout"
+                          type="number"
+                          placeholder="180"
+                          class="w-32 px-2.5 py-1.5 text-xs rounded-md outline-none"
+                          style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)"
+                        />
+                      </div>
+                    </template>
+
+                    <!-- Local fields -->
+                    <template v-else>
+                      <div>
+                        <div class="text-[10px] uppercase tracking-wider mb-1 font-medium" style="color: var(--color-muted-foreground)">Command</div>
+                        <input
+                          v-model="mcpForm.command"
+                          type="text"
+                          placeholder="npx"
+                          class="w-full px-2.5 py-1.5 text-xs font-mono rounded-md outline-none"
+                          style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)"
+                        />
+                      </div>
+                      <div>
+                        <div class="text-[10px] uppercase tracking-wider mb-1 font-medium" style="color: var(--color-muted-foreground)">Arguments</div>
+                        <input
+                          v-model="mcpForm.argsText"
+                          type="text"
+                          placeholder="-y @some/mcp-server"
+                          class="w-full px-2.5 py-1.5 text-xs font-mono rounded-md outline-none"
+                          style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)"
+                        />
+                      </div>
+                    </template>
+
+                    <div v-if="mcpFormError" class="text-[11px]" style="color: var(--color-error-fg)">{{ mcpFormError }}</div>
+
+                    <div class="flex justify-end gap-2 pt-1">
+                      <button class="text-[11px] px-3 py-1.5 rounded-md cursor-pointer" style="border: 1px solid var(--color-border); color: var(--color-foreground)" @click="cancelMCPEdit">Cancel</button>
+                      <button
+                        class="text-[11px] px-3 py-1.5 rounded-md cursor-pointer"
+                        style="background-color: var(--color-primary); color: #fff"
+                        :disabled="mcpSaving"
+                        @click="saveMCP"
+                      >{{ mcpSaving ? 'Saving…' : 'Save' }}</button>
+                    </div>
+                  </div>
+
                   <div v-if="mcpLoading" class="text-center text-xs py-6 animate-pulse" style="color: var(--color-muted-foreground)">
                     Loading...
                   </div>
-                  <div v-else-if="Object.keys(mcpServers).length === 0" class="text-center py-8">
-                    <div class="text-xs mb-1" style="color: var(--color-muted-foreground)">No MCP servers configured</div>
-                    <div class="text-[10px]" style="color: var(--color-muted-foreground)">
-                      Edit <span class="font-mono">~/.jcode/config.json</span>
+                  <div v-else-if="mcpEditing === null && Object.keys(mcpServers).length === 0" class="flex flex-col items-center justify-center text-center py-12 gap-2.5">
+                    <div class="w-9 h-9 grid place-items-center rounded-lg" style="background-color: var(--color-secondary); color: var(--color-muted-foreground)">
+                      <svg class="w-4 h-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" v-html="iconFor.mcp" />
                     </div>
+                    <div class="text-[13px] font-medium" style="color: var(--color-foreground)">No MCP servers configured</div>
+                    <div class="text-[11px] leading-relaxed max-w-[240px]" style="color: var(--color-muted-foreground)">Connect one with the <span class="font-mono">Add&nbsp;server</span> button above.</div>
                   </div>
-                  <div v-else class="space-y-2">
+                  <div v-else-if="mcpEditing === null" class="space-y-2">
                     <div
                       v-for="(info, name) in mcpServers"
                       :key="name"
-                      class="flex items-center gap-3 px-3 py-2.5 rounded-md"
+                      class="px-3 py-2.5 rounded-md"
                       :style="{
                         border: '1px solid var(--color-border)',
                         backgroundColor: info.enabled ? 'var(--color-surface)' : 'var(--color-muted)',
                         opacity: info.enabled ? 1 : 0.6,
                       }"
                     >
-                      <span class="text-sm">{{ serverIcon(info.type) }}</span>
-                      <div class="flex-1 min-w-0">
-                        <div class="text-xs font-medium" style="color: var(--color-foreground)">{{ name }}</div>
-                        <div class="text-[10px] font-mono truncate" style="color: var(--color-muted-foreground)">
-                          {{ info.type === 'sse' || info.type === 'http' ? info.url : info.command }}
+                      <div class="flex items-center gap-3">
+                        <span class="text-sm">{{ serverIcon(info.type) }}</span>
+                        <div class="flex-1 min-w-0">
+                          <div class="flex items-center gap-2">
+                            <span class="text-xs font-medium" style="color: var(--color-foreground)">{{ name }}</span>
+                            <span class="text-[9px] px-1.5 py-0.5 rounded uppercase tracking-wide" style="background-color: var(--color-muted); color: var(--color-muted-foreground)">{{ info.type || 'stdio' }}</span>
+                            <span class="text-[10px]" :style="{ color: mcpStatusColor(info) }">● {{ mcpStatusLabel(info) }}</span>
+                          </div>
+                          <div class="text-[10px] font-mono truncate" style="color: var(--color-muted-foreground)">
+                            {{ info.type === 'sse' || info.type === 'http' ? info.url : info.command }}
+                          </div>
                         </div>
+                        <button class="text-[11px] cursor-pointer px-1.5" style="color: var(--color-muted-foreground)" title="Edit" @click="openEditMCP(info)">Edit</button>
+                        <button class="text-[11px] cursor-pointer px-1.5" style="color: var(--color-error-fg)" title="Delete" @click="deleteMCP(String(name))">Delete</button>
+                        <button
+                          class="relative inline-flex h-5 w-9 items-center rounded-full cursor-pointer transition-colors shrink-0"
+                          :style="{ backgroundColor: info.enabled ? 'var(--color-primary)' : 'var(--color-border)' }"
+                          @click="toggleMCP(String(name), !info.enabled)"
+                          :title="info.enabled ? 'Disable' : 'Enable'"
+                        >
+                          <span
+                            class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform"
+                            :class="info.enabled ? 'translate-x-4.5' : 'translate-x-0.76'"
+                          />
+                        </button>
+                      </div>
+                      <!-- OAuth login row -->
+                      <div v-if="(info.type === 'http' || info.type === 'sse') && (info.oauth || info.status === 'needs_auth')" class="mt-2 flex items-center gap-2">
+                        <button
+                          class="text-[11px] px-2.5 py-1 rounded-md cursor-pointer"
+                          style="border: 1px solid var(--color-primary); color: var(--color-primary)"
+                          :disabled="mcpLoginBusy === name"
+                          @click="loginMCP(String(name))"
+                        >{{ mcpLoginBusy === name ? 'Waiting for browser…' : (info.has_auth ? 'Re-authenticate' : 'Log in') }}</button>
+                        <span v-if="info.has_auth" class="text-[10px]" style="color: var(--color-success-fg)">Authenticated</span>
+                      </div>
+                      <div v-if="mcpLoginBusy === name && mcpLoginMessage" class="mt-1 text-[10px]" style="color: var(--color-muted-foreground)">{{ mcpLoginMessage }}</div>
+                      <div v-else-if="mcpLoginMessage && !mcpLoginBusy" class="mt-1 text-[10px]" style="color: var(--color-warning-fg)">{{ mcpLoginMessage }}</div>
+                      <div v-if="info.error" class="mt-1 text-[10px] font-mono" style="color: var(--color-error-fg)">{{ info.error }}</div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Skills tab -->
+                <div v-if="activeTab === 'skills'">
+                  <div class="flex items-baseline gap-2 mb-4">
+                    <h3 class="text-[13px] font-semibold tracking-tight" style="color: var(--color-foreground)">Skills</h3>
+                    <span class="text-[11px] font-mono" style="color: var(--color-muted-foreground)">{{ skills.length }}</span>
+                  </div>
+                  <div class="flex items-center gap-2 mb-3">
+                    <div class="inline-flex rounded-md overflow-hidden" style="border: 1px solid var(--color-border)">
+                      <button
+                        v-for="f in (['all', 'local', 'builtin'] as const)"
+                        :key="f"
+                        class="px-2.5 py-1 text-[11px] cursor-pointer transition-colors"
+                        :style="skillFilter === f
+                          ? { backgroundColor: 'var(--color-primary)', color: '#fff' }
+                          : { color: 'var(--color-muted-foreground)' }"
+                        @click="skillFilter = f"
+                      >{{ f === 'all' ? 'All' : f === 'local' ? 'On this device' : 'Built-in' }}</button>
+                    </div>
+                    <input
+                      v-model="skillSearch"
+                      type="text"
+                      placeholder="Search skills…"
+                      class="flex-1 px-2.5 py-1 text-xs rounded-md outline-none"
+                      style="background-color: var(--color-background); border: 1px solid var(--color-border); color: var(--color-foreground)"
+                    />
+                  </div>
+
+                  <div v-if="skillsLoading" class="text-center text-xs py-6 animate-pulse" style="color: var(--color-muted-foreground)">Loading...</div>
+                  <div v-else-if="filteredSkills.length === 0" class="flex flex-col items-center justify-center text-center py-12 gap-2.5">
+                    <div class="w-9 h-9 grid place-items-center rounded-lg" style="background-color: var(--color-secondary); color: var(--color-muted-foreground)">
+                      <svg class="w-4 h-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" v-html="iconFor.skills" />
+                    </div>
+                    <div class="text-[13px] font-medium" style="color: var(--color-foreground)">No skills found</div>
+                    <div class="text-[11px] leading-relaxed max-w-[240px]" style="color: var(--color-muted-foreground)">Try a different filter or search term.</div>
+                  </div>
+                  <div v-else class="space-y-2">
+                    <div
+                      v-for="sk in filteredSkills"
+                      :key="sk.name"
+                      class="flex items-center gap-3 px-3 py-2.5 rounded-md"
+                      :style="{
+                        border: '1px solid var(--color-border)',
+                        backgroundColor: sk.enabled ? 'var(--color-surface)' : 'var(--color-muted)',
+                        opacity: sk.enabled ? 1 : 0.6,
+                      }"
+                    >
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-2">
+                          <span class="text-xs font-medium" style="color: var(--color-foreground)">{{ sk.name }}</span>
+                          <span v-if="sk.builtin" class="text-[9px] px-1.5 py-0.5 rounded uppercase tracking-wide" style="background-color: var(--color-muted); color: var(--color-muted-foreground)">Built-in</span>
+                        </div>
+                        <div v-if="sk.description" class="text-[10px] truncate" style="color: var(--color-muted-foreground)">{{ sk.description }}</div>
                       </div>
                       <button
                         class="relative inline-flex h-5 w-9 items-center rounded-full cursor-pointer transition-colors shrink-0"
-                        :style="{ backgroundColor: info.enabled ? 'var(--color-primary)' : 'var(--color-border)' }"
-                        @click="toggleMCP(String(name), !info.enabled)"
-                        :title="info.enabled ? 'Disable' : 'Enable'"
+                        :style="{ backgroundColor: sk.enabled ? 'var(--color-primary)' : 'var(--color-border)' }"
+                        @click="toggleSkill(sk.name, !sk.enabled)"
+                        :title="sk.enabled ? 'Disable' : 'Enable'"
                       >
                         <span
                           class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform"
-                          :class="info.enabled ? 'translate-x-4.5' : 'translate-x-0.76'"
+                          :class="sk.enabled ? 'translate-x-4.5' : 'translate-x-0.76'"
                         />
                       </button>
                     </div>
@@ -604,20 +1126,23 @@ const addProviderInfo = () => addProviderList.value.find(p => p.id === addSelect
 
                 <!-- SSH tab -->
                 <div v-if="activeTab === 'ssh'">
-                  <div class="text-[10px] uppercase tracking-wider mb-3 font-medium" style="color: var(--color-muted-foreground)">SSH Environments</div>
+                  <h3 class="text-[13px] font-semibold tracking-tight mb-4" style="color: var(--color-foreground)">SSH Environments</h3>
 
                   <div class="mb-3">
-                    <div class="text-[10px] mb-1" style="color: var(--color-muted-foreground)">Current Environment</div>
+                    <div class="text-[11px] font-medium mb-1" style="color: var(--color-muted-foreground)">Current Environment</div>
                     <div class="inline-flex items-center gap-1.5 px-2 py-1 rounded text-xs font-medium" style="background-color: rgba(255,132,0,0.1); color: var(--color-primary)">
                       <span class="w-1.5 h-1.5 rounded-full" style="background-color: var(--color-primary)" />
                       {{ sshCurrent }}
                     </div>
                   </div>
 
-                  <div v-if="sshAliases.length === 0" class="text-center py-6">
-                    <div class="text-xs mb-1" style="color: var(--color-muted-foreground)">No SSH aliases configured</div>
-                    <div class="text-[10px]" style="color: var(--color-muted-foreground)">
-                      Add aliases to <span class="font-mono">~/.jcode/config.json</span>
+                  <div v-if="sshAliases.length === 0" class="flex flex-col items-center justify-center text-center py-12 gap-2.5">
+                    <div class="w-9 h-9 grid place-items-center rounded-lg" style="background-color: var(--color-secondary); color: var(--color-muted-foreground)">
+                      <svg class="w-4 h-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" v-html="iconFor.ssh" />
+                    </div>
+                    <div class="text-[13px] font-medium" style="color: var(--color-foreground)">No SSH aliases configured</div>
+                    <div class="text-[11px] leading-relaxed max-w-[240px]" style="color: var(--color-muted-foreground)">
+                      Add aliases to <span class="font-mono">~/.jcode/config.json</span>.
                     </div>
                   </div>
                   <div v-else class="space-y-2">
@@ -648,12 +1173,15 @@ const addProviderInfo = () => addProviderList.value.find(p => p.id === addSelect
 
                 <!-- Channels tab -->
                 <div v-if="activeTab === 'channels'">
-                  <div class="text-[10px] uppercase tracking-wider mb-3 font-medium" style="color: var(--color-muted-foreground)">Notification Channels</div>
+                  <h3 class="text-[13px] font-semibold tracking-tight mb-4" style="color: var(--color-foreground)">Notification Channels</h3>
 
-                  <div v-if="!channelAvailable" class="text-center py-8">
-                    <div class="text-xs mb-1" style="color: var(--color-muted-foreground)">No channels configured</div>
-                    <div class="text-[10px]" style="color: var(--color-muted-foreground)">
-                      Set <span class="font-mono">channel.web_enabled: true</span> in <span class="font-mono">~/.jcode/config.json</span>
+                  <div v-if="!channelAvailable" class="flex flex-col items-center justify-center text-center py-12 gap-2.5">
+                    <div class="w-9 h-9 grid place-items-center rounded-lg" style="background-color: var(--color-secondary); color: var(--color-muted-foreground)">
+                      <svg class="w-4 h-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" v-html="iconFor.channels" />
+                    </div>
+                    <div class="text-[13px] font-medium" style="color: var(--color-foreground)">No channels configured</div>
+                    <div class="text-[11px] leading-relaxed max-w-[260px]" style="color: var(--color-muted-foreground)">
+                      Set <span class="font-mono">channel.web_enabled: true</span> in <span class="font-mono">~/.jcode/config.json</span>.
                     </div>
                   </div>
 
@@ -741,7 +1269,7 @@ const addProviderInfo = () => addProviderList.value.find(p => p.id === addSelect
 
                 <!-- Shortcuts tab -->
                 <div v-if="activeTab === 'shortcuts'">
-                  <div class="text-[10px] uppercase tracking-wider mb-3 font-medium" style="color: var(--color-muted-foreground)">Keyboard Shortcuts</div>
+                  <h3 class="text-[13px] font-semibold tracking-tight mb-4" style="color: var(--color-foreground)">Keyboard Shortcuts</h3>
                   <div class="space-y-1.5">
                     <div
                       v-for="s in shortcuts"
@@ -753,13 +1281,20 @@ const addProviderInfo = () => addProviderList.value.find(p => p.id === addSelect
                     </div>
                   </div>
                 </div>
+                </div>
               </div>
             </div>
 
-            <div class="px-5 py-3 flex justify-end" style="border-top: 1px solid var(--color-border)">
+            <!-- Footer: keyboard hint + low-chroma Done -->
+            <div class="flex items-center px-5 h-12 shrink-0" style="border-top: 1px solid var(--color-border); background-color: var(--color-sidebar-bg)">
+              <span class="text-[11px] flex items-center gap-1.5" style="color: var(--color-muted-foreground)">
+                Press
+                <kbd class="px-1.5 py-0.5 text-[10px] font-mono rounded" style="background-color: var(--color-secondary); border: 1px solid var(--color-border); color: var(--color-muted-foreground)">Esc</kbd>
+                to close
+              </span>
               <button
-                class="px-3 py-1.5 text-xs cursor-pointer transition-colors font-medium"
-                style="color: var(--color-muted-foreground)"
+                class="ml-auto h-7 px-3 text-xs font-medium rounded-md cursor-pointer transition-colors hover:bg-[rgba(255,132,0,0.16)]"
+                style="color: var(--color-primary); background-color: rgba(255,132,0,0.1)"
                 @click="emit('close')">
                 Done
               </button>

--- a/web/src/components/ToolCallCard.vue
+++ b/web/src/components/ToolCallCard.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue'
 import type { ToolCall, TodoItem } from '@/types/api'
 import TaskList from './TaskList.vue'
+import AskUserCard from './AskUserCard.vue'
 
 defineOptions({ name: 'ToolCallCard' })
 
@@ -12,6 +13,7 @@ const props = defineProps<{
 
 const expanded = ref(false)
 const isSubagent = computed(() => props.tool.name === 'subagent')
+const isAskUser = computed(() => props.tool.name === 'ask_user')
 const subagentExpanded = ref(true)
 
 // Display info: use backend-provided or fall back to name
@@ -320,6 +322,9 @@ function formatArgs(args: string): string {
       <div v-if="tool.error" class="mt-1 px-3 py-2 text-xs font-mono whitespace-pre-wrap overflow-hidden" :style="{ borderRadius: 'var(--radius-xl)', border: '1px solid var(--color-destructive)', color: 'var(--color-destructive)' }">{{ tool.error }}</div>
     </div>
   </div>
+
+  <!-- Ask User — interactive question card (or static answer on replay) -->
+  <AskUserCard v-else-if="isAskUser" :tool="tool" />
 
   <!-- Regular tool call -->
   <div v-else class="my-1">

--- a/web/src/composables/api.ts
+++ b/web/src/composables/api.ts
@@ -1,5 +1,5 @@
 // API client for jcode backend
-import type { ModelsResponse, AgentMode, ExecResponse, DiffResponse, MCPListResponse, BrowseResponse, SSHListResponse, SkillInfo, SlashCommandInfo, TodoItem, Goal, SessionItem, SessionEntry, FileItem, SetupProvider, SetupModel, ProviderDetail, ModelStateResponse, ChatImage } from '@/types/api'
+import type { ModelsResponse, AgentMode, ExecResponse, DiffResponse, MCPListResponse, MCPServerRequest, MCPLoginStatus, BrowseResponse, SSHListResponse, SkillInfo, SlashCommandInfo, TodoItem, Goal, SessionItem, SessionEntry, FileItem, SetupProvider, SetupModel, ProviderDetail, ModelStateResponse, ChatImage, AskUserAnswer, AskUserRequestData } from '@/types/api'
 
 const BASE = ''
 
@@ -76,6 +76,12 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ id, approved, approve_all: approveAll }),
     }),
+  askUser: (id: string, answers: AskUserAnswer[]) =>
+    request<{ status: string }>('/api/ask', {
+      method: 'POST',
+      body: JSON.stringify({ id, answers }),
+    }),
+  askPending: () => request<AskUserRequestData[]>('/api/ask/pending'),
   models: () => request<ModelsResponse>('/api/models'),
   switchModel: (provider: string, model: string) =>
     request<{ status: string }>('/api/model', {
@@ -102,6 +108,24 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ enabled }),
     }),
+  mcpCreate: (data: MCPServerRequest) =>
+    request<{ status: string; name: string }>('/api/mcp/servers', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  mcpUpdate: (name: string, data: MCPServerRequest) =>
+    request<{ status: string; name: string }>(`/api/mcp/servers/${encodeURIComponent(name)}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+  mcpDelete: (name: string) =>
+    request<{ status: string }>(`/api/mcp/servers/${encodeURIComponent(name)}`, {
+      method: 'DELETE',
+    }),
+  mcpLogin: (name: string) =>
+    request<MCPLoginStatus>(`/api/mcp/${encodeURIComponent(name)}/login`, { method: 'POST' }),
+  mcpLoginStatus: (name: string) =>
+    request<MCPLoginStatus>(`/api/mcp/${encodeURIComponent(name)}/login/status`),
   browse: (path?: string) => {
     const q = path ? `?path=${encodeURIComponent(path)}` : ''
     return request<BrowseResponse>(`/api/browse${q}`)
@@ -130,6 +154,11 @@ export const api = {
     request<SSHListResponse>('/api/ssh'),
   skillsList: () =>
     request<SkillInfo[]>('/api/skills'),
+  skillToggle: (name: string, enabled: boolean) =>
+    request<{ status: string }>(`/api/skills/${encodeURIComponent(name)}/toggle`, {
+      method: 'POST',
+      body: JSON.stringify({ enabled }),
+    }),
   slashCommands: () =>
     request<SlashCommandInfo[]>('/api/slash-commands'),
   channelStatus: () =>

--- a/web/src/composables/ws.ts
+++ b/web/src/composables/ws.ts
@@ -7,6 +7,7 @@ import type {
   TokenUpdateData,
   AgentDoneData,
   ApprovalRequestData,
+  AskUserRequestData,
   SubagentEventData,
   SubagentProgressData,
   Goal,
@@ -22,6 +23,7 @@ type WSHandler = {
   onTodoUpdate?: () => void
   onGoalUpdate?: (data: Goal | null) => void
   onApprovalRequest?: (data: ApprovalRequestData) => void
+  onAskUserRequest?: (data: AskUserRequestData) => void
   onSessionReset?: (data: { session_id: string }) => void
   onModelChanged?: (data: { provider: string; model: string }) => void
   onModeChanged?: (data: { mode: string }) => void
@@ -53,6 +55,7 @@ export function useWebSocket(handlers: WSHandler) {
     todo_update: () => handlers.onTodoUpdate?.(),
     goal_update: (d) => handlers.onGoalUpdate?.(d),
     approval_request: (d) => handlers.onApprovalRequest?.(d),
+    ask_user_request: (d) => handlers.onAskUserRequest?.(d),
     session_reset: (d) => handlers.onSessionReset?.(d),
     model_changed: (d) => handlers.onModelChanged?.(d),
     mode_changed: (d) => handlers.onModeChanged?.(d),

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -14,6 +14,8 @@ import type {
   ProviderInfo,
   ToolDisplayInfo,
   ModelRef,
+  AskUserQuestion,
+  AskUserAnswer,
 } from '@/types/api'
 import { normalizeMode } from '@/types/api'
 import { api } from '@/composables/api'
@@ -282,6 +284,89 @@ export const useChatStore = defineStore('chat', () => {
 
   function addApprovalRequest(data: PendingApproval) {
     timeline.value.push({ kind: 'approval', data, seq: nextSeqId() })
+  }
+
+  /**
+   * Arm a timeline ask_user tool item with a request id so its card switches to
+   * interactive answer mode. Returns true if a matching item was armed (or was
+   * already armed with this id — idempotent, so re-emits/pulls are safe).
+   * An item already armed with a *different* id is skipped, so two concurrent
+   * ask_user calls in one turn each bind to a distinct item.
+   */
+  function armAskItem(id: string, questions: AskUserQuestion[]): boolean {
+    for (let i = timeline.value.length - 1; i >= 0; i--) {
+      const item = timeline.value[i]
+      if (!item || item.kind !== 'tool' || item.data.name !== 'ask_user') continue
+      if (item.data.askUserId === id) return true // already armed (idempotent)
+      // Match an unarmed item: live (running) or a replayed one (done, no output).
+      if (!item.data.askUserId && (item.data.status === 'running' || (item.data.status === 'done' && !item.data.output))) {
+        item.data.status = 'running'
+        item.data.askUserId = id
+        item.data.askUserQuestions = questions
+        return true
+      }
+    }
+    return false
+  }
+
+  /**
+   * Handle an ask_user_request event. The tool_call event normally creates the
+   * timeline item first, so we just arm it. If no item exists — the tool_call
+   * was dropped (full event buffer), a rare but unrecoverable case — synthesize
+   * one so the question still renders instead of silently hanging the run.
+   */
+  function attachAskUserRequest(id: string, questions: AskUserQuestion[]) {
+    if (armAskItem(id, questions)) return
+    const args = JSON.stringify({ questions })
+    timeline.value.push({
+      kind: 'tool',
+      data: {
+        id: genId('tc'),
+        name: 'ask_user',
+        args,
+        status: 'running',
+        timestamp: Date.now(),
+        displayInfo: extractToolDisplayInfo('ask_user', args),
+        askUserId: id,
+        askUserQuestions: questions,
+      },
+      seq: nextSeqId(),
+    })
+  }
+
+  /**
+   * Re-attach any server-side pending ask_user questions after the timeline is
+   * (re)built from a session — covers page reload / session resume mid-question,
+   * where the live ask_user_request event was already consumed and lost.
+   */
+  async function reconcileAskUser() {
+    try {
+      const pending = await api.askPending()
+      for (const req of pending) armAskItem(req.id, req.questions)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /** Submit answers for a pending ask_user request and collapse its card. */
+  async function submitAskUser(id: string, answers: AskUserAnswer[]) {
+    try {
+      await api.askUser(id, answers)
+      // Clear the pending state only after the answer is delivered, so a failed
+      // POST leaves the card interactive (the agent is still blocked waiting).
+      for (const item of timeline.value) {
+        if (item.kind === 'tool' && item.data.askUserId === id) {
+          item.data.askUserId = undefined
+          break
+        }
+      }
+    } catch (err: unknown) {
+      addMessage(
+        'system',
+        `Failed to submit answer: ${err instanceof Error ? err.message : String(err)}`,
+        undefined, undefined, 'error',
+      )
+    }
   }
 
   function resolveApprovalLocal(id: string, approved: boolean) {
@@ -675,6 +760,8 @@ export const useChatStore = defineStore('chat', () => {
       for (const tc of pendingToolCalls.values()) {
         tc.status = 'done'
       }
+      // Re-attach any question still awaiting an answer on the server.
+      await reconcileAskUser()
     } catch {
       // Session file may not exist yet (lazy creation), silently ignore
     }
@@ -822,6 +909,8 @@ export const useChatStore = defineStore('chat', () => {
       for (const tc of pendingToolCalls.values()) {
         tc.status = 'done'
       }
+      // Re-attach any question still awaiting an answer on the server.
+      await reconcileAskUser()
     } catch (err: unknown) {
       addMessage('system', `Failed to load session: ${err instanceof Error ? err.message : String(err)}`)
     }
@@ -864,6 +953,9 @@ export const useChatStore = defineStore('chat', () => {
     addSubagentProgress,
     agentDone,
     addApprovalRequest,
+    attachAskUserRequest,
+    submitAskUser,
+    reconcileAskUser,
     resolveApproval,
     sendMessage,
     stopAgent,

--- a/web/src/styles/animations.css
+++ b/web/src/styles/animations.css
@@ -139,6 +139,33 @@
   animation: breathing 2s ease-in-out infinite;
 }
 
+/* Reusable dot-pulse utility (keyframe defined above) for the thinking footer. */
+.animate-dot-pulse {
+  animation: dot-pulse 1.4s ease-in-out infinite both;
+}
+
+/* "Thinking…" label — same text-sweep idiom as ToolCallCard's .shimmer-running,
+   so the global working cue and running tools share one motion vocabulary. */
+@keyframes thinking-sweep {
+  0%   { background-position: -200% center; }
+  100% { background-position: 200% center; }
+}
+.thinking-label {
+  background: linear-gradient(
+    90deg,
+    var(--color-muted-foreground) 20%,
+    var(--color-foreground) 50%,
+    var(--color-muted-foreground) 80%
+  );
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent; /* non-webkit fallback */
+  animation: thinking-sweep 1.8s linear infinite;
+  letter-spacing: 0.01em;
+}
+
 /* Stagger children */
 .stagger-children > * {
   animation: fade-up var(--duration-slow) var(--ease-out) both;
@@ -164,7 +191,15 @@
   .animate-breathing,
   .animate-spin,
   .animate-pulse,
+  .animate-dot-pulse,
+  .thinking-label,
   .stagger-children > * {
     animation: none !important;
+  }
+  /* Repaint the clipped-gradient label as solid muted text so the word stays
+     visible once the sweep is frozen. */
+  .thinking-label {
+    -webkit-text-fill-color: var(--color-muted-foreground);
+    color: var(--color-muted-foreground);
   }
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -140,15 +140,47 @@ export interface DiffResponse {
 
 // MCP types
 export interface MCPServerInfo {
+  name: string
   type: string
   command?: string
   url?: string
-  status: string
+  args?: string[]
+  env?: string[]
+  headers?: Record<string, string>
+  timeout?: number
   enabled: boolean
+  oauth: boolean
+  has_auth: boolean
+  status: string // connected | needs_auth | error | disabled | configured
+  error?: string
 }
 
 export interface MCPListResponse {
   servers: Record<string, MCPServerInfo>
+}
+
+// Request body for creating/updating an MCP server.
+export interface MCPServerRequest {
+  name: string
+  type: string // local | http | sse
+  url?: string
+  command?: string
+  args?: string[]
+  env?: string[]
+  headers?: Record<string, string>
+  timeout?: number
+  oauth?: {
+    enabled: boolean
+    client_id?: string
+    client_secret?: string
+    scopes?: string[]
+  }
+}
+
+export interface MCPLoginStatus {
+  status: string // idle | pending | authorized | error | needs_client_id
+  auth_url?: string
+  message?: string
 }
 
 // SSH types
@@ -168,6 +200,9 @@ export interface SkillInfo {
   name: string
   description: string
   slash?: string
+  builtin?: boolean
+  source?: string // builtin | local
+  enabled?: boolean
 }
 
 // Slash command types (unified built-in + skill)
@@ -222,6 +257,31 @@ export interface ApprovalRequestData {
   is_external: boolean
 }
 
+// ask_user types — an interactive question (or batch of questions) the agent
+// poses mid-run. Mirrors the Go AskUserQuestion / AskUserAnswer structs.
+export interface AskUserOption {
+  label: string
+  description?: string
+}
+
+export interface AskUserQuestion {
+  question: string
+  header?: string
+  options?: AskUserOption[]
+  multi_select?: boolean
+}
+
+export interface AskUserRequestData {
+  id: string
+  questions: AskUserQuestion[]
+}
+
+export interface AskUserAnswer {
+  question_header: string
+  answer: string
+  selected?: string[]
+}
+
 // UI message types
 export type MessageRole = 'user' | 'assistant' | 'system'
 
@@ -268,6 +328,14 @@ export interface ToolCall {
   displayInfo?: ToolDisplayInfo
   /** For subagent tools: nested tool calls from within the subagent */
   children?: ToolCall[]
+  /**
+   * For ask_user tools: the request id from the ask_user_request event. Present
+   * only while the question is awaiting an answer (live runs, not replay).
+   * Cleared once answered/resolved so the interactive UI collapses.
+   */
+  askUserId?: string
+  /** For ask_user tools: the backend-normalized questions to render. */
+  askUserQuestions?: AskUserQuestion[]
 }
 
 /** Subagent lifecycle event (start/done). */


### PR DESCRIPTION
## Summary

- **Interactive Ask User (web)** — primary change this session. The web `ask_user` tool was wired with a dead response channel: it **blocked the agent forever** and the UI showed raw JSON args. This PR makes it an interactive question card (options, multi-select, free-text "Other", Skip/Submit), with the agent loop properly unblocking on the user's answer — mirroring the existing approval flow.
- **MCP OAuth & management** — carried in from prior uncommitted work that shared the working tree: MCP OAuth login, MCP/skills management across web + TUI with hot-reload, and a settings dialog redesign.

> Note: this PR bundles two feature sets that were both sitting uncommitted on `main`. They are described separately below.

## Related Issues / Tickets

-

## Type of Change

- [x] Bug fix (web ask_user hang)
- [x] New feature (interactive ask_user, MCP OAuth/management)
- [ ] Breaking change
- [x] Documentation update (MCP docs)
- [ ] Refactoring / code cleanup
- [ ] Performance improvement
- [x] Test update

## Changes Made

**Interactive Ask User (web)**
1. `tools.AskUserDeps` gains a blocking `BatchRequestFn` (handles batch + legacy single-question); TUI/ACP paths unchanged.
2. `handler.WebHandler`: `RequestAskUser` emits an `ask_user_request` event and blocks on a per-id channel; `ResolveAskUser` (via `POST /api/ask`) unblocks it. `PendingAskUserRequests` + `GET /api/ask/pending` re-surface in-flight questions so a page reload mid-question doesn't strand the agent.
3. New `AskUserCard.vue` (options + descriptions, multi-select, free-text, Skip/Submit, collapse, digit-key selection, resolved/replay view); `ToolCallCard` special-cases `ask_user`; store/ws/api/types plumbing added.
4. Hardened against: failed-POST re-arm, two concurrent asks colliding, dropped `tool_call`, and skip/no-answer display — all found via an adversarial multi-agent review.

**MCP OAuth & management (carried in)**
5. MCP OAuth login flow (`internal/tools/mcp_oauth.go`), MCP/skills management for web + TUI with hot-reload, settings dialog redesign, supporting config/util/tui changes and docs.

## Testing

- Go: `go build ./...`, `go vet ./internal/...`, `go test ./internal/tools ./internal/handler ./internal/web ./internal/runner` — all pass.
- New `TestWebHandler_AskUserRoundTrip` proves the full emit → resolve → tool-returns loop (the hang this fixes) and the pending re-surface contract.
- Web: `npm run type-check`, `vite build`, and `eslint` on touched files — all clean.

## Screenshots / Recordings

_The Ask User card renders the question with labelled options + descriptions, an "Other" free-text input, and Skip/Submit, matching the reference design._

## Checklist

- [x] I have performed a self-review of my code (plus a multi-agent adversarial review of the ask_user flow).
- [x] My code follows the project's style guidelines.
- [x] I have added/updated tests as needed (ask_user round-trip).
- [x] I have updated relevant documentation (MCP docs).
- [x] All new and existing tests pass.

## Additional Notes

- The interactive ask_user flow adds **reload resilience** (pull-based `GET /api/ask/pending` reconcile) that the **approval flow still lacks** — the same pattern could be applied there as a follow-up.
- Four files (`internal/command/web.go`, `internal/web/server.go`, `web/src/composables/api.ts`, `web/src/types/api.ts`) contain changes from both feature sets, which is why they're bundled in one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)