### PR TITLE
fix(desktop): point beforeBuildCommand at the root Makefile

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../../internal/web/dist",
     "beforeDevCommand": "pnpm --dir ../web dev",
     "devUrl": "http://localhost:5173",
-    "beforeBuildCommand": "make build-web"
+    "beforeBuildCommand": "make -C .. build-web"
   },
   "app": {
     "withGlobalTauri": true,


### PR DESCRIPTION
## Problem
The v0.6.2 release pipeline failed in the desktop bundle job:

```
Running beforeBuildCommand `make build-web`
make: *** No rule to make target `build-web'.  Stop.
```

The `Build desktop bundle` step runs with `working-directory: desktop`, so Tauri's `beforeBuildCommand` executes from `desktop/`. There is no Makefile there — the `build-web` target lives in the repo root.

## Fix
`beforeBuildCommand`: `make build-web` → `make -C .. build-web`, so the root target resolves from the desktop dir in both CI and local `make desktop-build`.

Verified with a dry-run from `desktop/`: `make -C .. -n build-web` resolves and runs the web build. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)