### PR TITLE
chore(extension): bump Browser Bridge to 0.1.5

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "jcode Browser Bridge",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Let jcode see and operate your browser via the DevTools Protocol. Connects to your local jcode server.",
   "minimum_chrome_version": "116",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0JN3n8PBlNtsaMBRXs5g76Kt8C1VIO5bz+vRY4HMAyn1soIAhNDu9ZAcQjOUmuu1SyJe7A683EfgXJhpFghvSULi63rKHO584FBc9zK53b8m1yVq6HuNZtwXTZyDXeCVNwKstI9zHCLqTUEWyBuy3zJOWRq+0d8h9Moz2a0rDLePqAmPyQb6nlSvDomPIIRnk4p0sBSQbENWKwd/hhJwlsl/D4JK/SVWLXfhQZOP5PceGJ0gnOmIH38bPuxW3l1EWk3nuOZyIVRUvF9QkuAhS9U/+1WEVCco6tijVaBoHI6rzbxouR5BH9Drg0lt9VPJPlq0HlU8AyLLepweJ6MWxwIDAQAB",


### PR DESCRIPTION
## Summary

- Bump the jcode Browser Bridge Chrome extension manifest version from `0.1.4` to `0.1.5` for a new Web Store release.

## Related Issues / Tickets

- N/A

## Type of Change

- [x] Documentation update / release chore (version bump)

## Changes Made

1. `extension/manifest.json`: `version` `0.1.4` → `0.1.5`.

## Testing

- Built the Web Store upload package from the bumped manifest and verified the packaged `manifest.json` reports `"version": "0.1.5"`.
- Confirmed the store package must ship **without** the manifest `key` field: uploading a package that carries the committed dev `key` triggers Chrome's "the value of the `key` field in the manifest does not match the current content" error, because the store re-signs under its own id (`olkapiiikpfhaccmjphakolinkcggcbd`, per `internal/browser/discover.go`). The committed manifest keeps `key` so the unpacked/dev build retains its stable id (`ekcnni...`); only the upload artifact strips it.

## Additional Notes

- No code changes — the `key` field intentionally remains in the committed manifest for unpacked/dev installs. The Web Store `.zip` is a build artifact (key stripped) and is not tracked in git.

Generated with Jack AI bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the browser extension version to **0.1.5**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->