### PR TITLE
fix(build): make build-web generate web assets first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ generate:
 	go generate ./internal/model/...
 	go generate ./internal/theme/...
 
-build-web:
+build-web: generate
 	@echo "Building frontend..."
 	cd web && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install)
 	cd web && npx vite build


### PR DESCRIPTION
## Problem
After fixing the `make build-web` path (#93), the v0.6.2 desktop jobs failed deeper — the web build couldn't resolve generated files on a clean checkout:

```
Can't resolve './styles/tokens.generated.css'
Could not resolve './themes.generated' in src/composables/useTheme.ts
```

`web/src/styles/tokens.generated.css` and `web/src/composables/themes.generated.ts` are produced by the theme generator (`go generate ./internal/theme/...`) and are **gitignored**. The desktop job's sidecar step uses a plain `go build` and never runs `make generate`, so those files don't exist when Tauri's `beforeBuildCommand` runs `make -C .. build-web`.

## Fix
Make `build-web` depend on `generate`, so the frontend build is self-contained (also fixes local `make desktop-build`).

Verified locally by deleting both generated files and running `make -C .. build-web` from `desktop/` — they regenerate and vite build succeeds (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)