### PR TITLE
fix(browser): resolve flaky TestManagedBackendErrorPropagation (CDP send race)

### DIFF
--- a/internal/browser/cdp.go
+++ b/internal/browser/cdp.go
@@ -183,6 +183,21 @@ func (c *wsCDP) send(ctx context.Context, sessionID, method string, params any) 
 		c.mu.Unlock()
 		return nil, ctx.Err()
 	case <-c.closed:
+		// The read loop signals c.closed only after delivering (or closing) every
+		// pending channel, so a response for THIS request may already be waiting in
+		// ch — e.g. a server that writes a result frame and immediately drops the
+		// socket. Prefer the real response over reporting the close; select alone
+		// would pick between the two ready cases at random (a source of flakes).
+		select {
+		case msg, ok := <-ch:
+			if ok {
+				if msg.Error != nil {
+					return nil, fmt.Errorf("%s: %w", method, msg.Error)
+				}
+				return msg.Result, nil
+			}
+		default:
+		}
 		return nil, fmt.Errorf("cdp connection closed during %s", method)
 	}
 }

--- a/internal/browser/cdp_test.go
+++ b/internal/browser/cdp_test.go
@@ -86,7 +86,11 @@ func TestManagedBackendNewTabAndSend(t *testing.T) {
 }
 
 func TestManagedBackendErrorPropagation(t *testing.T) {
-	// A handler that returns nothing useful; drive the error path by closing.
+	// Reply with a CDP error frame and immediately drop the socket. The error
+	// frame and the connection-close then race inside send's select; the caller
+	// must still surface the "boom" error rather than a "connection closed" one.
+	// Loop so a regression (picking the close signal at random) fails reliably
+	// instead of only ~half the time.
 	up := websocket.Upgrader{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := up.Upgrade(w, r, nil)
@@ -95,21 +99,23 @@ func TestManagedBackendErrorPropagation(t *testing.T) {
 		}
 		var msg cdpMessage
 		_ = conn.ReadJSON(&msg)
-		// Reply with a CDP error frame.
 		_ = conn.WriteJSON(cdpMessage{ID: msg.ID, Error: &cdpError{Code: -32000, Message: "boom"}})
 		_ = conn.Close()
 	}))
 	defer srv.Close()
 
-	ctx := context.Background()
-	backend, err := connectManaged(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
-	defer func() { _ = backend.Close() }()
-	_, err = backend.cdp.send(ctx, "", "Target.getTargets", nil)
-	if err == nil || !strings.Contains(err.Error(), "boom") {
-		t.Fatalf("expected boom error, got %v", err)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	for i := 0; i < 50; i++ {
+		ctx := context.Background()
+		backend, err := connectManaged(ctx, wsURL, nil)
+		if err != nil {
+			t.Fatalf("connect: %v", err)
+		}
+		_, err = backend.cdp.send(ctx, "", "Target.getTargets", nil)
+		_ = backend.Close()
+		if err == nil || !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("iter %d: expected boom error, got %v", i, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestManagedBackendErrorPropagation` in `internal/browser` fails intermittently on CI:

```
cdp_test.go: expected boom error, got cdp connection closed during Target.getTargets
FAIL github.com/cnjack/jcode/internal/browser
```

(Seen blocking an unrelated PR — the failure has nothing to do with that PR's diff.)

## Root cause

`wsCDP.send` ([cdp.go](internal/browser/cdp.go)) waits on a `select` over three cases: the per-request response channel `ch`, `ctx.Done()`, and `c.closed`. When a server writes a result/error frame **and immediately drops the socket**, the read loop:

1. delivers the frame into the buffered `ch` (`ch <- msg`), then
2. on the next read sees the closed socket, closes any still-pending channels, and `close(c.closed)`.

That leaves **both** `<-ch` and `<-c.closed` ready at once. Go's `select` picks a ready case at random, so ~50% of the time `send` returns `"cdp connection closed during <method>"` and discards the response that had already arrived. This is both the test flake and a latent correctness bug (a real CDP response racing a socket close could be dropped).

CI runs `go test ./...` without `-race`, so it only manifested as the occasional assertion failure, not a race warning.

## Fix

In the `c.closed` branch, do a non-blocking receive on `ch` first and return the buffered response if one is present. The read loop always delivers-or-closes every pending channel *before* signaling `c.closed`, so this recovery is decisive — no new races, no busy-waiting.

## Verification

- Reproduced the exact CI failure **pre-fix** under scheduling pressure: `GOMAXPROCS=2 go test ./internal/browser -run TestManagedBackendErrorPropagation -count=3000` → multiple `expected boom error, got cdp connection closed` failures.
- **Post-fix**: same 3000× stress passes; focused browser tests pass under `-race`.
- Hardened the test to loop the boom-then-close scenario 50× so a regression fails reliably instead of ~half the time.

## Note (out of scope)

Running the full `internal/browser` package under `-race` also surfaces a **separate, pre-existing** data race in `TestBridgeKeepAlivePing` (it mutates the package globals `keepAlivePing`/`keepAliveWait` that a `keepAlive()` goroutine reads at [bridge.go:178](internal/browser/bridge.go:178)). It exists on `main` independent of this change and CI doesn't run `-race`, so it's left for a follow-up.

Generated with Jack AI bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when a browser connection closes at the same time a command error is returned, so the original error is preserved more consistently.
  * Made error handling during this race condition more deterministic, reducing cases where a generic connection-closed message could mask the real failure.
* **Tests**
  * Strengthened coverage for this close/error race to ensure the expected error is consistently reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->