### PR TITLE
feat(flow): workflow /<name> slash commands across TUI, Web, and ACP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/.jekyll-metadata
 .claude
 site/dist
 site/node_modules
+.jcode

--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cnjack/jcode/internal/agent"
 	"github.com/cnjack/jcode/internal/config"
+	"github.com/cnjack/jcode/internal/flow"
 	"github.com/cnjack/jcode/internal/handler"
 	"github.com/cnjack/jcode/internal/hooks"
 	mempipeline "github.com/cnjack/jcode/internal/memory/pipeline"
@@ -80,6 +81,7 @@ type acpSession struct {
 	normalPrompt string
 	planPrompt   string
 	skillLoader  *skills.Loader
+	flowLoader   *flow.Loader
 }
 
 // Close releases resources held by the session (recorder file handle, tracer).
@@ -145,7 +147,7 @@ func handleACPSubcommand() {
 
 // availableCommandList builds the slash commands advertised to ACP clients:
 // the built-in /goal command plus any skill-based commands.
-func availableCommandList(skillLoader *skills.Loader) []acp.AvailableCommand {
+func availableCommandList(skillLoader *skills.Loader, flowLoader *flow.Loader) []acp.AvailableCommand {
 	cmds := []acp.AvailableCommand{
 		{
 			Name:        "goal",
@@ -176,13 +178,32 @@ func availableCommandList(skillLoader *skills.Loader) []acp.AvailableCommand {
 			})
 		}
 	}
+	if flowLoader != nil {
+		for _, fc := range flowLoader.SlashCommands() {
+			name := strings.TrimPrefix(fc.Slash, "/")
+			if name == "goal" {
+				continue
+			}
+			// ACP has no "type" field, so mark workflows in the description so
+			// editor command palettes distinguish them from skills.
+			cmds = append(cmds, acp.AvailableCommand{
+				Name:        name,
+				Description: "workflow — " + fc.Description,
+				Input: &acp.AvailableCommandInput{
+					Unstructured: &acp.UnstructuredCommandInput{
+						Hint: "args / context",
+					},
+				},
+			})
+		}
+	}
 	return cmds
 }
 
 // broadcastSlashCommands sends the available slash commands to the client via
 // an available_commands_update session notification.
 func (a *acpAgent) broadcastSlashCommands(sessionID acp.SessionId, sess *acpSession) {
-	cmds := availableCommandList(sess.skillLoader)
+	cmds := availableCommandList(sess.skillLoader, sess.flowLoader)
 	if len(cmds) == 0 {
 		return
 	}
@@ -324,6 +345,9 @@ func (a *acpAgent) buildAgentSession(
 	skillLoader := skills.NewLoader()
 	skillLoader.ScanProjectSkills(pwd)
 
+	flowLoader := flow.NewLoader()
+	flowLoader.LoadProject(pwd)
+
 	providerName, modelName := cfg.GetProviderModel()
 	providers := cfg.GetProviders()
 	providerCfg := providers[providerName]
@@ -371,6 +395,7 @@ func (a *acpAgent) buildAgentSession(
 		env.NewWorkflowRunTool(&tools.WorkflowToolDeps{
 			ModelFactory: internalmodel.NewModelFactory(cfg, chatModel),
 			Recorder:     rec,
+			Loader:       flowLoader,
 		}),
 	}
 	if config.MemoryEnabled(cfg) {
@@ -522,6 +547,7 @@ func (a *acpAgent) buildAgentSession(
 		normalPrompt:  normalPrompt,
 		planPrompt:    planPrompt,
 		skillLoader:   skillLoader,
+		flowLoader:    flowLoader,
 	}
 
 	// Reconcile the session's advertised mode when the handler promotes to
@@ -623,6 +649,7 @@ func (a *acpAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Pr
 		}
 
 		// Check if it's a skill slash command.
+		matchedSkill := false
 		if sess.skillLoader != nil {
 			if sk := sess.skillLoader.GetBySlash("/" + cmdName); sk != nil {
 				userInput := ""
@@ -630,6 +657,18 @@ func (a *acpAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Pr
 					userInput = parts[1]
 				}
 				prompt = fmt.Sprintf("Use the load_skill tool with name=%q and follow its instructions. %s", sk.Name, userInput)
+				matchedSkill = true
+			}
+		}
+
+		// Otherwise check workflow slash commands (e.g. /repo-audit).
+		if !matchedSkill && sess.flowLoader != nil {
+			if wf, ok := sess.flowLoader.GetBySlash("/" + cmdName); ok {
+				userInput := ""
+				if len(parts) > 1 {
+					userInput = parts[1]
+				}
+				prompt = flow.SlashRunPrompt(wf.Meta.Name, userInput)
 			}
 		}
 	}

--- a/internal/command/acp_goal_test.go
+++ b/internal/command/acp_goal_test.go
@@ -3,7 +3,7 @@ package command
 import "testing"
 
 func TestAvailableCommandList_IncludesGoal(t *testing.T) {
-	cmds := availableCommandList(nil)
+	cmds := availableCommandList(nil, nil)
 	if len(cmds) == 0 {
 		t.Fatal("expected at least the goal command")
 	}

--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cnjack/jcode/internal/browser"
 	"github.com/cnjack/jcode/internal/channel"
 	"github.com/cnjack/jcode/internal/config"
+	"github.com/cnjack/jcode/internal/flow"
 	"github.com/cnjack/jcode/internal/handler"
 	"github.com/cnjack/jcode/internal/hooks"
 	mempipeline "github.com/cnjack/jcode/internal/memory/pipeline"
@@ -62,6 +63,7 @@ type interactiveState struct {
 	platform        string
 	registry        *internalmodel.ModelRegistry
 	skillLoader     *skills.Loader
+	flowLoader      *flow.Loader
 	langfuseTracer  *telemetry.LangfuseTracer
 	h               handler.AgentEventHandler
 	askUserDeps     *tools.AskUserDeps
@@ -108,6 +110,7 @@ func (s *interactiveState) buildAllTools() []tool.BaseTool {
 			ModelFactory: internalmodel.NewModelFactory(s.cfg, s.chatModel),
 			Recorder:     s.rec,
 			Tracer:       s.langfuseTracer,
+			Loader:       s.flowLoader,
 		}),
 		tools.NewAskUserTool(s.askUserDeps),
 		skills.NewLoadSkillTool(s.skillLoader),
@@ -812,6 +815,19 @@ func (s *interactiveState) runEventLoop(initialHistory []adk.Message, initialRes
 		s.p.Send(tui.SkillsLoadedMsg{SlashCommands: slashInfos})
 	}
 
+	if s.flowLoader != nil {
+		if slashFlows := s.flowLoader.SlashCommands(); len(slashFlows) > 0 {
+			var flowInfos []tui.FlowSlashInfo
+			for _, fc := range slashFlows {
+				flowInfos = append(flowInfos, tui.FlowSlashInfo{
+					Slash:       fc.Slash,
+					Description: fc.Description,
+				})
+			}
+			s.p.Send(tui.FlowsLoadedMsg{SlashCommands: flowInfos})
+		}
+	}
+
 	s.history = initialHistory
 	if initialResumeUUID != "" {
 		s.p.Send(tui.SessionResumedMsg{UUID: initialResumeUUID, Entries: initialResumeEntries})
@@ -977,6 +993,9 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 	skillLoader := skills.NewLoaderWithDisabled(cfg.DisabledSkills)
 	skillLoader.ScanProjectSkills(pwd)
 
+	flowLoader := flow.NewLoader()
+	flowLoader.LoadProject(pwd)
+
 	// Memory distillation runs in the background on session start (design
 	// §5.1); one-shot -p runs are excluded, gates (cooldown/budget/lock) are
 	// inside the pipeline.
@@ -1071,6 +1090,7 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 		platform:     platform,
 		registry:     registry,
 		skillLoader:  skillLoader,
+		flowLoader:   flowLoader,
 		askUserDeps:  askUserDeps,
 		mcpTools:     mcpTools,
 		rec:          rec,

--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cnjack/jcode/internal/channel/ble"
 	"github.com/cnjack/jcode/internal/config"
 	"github.com/cnjack/jcode/internal/feature"
+	"github.com/cnjack/jcode/internal/flow"
 	"github.com/cnjack/jcode/internal/handler"
 	mempipeline "github.com/cnjack/jcode/internal/memory/pipeline"
 	"github.com/cnjack/jcode/internal/mode"
@@ -239,6 +240,9 @@ func runWebServer(port int, host string, openBrowser bool, authToken string) err
 	skillLoader := skills.NewLoaderWithDisabled(cfg.DisabledSkills)
 	skillLoader.ScanProjectSkills(pwd)
 
+	flowLoader := flow.NewLoader()
+	flowLoader.LoadProject(pwd)
+
 	var providerName, modelName string
 	if !needsSetup {
 		providerName, modelName = cfg.GetProviderModel()
@@ -406,6 +410,14 @@ func runWebServer(port int, host string, openBrowser bool, authToken string) err
 			taskEnvInfo = util.CollectEnvInfo(taskPwd)
 		}
 
+		// Per-task flow loader (builtin + user + this task's project workflows),
+		// shared with the workflow_run tool so slash triggers and inline runs
+		// resolve the same set. Project workflows only apply to a local exec.
+		taskFlowLoader := flow.NewLoader()
+		if exec == nil {
+			taskFlowLoader.LoadProject(taskPwd)
+		}
+
 		tbg := tools.NewBackgroundManager(tenv)
 		trec, _ := session.NewRecorder(projectKey, providerName, modelName)
 		if taskID != "" && trec != nil {
@@ -494,6 +506,7 @@ func runWebServer(port int, host string, openBrowser bool, authToken string) err
 				tenv.NewWorkflowRunTool(&tools.WorkflowToolDeps{
 					ModelFactory: internalmodel.NewModelFactory(cfg, cm),
 					Recorder:     trec,
+					Loader:       taskFlowLoader,
 				}),
 				tools.NewAskUserTool(&tools.AskUserDeps{
 					BatchRequestFn: twh.RequestAskUser,
@@ -764,6 +777,7 @@ func runWebServer(port int, host string, openBrowser bool, authToken string) err
 		Registry:           registry,
 		ApprovalState:      bootEC.ApprovalState,
 		SkillLoader:        skillLoader,
+		FlowLoader:         flowLoader,
 		ReloadMCP:          reloadMCPTools,
 		InitialMCPStatuses: initialMCPStatuses,
 		WechatClient:       wechatClient,

--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -723,6 +723,7 @@ func runWebServer(port int, host string, openBrowser bool, authToken string) err
 			BreakdownFn:    breakdownFn,
 			CreateAgent:    createAgent,
 			RebuildForMode: rebuildForMode,
+			FlowLoader:     taskFlowLoader,
 		}, nil
 	}
 

--- a/internal/flow/slash.go
+++ b/internal/flow/slash.go
@@ -1,0 +1,29 @@
+package flow
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetBySlash returns the workflow whose auto-generated "/<name>" trigger matches
+// slash. Workflows only expose auto-generated slashes (see SlashCommands), so this
+// is a name lookup with the leading "/" stripped.
+func (l *Loader) GetBySlash(slash string) (Workflow, bool) {
+	return l.Get(strings.TrimPrefix(slash, "/"))
+}
+
+// SlashRunPrompt is the agent instruction a "/<workflow>" slash command expands
+// to on every frontend (TUI / Web / ACP). It tells the agent to run the named
+// saved workflow via the workflow_run tool rather than authoring an inline
+// script; any text the user typed after the slash is handed over so the agent can
+// shape it into the workflow's `args` object. Keeping the wording here means all
+// frontends stay in lockstep.
+func SlashRunPrompt(name, userInput string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Run the saved workflow %q by calling the workflow_run tool with name=%q. "+
+		"Do not write an inline script — run the saved workflow by name.", name, name)
+	if s := strings.TrimSpace(userInput); s != "" {
+		fmt.Fprintf(&b, "\n\nShape the workflow's `args` from this input: %s", s)
+	}
+	return b.String()
+}

--- a/internal/tui/input_views.go
+++ b/internal/tui/input_views.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/cnjack/jcode/internal/config"
+	"github.com/cnjack/jcode/internal/flow"
 	"github.com/cnjack/jcode/internal/memory"
 	"github.com/cnjack/jcode/internal/mode"
 	"github.com/cnjack/jcode/internal/tools"
@@ -42,7 +43,21 @@ func (m Model) getAllCommands() []commandSuggestion {
 	for _, sc := range m.skillSlashCommands {
 		commands = append(commands, commandSuggestion{sc.Slash, sc.Description})
 	}
+	for _, fc := range m.flowSlashCommands {
+		commands = append(commands, commandSuggestion{fc.Slash, fc.Description})
+	}
 	return commands
+}
+
+// isFlowSlash reports whether cmd (e.g. "/repo-audit") is a workflow slash
+// command, used to mark it distinctly in the suggestion list.
+func (m Model) isFlowSlash(cmd string) bool {
+	for _, fc := range m.flowSlashCommands {
+		if fc.Slash == cmd {
+			return true
+		}
+	}
+	return false
 }
 
 // filterCommands returns commands that match the given prefix.
@@ -158,18 +173,27 @@ func (m Model) renderCommandSuggestions() string {
 		s := suggestions[i]
 		cmdText := s.cmd
 		descText := s.desc
+		isFlow := m.isFlowSlash(s.cmd)
 		if i == m.cmdSuggestionIndex {
 			// Highlighted item
 			cmdStyled := lipgloss.NewStyle().Bold(true).Foreground(colorOnPrimary).Background(colorPrimary).Render(cmdText)
 			descStyled := lipgloss.NewStyle().Foreground(colorOnPrimary).Background(colorPrimary).Render(" " + descText)
+			tag := ""
+			if isFlow {
+				tag = lipgloss.NewStyle().Italic(true).Foreground(colorOnPrimary).Background(colorPrimary).Render(" workflow")
+			}
 			// Indicator
 			indicator := lipgloss.NewStyle().Foreground(colorPrimary).Render("❯")
-			lines = append(lines, fmt.Sprintf("  %s %s%s", indicator, cmdStyled, descStyled))
+			lines = append(lines, fmt.Sprintf("  %s %s%s%s", indicator, cmdStyled, tag, descStyled))
 		} else {
 			cmdStyled := lipgloss.NewStyle().Foreground(colorText).Render(cmdText)
 			descStyled := lipgloss.NewStyle().Foreground(colorMuted).Render(" " + descText)
+			tag := ""
+			if isFlow {
+				tag = lipgloss.NewStyle().Italic(true).Foreground(colorPrimary).Render(" workflow")
+			}
 			indicator := lipgloss.NewStyle().Foreground(colorMuted).Render(" ")
-			lines = append(lines, fmt.Sprintf("  %s %s%s", indicator, cmdStyled, descStyled))
+			lines = append(lines, fmt.Sprintf("  %s %s%s%s", indicator, cmdStyled, tag, descStyled))
 		}
 	}
 
@@ -430,6 +454,51 @@ func (m *Model) handleSkillSlashInput(skillName, userInput string, cmds []tea.Cm
 	m.thinking = true
 	m.lines = append(m.lines, textLine(fmt.Sprintf("%s %s",
 		userLabelStyle.Render("🔧 Skill:"), displayLabel)))
+	if m.ready {
+		m.viewport.SetHeight(m.calcViewportHeight(false))
+		m.viewport.SetContent(m.renderViewportContent())
+		m.viewport.GotoBottom()
+	}
+	cmds = append(cmds, func() tea.Msg {
+		return PromptSubmitMsg{Prompt: prompt}
+	})
+	cmds = append(cmds, m.spinner.Tick)
+	return m, tea.Batch(cmds...)
+}
+
+// matchFlowSlash checks if the prompt matches a registered workflow slash command.
+// Returns a FlowSlashMsg if matched, nil otherwise.
+func (m Model) matchFlowSlash(prompt string) *FlowSlashMsg {
+	for _, fc := range m.flowSlashCommands {
+		if prompt == fc.Slash || strings.HasPrefix(prompt, fc.Slash+" ") {
+			userInput := ""
+			if strings.HasPrefix(prompt, fc.Slash+" ") {
+				userInput = strings.TrimSpace(prompt[len(fc.Slash):])
+			}
+			return &FlowSlashMsg{
+				FlowName:  strings.TrimPrefix(fc.Slash, "/"),
+				UserInput: userInput,
+			}
+		}
+	}
+	return nil
+}
+
+// handleFlowSlashInput handles a workflow slash command by sending a prompt that
+// runs the saved workflow via the workflow_run tool.
+func (m *Model) handleFlowSlashInput(flowName, userInput string, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	prompt := flow.SlashRunPrompt(flowName, userInput)
+
+	displayLabel := "/" + flowName
+	if userInput != "" {
+		displayLabel += " " + userInput
+	}
+
+	m.mode = ModeAgent
+	m.agentDone = false
+	m.thinking = true
+	m.lines = append(m.lines, textLine(fmt.Sprintf("%s %s",
+		userLabelStyle.Render("Workflow:"), displayLabel)))
 	if m.ready {
 		m.viewport.SetHeight(m.calcViewportHeight(false))
 		m.viewport.SetContent(m.renderViewportContent())

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -358,6 +358,24 @@ type SkillSlashInfo struct {
 	Description string
 }
 
+// FlowSlashMsg is emitted when the user submits a "/<workflow>" slash command.
+type FlowSlashMsg struct {
+	FlowName  string // workflow name to run
+	UserInput string // additional user input after the slash command
+}
+
+// FlowsLoadedMsg is sent at startup to inform the TUI about available workflow
+// slash commands (e.g. /repo-audit, /roundtable).
+type FlowsLoadedMsg struct {
+	SlashCommands []FlowSlashInfo
+}
+
+// FlowSlashInfo describes a workflow's slash command for TUI hint display.
+type FlowSlashInfo struct {
+	Slash       string
+	Description string
+}
+
 // --- Channel (WeChat etc.) messages ---
 
 // ChannelAction represents an action the user wants to perform on a channel.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -141,6 +141,8 @@ type Model struct {
 
 	// Skill slash commands from skill loader
 	skillSlashCommands []SkillSlashInfo
+	// Workflow slash commands from flow loader (e.g. /repo-audit)
+	flowSlashCommands []FlowSlashInfo
 
 	// Subagent progress tracking
 	subagentActive    bool

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -867,9 +867,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 					}
 
 					// Check skill slash commands (e.g. /review-pr, /security-review)
+					// then workflow slash commands (e.g. /repo-audit, /roundtable).
 					if strings.HasPrefix(prompt, "/") {
 						if skillCmd := m.matchSkillSlash(prompt); skillCmd != nil {
 							return m.handleSkillSlashInput(skillCmd.SkillName, skillCmd.UserInput, cmds)
+						}
+						if flowCmd := m.matchFlowSlash(prompt); flowCmd != nil {
+							return m.handleFlowSlashInput(flowCmd.FlowName, flowCmd.UserInput, cmds)
 						}
 					}
 
@@ -1339,6 +1343,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 
 	case SkillsLoadedMsg:
 		m.skillSlashCommands = msg.SlashCommands
+
+	case FlowsLoadedMsg:
+		m.flowSlashCommands = msg.SlashCommands
 
 	case SessionResumedMsg:
 		m.approvalMode = ModeManual

--- a/internal/web/engine.go
+++ b/internal/web/engine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cloudwego/eino/adk"
 
+	"github.com/cnjack/jcode/internal/flow"
 	"github.com/cnjack/jcode/internal/handler"
 	"github.com/cnjack/jcode/internal/model"
 	"github.com/cnjack/jcode/internal/runner"
@@ -87,6 +88,12 @@ type Engine struct {
 
 	// pumpCancel stops this engine's event-forwarding goroutine on teardown.
 	pumpCancel context.CancelFunc
+
+	// flowLoader resolves workflow slash commands (/api/slash-commands, slash
+	// rewrites) for THIS task's project, so a task in a different project sees its
+	// own .jcode/workflows. Shared with this task's workflow_run tool. nil ⇒ the
+	// server falls back to its boot loader.
+	flowLoader *flow.Loader
 }
 
 // EngineConfig carries the per-task pieces a factory (command.buildWebTask)
@@ -110,6 +117,7 @@ type EngineConfig struct {
 	BreakdownFn    func() usage.ContextBreakdown
 	CreateAgent    func(providerName, modelName string) (*adk.ChatModelAgent, error)
 	RebuildForMode func(planMode bool) (*adk.ChatModelAgent, error)
+	FlowLoader     *flow.Loader
 }
 
 // newEngine assembles an *Engine from the factory-produced config. The engine's
@@ -141,6 +149,7 @@ func newEngine(c *EngineConfig) *Engine {
 		breakdownFn:    c.BreakdownFn,
 		createAgent:    c.CreateAgent,
 		rebuildForMode: c.RebuildForMode,
+		flowLoader:     c.FlowLoader,
 	}
 }
 
@@ -152,6 +161,16 @@ func (s *Server) activeEngine() *Engine {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.Engine
+}
+
+// flowLoaderFor returns the task-scoped workflow loader for eng (so slash
+// commands resolve THIS task's project workflows), falling back to the server's
+// boot loader when the engine has none — e.g. before any task engine exists.
+func (s *Server) flowLoaderFor(eng *Engine) *flow.Loader {
+	if eng != nil && eng.flowLoader != nil {
+		return eng.flowLoader
+	}
+	return s.flowLoader
 }
 
 // --- emu-guarded accessors for an engine's MUTABLE run-state fields (agent,

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cnjack/jcode/internal/browser"
 	"github.com/cnjack/jcode/internal/channel"
 	"github.com/cnjack/jcode/internal/config"
+	"github.com/cnjack/jcode/internal/flow"
 	"github.com/cnjack/jcode/internal/handler"
 	"github.com/cnjack/jcode/internal/hooks"
 	"github.com/cnjack/jcode/internal/mode"
@@ -110,6 +111,9 @@ type Server struct {
 	// skillLoader provides skill listing for slash commands.
 	skillLoader *skills.Loader
 
+	// flowLoader provides workflow listing for slash commands (e.g. /repo-audit).
+	flowLoader *flow.Loader
+
 	// reloadMCP re-establishes MCP connections from the given server map and
 	// swaps in the fresh tool set (the agent is rebuilt by the caller). nil
 	// when MCP hot-reload is unavailable. Returns per-server statuses.
@@ -188,6 +192,7 @@ type ServerConfig struct {
 	Registry            *model.ModelRegistry
 	ApprovalState       *runner.ApprovalState
 	SkillLoader         *skills.Loader
+	FlowLoader          *flow.Loader
 	ReloadMCP           func(servers map[string]*config.MCPServer) ([]tools.MCPStatus, error) // optional: hot-reload MCP tools
 	InitialMCPStatuses  []tools.MCPStatus                                                     // statuses from the startup MCP load
 	WechatClient        channel.Channel                                                       // optional WeChat channel
@@ -256,6 +261,7 @@ func NewServer(cfg *ServerConfig) *Server {
 		registry:            cfg.Registry,
 		ptyMgr:              newPTYManager(),
 		skillLoader:         cfg.SkillLoader,
+		flowLoader:          cfg.FlowLoader,
 		reloadMCP:           cfg.ReloadMCP,
 		mcpStatuses:         make(map[string]tools.MCPStatus),
 		mcpLogins:           make(map[string]*mcpLoginState),
@@ -688,12 +694,13 @@ func (s *Server) submitMessage(eng *Engine, message, mode, source, sessionID str
 		cmd := strings.TrimPrefix(message, "/")
 		parts := strings.SplitN(cmd, " ", 2)
 		cmdName := parts[0]
+		userInput := ""
+		if len(parts) > 1 {
+			userInput = parts[1]
+		}
+		matchedSkill := false
 		if s.skillLoader != nil {
 			if sk := s.skillLoader.GetBySlash("/" + cmdName); sk != nil {
-				userInput := ""
-				if len(parts) > 1 {
-					userInput = parts[1]
-				}
 				var sb strings.Builder
 				fmt.Fprintf(&sb, "Use the load_skill tool with name=%q and follow its instructions.", sk.Name)
 				if userInput != "" {
@@ -701,6 +708,13 @@ func (s *Server) submitMessage(eng *Engine, message, mode, source, sessionID str
 					sb.WriteString(userInput)
 				}
 				agentMsg = sb.String()
+				matchedSkill = true
+			}
+		}
+		// Otherwise check workflow slash commands (e.g. /repo-audit).
+		if !matchedSkill && s.flowLoader != nil {
+			if wf, ok := s.flowLoader.GetBySlash("/" + cmdName); ok {
+				agentMsg = flow.SlashRunPrompt(wf.Meta.Name, userInput)
 			}
 		}
 	}
@@ -2857,7 +2871,7 @@ func (s *Server) handleSlashCommands(w http.ResponseWriter, r *http.Request) {
 	type slashItem struct {
 		Slash       string `json:"slash"`
 		Description string `json:"description"`
-		Type        string `json:"type"` // "skill"
+		Type        string `json:"type"` // "skill" | "flow"
 	}
 
 	var items []slashItem
@@ -2867,6 +2881,15 @@ func (s *Server) handleSlashCommands(w http.ResponseWriter, r *http.Request) {
 				Slash:       sk.Slash,
 				Description: sk.Description,
 				Type:        "skill",
+			})
+		}
+	}
+	if s.flowLoader != nil {
+		for _, fc := range s.flowLoader.SlashCommands() {
+			items = append(items, slashItem{
+				Slash:       fc.Slash,
+				Description: fc.Description,
+				Type:        "flow",
 			})
 		}
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -711,9 +711,10 @@ func (s *Server) submitMessage(eng *Engine, message, mode, source, sessionID str
 				matchedSkill = true
 			}
 		}
-		// Otherwise check workflow slash commands (e.g. /repo-audit).
-		if !matchedSkill && s.flowLoader != nil {
-			if wf, ok := s.flowLoader.GetBySlash("/" + cmdName); ok {
+		// Otherwise check workflow slash commands (e.g. /repo-audit) against this
+		// task's project loader so its .jcode/workflows resolve.
+		if fl := s.flowLoaderFor(eng); !matchedSkill && fl != nil {
+			if wf, ok := fl.GetBySlash("/" + cmdName); ok {
 				agentMsg = flow.SlashRunPrompt(wf.Meta.Name, userInput)
 			}
 		}
@@ -2884,8 +2885,10 @@ func (s *Server) handleSlashCommands(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 	}
-	if s.flowLoader != nil {
-		for _, fc := range s.flowLoader.SlashCommands() {
+	// Workflows resolve against the foreground task's project so its
+	// .jcode/workflows show up in autocomplete, falling back to the boot loader.
+	if fl := s.flowLoaderFor(s.activeEngine()); fl != nil {
+		for _, fc := range fl.SlashCommands() {
 			items = append(items, slashItem{
 				Slash:       fc.Slash,
 				Description: fc.Description,

--- a/internal/web/slash_commands_test.go
+++ b/internal/web/slash_commands_test.go
@@ -1,0 +1,73 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cnjack/jcode/internal/flow"
+)
+
+// TestHandleSlashCommands_IncludesFlows verifies the slash-command endpoint
+// advertises workflow slashes (marked type:"flow") alongside skills, so the web
+// autocomplete can surface and badge them.
+func TestHandleSlashCommands_IncludesFlows(t *testing.T) {
+	s := &Server{flowLoader: flow.NewLoader()} // builtins only
+
+	rec := httptest.NewRecorder()
+	s.handleSlashCommands(rec, httptest.NewRequest(http.MethodGet, "/api/slash-commands", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%q", rec.Code, rec.Body.String())
+	}
+
+	var items []struct {
+		Slash string `json:"slash"`
+		Type  string `json:"type"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+		t.Fatalf("response not JSON: %v", err)
+	}
+
+	// The three builtin workflows must appear, each tagged as a flow.
+	want := map[string]bool{"/repo-audit": false, "/pr-review": false, "/roundtable": false}
+	for _, it := range items {
+		if _, ok := want[it.Slash]; ok {
+			if it.Type != "flow" {
+				t.Errorf("%s advertised as type %q, want \"flow\"", it.Slash, it.Type)
+			}
+			want[it.Slash] = true
+		}
+	}
+	for slash, seen := range want {
+		if !seen {
+			t.Errorf("builtin workflow slash %s not advertised", slash)
+		}
+	}
+}
+
+// TestSlashRunPrompt shapes the agent instruction a "/<workflow>" slash expands
+// to: run by name via workflow_run, with trailing input handed over as args.
+func TestSlashRunPrompt(t *testing.T) {
+	p := flow.SlashRunPrompt("repo-audit", "internal/auth")
+	if !contains(p, "workflow_run") || !contains(p, "repo-audit") {
+		t.Errorf("prompt missing tool/name: %q", p)
+	}
+	if !contains(p, "internal/auth") {
+		t.Errorf("prompt dropped user args: %q", p)
+	}
+
+	bare := flow.SlashRunPrompt("roundtable", "")
+	if contains(bare, "args` from this input") {
+		t.Errorf("empty input should not add an args line: %q", bare)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/web/slash_commands_test.go
+++ b/internal/web/slash_commands_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/cnjack/jcode/internal/flow"
@@ -43,6 +45,56 @@ func TestHandleSlashCommands_IncludesFlows(t *testing.T) {
 		if !seen {
 			t.Errorf("builtin workflow slash %s not advertised", slash)
 		}
+	}
+}
+
+// TestHandleSlashCommands_TaskScoped verifies the endpoint resolves workflows
+// from the FOREGROUND task's project loader, so a task in another project sees
+// its own .jcode/workflows even though the server's boot loader does not.
+func TestHandleSlashCommands_TaskScoped(t *testing.T) {
+	// A project dir with one project-only workflow.
+	proj := t.TempDir()
+	wfDir := filepath.Join(proj, ".jcode", "workflows")
+	if err := os.MkdirAll(wfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := `export const meta = { name: "task-only-wf", description: "scoped" };
+return "ok";`
+	if err := os.WriteFile(filepath.Join(wfDir, "task-only-wf.js"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	taskLoader := flow.NewLoader()
+	taskLoader.LoadProject(proj)
+
+	// Boot loader (builtins only) must NOT know the project workflow; the active
+	// engine's loader must.
+	s := &Server{
+		flowLoader: flow.NewLoader(),
+		Engine:     &Engine{flowLoader: taskLoader},
+	}
+
+	rec := httptest.NewRecorder()
+	s.handleSlashCommands(rec, httptest.NewRequest(http.MethodGet, "/api/slash-commands", nil))
+
+	var items []struct {
+		Slash string `json:"slash"`
+		Type  string `json:"type"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+		t.Fatalf("response not JSON: %v", err)
+	}
+	found := false
+	for _, it := range items {
+		if it.Slash == "/task-only-wf" {
+			found = true
+			if it.Type != "flow" {
+				t.Errorf("task workflow type=%q, want \"flow\"", it.Type)
+			}
+		}
+	}
+	if !found {
+		t.Error("foreground task's project workflow /task-only-wf not advertised")
 	}
 }
 

--- a/site/docs/overview/workflows.md
+++ b/site/docs/overview/workflows.md
@@ -136,10 +136,20 @@ jcode flow run ./my-workflow.js              # run a script by path
 
 Progress streams to stderr; the final result prints to stdout.
 
-**From a chat (TUI / Web / ACP):** just ask — "audit the auth module with a
-workflow". The agent uses the `workflow_run` tool to either run a saved workflow
-by name or write an inline script for the task and run it. Intermediate agent work
-stays out of the conversation; only the result comes back.
+**From a chat (TUI / Web / ACP):** every saved workflow gets a `/<name>` slash
+command (e.g. `/repo-audit`, `/roundtable`), marked with a **workflow** badge in
+the command menu so it's distinct from skills. Type the slash — anything after it
+becomes the workflow's `args` — and jcode runs the saved workflow by name:
+
+```
+/repo-audit internal/auth
+/roundtable Should we adopt gRPC internally?
+```
+
+Or just ask in plain language — "audit the auth module with a workflow". Either
+way the agent uses the `workflow_run` tool to run a saved workflow by name (or
+write an inline script for the task and run it). Intermediate agent work stays out
+of the conversation; only the result comes back.
 
 ## Built-in workflows
 

--- a/site/docs/overview/workflows.md
+++ b/site/docs/overview/workflows.md
@@ -141,7 +141,7 @@ command (e.g. `/repo-audit`, `/roundtable`), marked with a **workflow** badge in
 the command menu so it's distinct from skills. Type the slash — anything after it
 becomes the workflow's `args` — and jcode runs the saved workflow by name:
 
-```
+```text
 /repo-audit internal/auth
 /roundtable Should we adopt gRPC internally?
 ```

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -507,6 +507,7 @@ watch(() => store.imageSupport, (supported) => {
             @mouseenter="selectedSlashIdx = i"
           >
             <span class="slash-cmd">{{ cmd.slash }}</span>
+            <span v-if="cmd.type === 'flow'" class="slash-badge slash-badge-flow">workflow</span>
             <span class="slash-desc">{{ cmd.description }}</span>
           </button>
         </div>
@@ -2177,6 +2178,22 @@ watch(() => store.imageSupport, (supported) => {
   font-family: var(--font-mono);
   color: var(--color-accent-neutral);
   flex-shrink: 0;
+}
+
+.slash-badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.slash-badge-flow {
+  color: var(--color-accent);
+  background: var(--color-accent-wash);
+  border: 1px solid var(--color-accent-wash);
 }
 
 .slash-desc {

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -2192,8 +2192,8 @@ watch(() => store.imageSupport, (supported) => {
 
 .slash-badge-flow {
   color: var(--color-accent);
-  background: var(--color-accent-wash);
-  border: 1px solid var(--color-accent-wash);
+  background: var(--accent-wash);
+  border: 1px solid var(--accent-wash);
 }
 
 .slash-desc {

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -310,7 +310,7 @@ export interface SkillInfo {
 export interface SlashCommandInfo {
   slash: string
   description: string
-  type: 'builtin' | 'skill'
+  type: 'builtin' | 'skill' | 'flow'
 }
 
 // WebSocket event data types


### PR DESCRIPTION
## What

Every saved workflow now surfaces as a `/<name>` slash command on **all three frontends** (TUI, Web, ACP), badged as a **workflow** so it reads as distinct from a skill. Typing the slash runs the saved workflow *by name* via the `workflow_run` tool — no inline script — and any text after the slash is handed to the agent to shape into the workflow's `args`.

```
/repo-audit internal/auth
/roundtable Should we adopt gRPC internally?
```

## Why

Previously the only way to run a workflow from a chat was to ask in plain language and hope the agent picked `workflow_run` with the right name. Slash commands make saved workflows first-class and discoverable in the command menu, in lockstep across frontends.

## How

- **`internal/flow/slash.go`** — shared `SlashRunPrompt` + `GetBySlash` so every frontend expands a workflow slash identically (single source of wording).
- **`internal/web`** — `/api/slash-commands` advertises workflow slashes (type `"flow"`) alongside skills; the web autocomplete surfaces and badges them. Covered by `slash_commands_test.go`.
- **TUI + ACP** — workflow slashes join the command menu / `availableCommandList` (the `acp_goal_test` signature bump rides along because `availableCommandList` now takes the flow loader).
- **docs** — `workflows.md` documents the slash entry point.
- **`.gitignore`** — ignore the local `.jcode` workflow store.

## Test

- `go build ./internal/flow/... ./internal/command/... ./internal/tui/... ./internal/web/...` — OK
- `go test ./internal/flow/... ./internal/web/` — OK (incl. `TestHandleSlashCommands_IncludesFlows`)

Generated with Jack AI bot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for workflow slash commands across chat, TUI, web, and ACP surfaces.
  * Workflow commands now appear in autocomplete with a distinct “workflow” label and can be run with `/<name>`.

* **Bug Fixes**
  * Slash-command handling now recognizes workflow commands when no skill command matches, improving command routing and execution.
  * Workflow-related commands are now loaded and shown consistently during session start-up and in interactive views.

* **Documentation**
  * Updated workflow docs with examples for running saved workflows by name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->