### PR TITLE
chore(lint): fix pre-existing golangci-lint issues

### DIFF
--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -1300,7 +1300,7 @@ func resolveStartupMode(cfg *config.Config, unsafe bool) mode.SessionMode {
 	if cfg != nil && cfg.DefaultMode != "" {
 		return mode.Parse(cfg.DefaultMode)
 	}
-	if cfg != nil && cfg.AutoApprove {
+	if cfg != nil && cfg.AutoApprove { //nolint:staticcheck // intentional fallback to the deprecated field when DefaultMode is unset
 		return mode.Autopilot
 	}
 	return mode.Ask

--- a/internal/command/ssh.go
+++ b/internal/command/ssh.go
@@ -53,7 +53,7 @@ func HandleSSHConnect(
 		return // Do not initialize agent yet
 	}
 
-	remotePwd := "/root"
+	var remotePwd string
 	if path != "" {
 		remotePwd = path
 	} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,6 +161,7 @@ type Config struct {
 	Team          *TeamConfig           `json:"team,omitempty"`
 
 	// AutoApprove sets the default approval mode to auto on startup.
+	//
 	// Deprecated: superseded by DefaultMode; still honored as a fallback when
 	// DefaultMode is empty (true → "autopilot").
 	AutoApprove bool `json:"auto_approve,omitempty"`

--- a/internal/handler/acp.go
+++ b/internal/handler/acp.go
@@ -208,11 +208,12 @@ func (h *ACPHandler) presentationForTool(name, argsJSON string) acpToolPresentat
 		p.Title = "Load skill " + getString("name")
 	case "team_send_message":
 		to := getString("to")
-		if to == "*" {
+		switch {
+		case to == "*":
 			p.Title = "Message team"
-		} else if to != "" {
+		case to != "":
 			p.Title = "Message @" + to
-		} else {
+		default:
 			p.Title = "Send team message"
 		}
 	case "team_create":

--- a/internal/tools/goal.go
+++ b/internal/tools/goal.go
@@ -169,32 +169,30 @@ func (s *GoalStore) IsActive() bool {
 	return s.goal != nil && s.goal.Status == GoalActive
 }
 
-// setStatus transitions the goal to a terminal status. Returns the snapshot and
-// whether a goal existed to update.
-func (s *GoalStore) setStatus(status GoalStatus) (*Goal, bool) {
+// setStatus transitions the goal to a terminal status. Returns whether a goal
+// existed to update.
+func (s *GoalStore) setStatus(status GoalStatus) bool {
 	s.mu.Lock()
 	if s.goal == nil {
 		s.mu.Unlock()
-		return nil, false
+		return false
 	}
 	s.goal.Status = status
 	s.goal.UpdatedAt = s.now()
 	snap := s.goal.clone()
 	s.mu.Unlock()
 	s.fireUpdate(snap)
-	return snap, true
+	return true
 }
 
 // Complete marks the goal complete. Returns false if no goal is set.
 func (s *GoalStore) Complete() bool {
-	_, ok := s.setStatus(GoalComplete)
-	return ok
+	return s.setStatus(GoalComplete)
 }
 
 // Block marks the goal blocked. Returns false if no goal is set.
 func (s *GoalStore) Block() bool {
-	_, ok := s.setStatus(GoalBlocked)
-	return ok
+	return s.setStatus(GoalBlocked)
 }
 
 // Clear removes the goal entirely.

--- a/internal/tools/goal_test.go
+++ b/internal/tools/goal_test.go
@@ -3,9 +3,10 @@ package tools
 import (
 	"context"
 	"encoding/json"
-	"github.com/cnjack/jcode/internal/session"
 	"strings"
 	"testing"
+
+	"github.com/cnjack/jcode/internal/session"
 )
 
 func TestGoalStore_SetAndGet(t *testing.T) {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -319,7 +319,7 @@ func NewModel(hasPrompt bool, pwd string, todoStore *tools.TodoStore) Model {
 
 	if cfg, err := config.LoadConfig(); err == nil {
 		m.activeProvider, m.activeModel = cfg.GetProviderModel()
-		if cfg.AutoApprove {
+		if cfg.AutoApprove { //nolint:staticcheck // intentional fallback to the deprecated field when DefaultMode is unset
 			m.approvalMode = ModeAuto
 		}
 	}


### PR DESCRIPTION
## Summary

- Cleans up the 5 trivial (non-deprecation) issues reported by `golangci-lint run ./...` that don't block CI (`only-new-issues: true`) but were flagged by the new quality gate.
- No behavior change — these are mechanical lint fixes only.

## Related Issues / Tickets

- N/A — follow-up to the new CI quality gate in `.github/workflows/ci.yml`.

## Type of Change

- [x] Refactoring / code cleanup

## Changes Made

1. **unparam** ([goal.go](internal/tools/goal.go)) — dropped the unused `*Goal` return from `(*GoalStore).setStatus`; both callers (`Complete`/`Block`) only used the `bool`.
2. **goimports** ([goal_test.go](internal/tools/goal_test.go)) — moved the `internal/session` import into its own third-party group.
3. **ineffassign** ([ssh.go](internal/command/ssh.go)) — replaced `remotePwd := "/root"` with `var remotePwd string`; the initializer was always overwritten by the following if/else.
4. **gocritic / deprecatedComment** ([config.go](internal/config/config.go)) — moved the `AutoApprove` `Deprecated:` notice into its own paragraph.
5. **gocritic / ifElseChain** ([acp.go](internal/handler/acp.go)) — rewrote the `team_send_message` if-else chain as a tagless `switch`.

## Testing

- `golangci-lint run ./...` → only the 9 `adk.AgentMiddleware` SA1019 deprecation warnings remain (intentionally left for the separate dependency-migration task); 0 other issues.
- `go build ./...` → OK
- `go test ./...` → all packages pass

## Additional Notes

Fixing the `Deprecated:` comment format (#4) made staticcheck correctly recognize `AutoApprove` as deprecated, surfacing two new SA1019 warnings on intentional fallback reads ([interactive.go](internal/command/interactive.go), [tui.go](internal/tui/tui.go)). Those reads are documented behavior — the field is still honored as a fallback when `DefaultMode` is unset — so they're annotated with `//nolint:staticcheck` rather than removed. This keeps the remaining-warning count at exactly the 9 `adk.AgentMiddleware` items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure and helper method implementations for better maintainability.
  * Enhanced conditional logic formatting for improved readability.

* **Tests**
  * Updated test imports for consistency.

* **Chores**
  * Added linter directives to preserve backward compatibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->