### PR TITLE
chore(deps): upgrade cloudwego/eino v0.9.6 → v0.9.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/charmbracelet/x/ansi v0.11.7
-	github.com/cloudwego/eino v0.9.6
+	github.com/cloudwego/eino v0.9.9
 	github.com/cloudwego/eino-ext/components/tool/mcp v0.0.8
 	github.com/cloudwego/eino-ext/libs/acl/langfuse v0.1.1
 	github.com/coder/acp-go-sdk v0.13.5
@@ -22,6 +22,7 @@ require (
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.51.0
+	golang.org/x/sys v0.45.0
 	tinygo.org/x/bluetooth v0.15.0
 )
 
@@ -114,7 +115,6 @@ require (
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.6 h1:M3IRhIpDxNwIuQ2SRUX1yUTkC8lcMggRI5wtHZy8A5M=
-github.com/cloudwego/eino v0.9.6/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.9 h1:x63hvRif6ANPh9YEPoTIrp1potEeoLQFAjOclKaX/Kg=
+github.com/cloudwego/eino v0.9.9/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/components/tool/mcp v0.0.8 h1:/QwCVAtB61b4Q2+RUvhoy9AZNkhiThsTySIoimxiJS4=
 github.com/cloudwego/eino-ext/components/tool/mcp v0.0.8/go.mod h1:zxP8sFkADBqflNc0a4qfKdLYQ+edzHPlkOaZF0A1X7o=
 github.com/cloudwego/eino-ext/libs/acl/langfuse v0.1.1 h1:y7LwRyPGcSLPkt/A9HJf+06Z+Jp4yj67zCDpd24762w=


### PR DESCRIPTION
## What

Upgrades `github.com/cloudwego/eino` from **v0.9.6** to **v0.9.9** (latest stable patch).

| Module | Before | After |
|--------|--------|-------|
| `github.com/cloudwego/eino` | v0.9.6 | **v0.9.9** |
| `eino-ext/components/tool/mcp` | v0.0.8 | v0.0.8 (already latest) |
| `eino-ext/libs/acl/langfuse` | v0.1.1 | v0.1.1 (already latest) |

`go mod tidy` also promoted `golang.org/x/sys` from an indirect to a direct dependency.

## Why

All changes between v0.9.6 and v0.9.9 are bug/security fixes with **no breaking API changes**:

- **v0.9.7** — `fix(adk)`: wire `ModelFailoverConfig` into agentic ReAct path (#1078)
- **v0.9.8** — `fix(schema)`: preserve empty params map across `ToolInfo` JSON roundtrip (#1081)
- **v0.9.8** — `fix(schema)`: **gonja SSTI security fix** (#1077)
- **v0.9.9** — `fix(adk)`: copy-on-write `SetMessageID` to avoid concurrent map panic (#1085)

Notably this pulls in a server-side template injection (SSTI) security fix and a concurrency panic fix.

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅ (no warnings)
- Package tests pass ✅ — `internal/agent`, `internal/model`, `internal/tools`, `internal/web`, `internal/command`

No source code changes were required — only `go.mod` / `go.sum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to a newer version for improved stability and compatibility.
  * Cleaned up dependency declarations by promoting one package to a direct requirement and removing a duplicate indirect entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->