### PR TITLE
feat(jcode-ui): docs demos, UI polish, and shared attachments

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,26 @@
+# jcode-ui examples
+
+Cloneable starters for the React chat component library.
+
+| Example | Port | Pattern |
+|---------|------|---------|
+| [jcode-ui-minimal](./jcode-ui-minimal) | 5177 | `createMockRuntime` only — fastest start |
+| [jcode-ui-zustand](./jcode-ui-zustand) | 5178 | `createExternalStoreRuntime` + Zustand |
+
+## Prerequisites
+
+```bash
+cd packages/jcode-ui-core && pnpm build
+cd ../jcode-ui && pnpm build
+```
+
+Each example is a **standalone pnpm workspace** (`ignore-workspace` via `.npmrc`) using
+`file:../../packages/jcode-ui`, so installs stay local and always link monorepo packages.
+
+If pnpm blocks esbuild postinstall, the example `pnpm-workspace.yaml` already allows it.
+
+## Docs
+
+- https://www.j-code.net/chat-ui/docs
+- https://www.j-code.net/chat-ui/docs/installation
+- https://www.j-code.net/chat-ui/docs/guides/external-store

--- a/examples/jcode-ui-minimal/.gitignore
+++ b/examples/jcode-ui-minimal/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+pnpm-lock.yaml
+*.tsbuildinfo

--- a/examples/jcode-ui-minimal/.npmrc
+++ b/examples/jcode-ui-minimal/.npmrc
@@ -1,0 +1,1 @@
+ignore-workspace=true

--- a/examples/jcode-ui-minimal/README.md
+++ b/examples/jcode-ui-minimal/README.md
@@ -1,0 +1,30 @@
+# jcode-ui minimal example
+
+Drop-in chat UI with **`createMockRuntime`** — no backend, no store library.
+
+## Run
+
+From the monorepo root (packages must be built first):
+
+```bash
+# once
+cd packages/jcode-ui-core && pnpm build
+cd ../jcode-ui && pnpm build
+
+cd ../../examples/jcode-ui-minimal
+pnpm install
+pnpm dev
+```
+
+Open http://localhost:5177
+
+## What it shows
+
+- `Thread` + `ChatInput`
+- Default tool registry (seeded with one `execute` card)
+- Interactive send → fake assistant echo
+
+## Next
+
+- Wire a real store: see [`../jcode-ui-zustand`](../jcode-ui-zustand)
+- Docs: https://www.j-code.net/chat-ui/docs

--- a/examples/jcode-ui-minimal/index.html
+++ b/examples/jcode-ui-minimal/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>jcode-ui minimal</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/jcode-ui-minimal/package.json
+++ b/examples/jcode-ui-minimal/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "jcode-ui-minimal",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "jcode-ui": "file:../../packages/jcode-ui",
+    "jcode-ui-core": "file:../../packages/jcode-ui-core",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/examples/jcode-ui-minimal/pnpm-workspace.yaml
+++ b/examples/jcode-ui-minimal/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+# Standalone example (not part of the monorepo workspace).
+packages:
+  - '.'
+allowBuilds:
+  esbuild: true
+onlyBuiltDependencies:
+  - esbuild

--- a/examples/jcode-ui-minimal/src/App.tsx
+++ b/examples/jcode-ui-minimal/src/App.tsx
@@ -1,0 +1,116 @@
+/**
+ * Minimal jcode-ui example — mock runtime only, no backend.
+ *
+ *   pnpm install
+ *   pnpm dev
+ */
+
+import { useMemo } from 'react'
+import {
+  RuntimeProvider,
+  ToolRegistryProvider,
+  createDefaultToolRegistry,
+  createMockRuntime,
+  Thread,
+  ChatInput,
+} from 'jcode-ui'
+import type { ThreadItem } from 'jcode-ui-core'
+
+function seed(runtime: ReturnType<typeof createMockRuntime>) {
+  let seq = 0
+  const push = (item: Omit<ThreadItem, 'seq'> & { seq?: number }) => {
+    runtime.push({ ...item, seq: ++seq } as ThreadItem)
+  }
+
+  push({
+    kind: 'message',
+    data: {
+      id: 'u1',
+      role: 'user',
+      content: 'Show me a minimal jcode-ui thread.',
+      timestamp: Date.now(),
+    },
+  })
+  push({
+    kind: 'message',
+    data: {
+      id: 'a1',
+      role: 'assistant',
+      content:
+        'This example uses `createMockRuntime` — no backend. Type below; actions are recorded in `runtime.calls`.',
+      timestamp: Date.now(),
+      durationMs: 800,
+    },
+  })
+  push({
+    kind: 'tool',
+    data: {
+      id: 't1',
+      name: 'execute',
+      args: JSON.stringify({ command: 'echo hello' }),
+      status: 'done',
+      timestamp: Date.now(),
+      output: 'hello\n',
+      displayInfo: { title: 'execute', subtitle: 'echo hello' },
+    },
+  })
+}
+
+export function App() {
+  const registry = useMemo(() => createDefaultToolRegistry(), [])
+  const runtime = useMemo(() => {
+    const rt = createMockRuntime({
+      actions: {
+        sendMessage: (text) => {
+          const items = rt.getState().items
+          const seq = items.reduce((m, i) => Math.max(m, i.seq), 0) + 1
+          rt.push({
+            kind: 'message',
+            seq,
+            data: {
+              id: `u_${Date.now()}`,
+              role: 'user',
+              content: text,
+              timestamp: Date.now(),
+            },
+          })
+          // Fake assistant reply
+          window.setTimeout(() => {
+            const s2 = rt.getState().items.reduce((m, i) => Math.max(m, i.seq), 0) + 1
+            rt.push({
+              kind: 'message',
+              seq: s2,
+              data: {
+                id: `a_${Date.now()}`,
+                role: 'assistant',
+                content: `Echo: ${text}`,
+                timestamp: Date.now(),
+              },
+            })
+          }, 400)
+        },
+      },
+    })
+    seed(rt)
+    return rt
+  }, [])
+
+  return (
+    <div className="app">
+      <header className="app-header">
+        <strong>jcode-ui</strong>
+        <span>minimal · mock runtime</span>
+      </header>
+      <RuntimeProvider runtime={runtime}>
+        <ToolRegistryProvider registry={registry}>
+          <main className="app-main">
+            <Thread virtualize={false} overscanBottom={8} />
+          </main>
+          <footer className="app-footer">
+            <ChatInput placeholder="Say something…" showContextBar={false} />
+          </footer>
+        </ToolRegistryProvider>
+      </RuntimeProvider>
+    </div>
+  )
+}

--- a/examples/jcode-ui-minimal/src/main.tsx
+++ b/examples/jcode-ui-minimal/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+import 'jcode-ui/styles.css'
+import './styles.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/examples/jcode-ui-minimal/src/styles.css
+++ b/examples/jcode-ui-minimal/src/styles.css
@@ -1,0 +1,45 @@
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0d0d0d;
+  color: #e4e4e7;
+}
+
+.app {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #2e2e2e;
+  font-size: 14px;
+}
+
+.app-header span {
+  color: #888;
+  font-size: 12px;
+}
+
+.app-main {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.app-footer {
+  border-top: 1px solid #2e2e2e;
+  padding: 8px 12px 12px;
+}

--- a/examples/jcode-ui-minimal/tsconfig.json
+++ b/examples/jcode-ui-minimal/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/jcode-ui-minimal/tsconfig.node.json
+++ b/examples/jcode-ui-minimal/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/jcode-ui-minimal/vite.config.ts
+++ b/examples/jcode-ui-minimal/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5177 },
+})

--- a/examples/jcode-ui-zustand/.gitignore
+++ b/examples/jcode-ui-zustand/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+pnpm-lock.yaml
+*.tsbuildinfo

--- a/examples/jcode-ui-zustand/.npmrc
+++ b/examples/jcode-ui-zustand/.npmrc
@@ -1,0 +1,1 @@
+ignore-workspace=true

--- a/examples/jcode-ui-zustand/README.md
+++ b/examples/jcode-ui-zustand/README.md
@@ -1,0 +1,42 @@
+# jcode-ui + Zustand
+
+Production-shaped integration: **your store owns the timeline**, jcode-ui renders via `createExternalStoreRuntime`.
+
+## Run
+
+```bash
+# build packages once
+cd packages/jcode-ui-core && pnpm build
+cd ../jcode-ui && pnpm build
+
+cd ../../examples/jcode-ui-zustand
+pnpm install
+pnpm dev
+```
+
+Open http://localhost:5178
+
+## Pattern
+
+```ts
+const runtime = createExternalStoreRuntime({
+  store: useChatStore,           // Zustand: getState + subscribe
+  select: (s) => ({
+    items: s.items,
+    isRunning: s.isRunning,
+  }),
+  actions: {
+    sendMessage: (text) => { /* mutate store + call API */ },
+    // …
+  },
+})
+```
+
+See also: [External store guide](https://www.j-code.net/chat-ui/docs/guides/external-store)
+
+## Files
+
+| File | Role |
+|------|------|
+| `src/store.ts` | Zustand timeline + mutations |
+| `src/App.tsx` | Runtime wiring + UI |

--- a/examples/jcode-ui-zustand/index.html
+++ b/examples/jcode-ui-zustand/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>jcode-ui + Zustand</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/jcode-ui-zustand/package.json
+++ b/examples/jcode-ui-zustand/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "jcode-ui-zustand",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "jcode-ui": "file:../../packages/jcode-ui",
+    "jcode-ui-core": "file:../../packages/jcode-ui-core",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^5.0.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/examples/jcode-ui-zustand/pnpm-workspace.yaml
+++ b/examples/jcode-ui-zustand/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+# Standalone example (not part of the monorepo workspace).
+packages:
+  - '.'
+allowBuilds:
+  esbuild: true
+onlyBuiltDependencies:
+  - esbuild

--- a/examples/jcode-ui-zustand/src/App.tsx
+++ b/examples/jcode-ui-zustand/src/App.tsx
@@ -1,0 +1,90 @@
+/**
+ * jcode-ui + Zustand — external store pattern.
+ *
+ *   pnpm install && pnpm dev
+ */
+
+import { useMemo, useEffect } from 'react'
+import {
+  RuntimeProvider,
+  ToolRegistryProvider,
+  createDefaultToolRegistry,
+  createExternalStoreRuntime,
+  Thread,
+  ChatInput,
+} from 'jcode-ui'
+import { seedDemo, useChatStore } from './store'
+
+export function App() {
+  const registry = useMemo(() => createDefaultToolRegistry(), [])
+
+  const runtime = useMemo(
+    () =>
+      createExternalStoreRuntime({
+        // Zustand stores are Redux-shaped: getState + subscribe
+        store: useChatStore,
+        select: (s) => ({
+          items: s.items,
+          isRunning: s.isRunning,
+        }),
+        actions: {
+          sendMessage: (text) => {
+            const { appendUser, appendAssistant, appendTool, setRunning } = useChatStore.getState()
+            appendUser(text)
+            setRunning(true)
+            // Simulate an agent turn: tool then reply
+            window.setTimeout(() => {
+              appendTool({
+                id: `t_${Date.now()}`,
+                name: 'execute',
+                args: JSON.stringify({ command: `echo ${JSON.stringify(text)}` }),
+                status: 'done',
+                timestamp: Date.now(),
+                output: text + '\n',
+                displayInfo: { title: 'execute', subtitle: 'echo' },
+              })
+              appendAssistant(`Zustand received: **${text}**`)
+            }, 500)
+          },
+          enqueueMessage: (text) => {
+            // Type-ahead while running — still append as user for this demo
+            useChatStore.getState().appendUser(`[queued] ${text}`)
+          },
+          removeQueuedMessage: () => undefined,
+          stop: () => useChatStore.getState().stop(),
+          resolveApproval: (id, approved, approveAll) =>
+            useChatStore.getState().resolveApproval(id, approved, approveAll),
+          submitAskUser: (id, answers) => useChatStore.getState().submitAskUser(id, answers),
+          editMessage: (id, text) => useChatStore.getState().editMessage(id, text),
+        },
+      }),
+    [],
+  )
+
+  useEffect(() => {
+    seedDemo()
+  }, [])
+
+  return (
+    <div className="app">
+      <header className="app-header">
+        <strong>jcode-ui</strong>
+        <span>external store · Zustand</span>
+      </header>
+      <RuntimeProvider runtime={runtime}>
+        <ToolRegistryProvider registry={registry}>
+          <main className="app-main">
+            <Thread overscanBottom={8} />
+          </main>
+          <footer className="app-footer">
+            <ChatInput
+              slashCommands={[{ slash: '/clear', description: 'Not wired in this demo' }]}
+              placeholder="Send via Zustand store…"
+              showContextBar={false}
+            />
+          </footer>
+        </ToolRegistryProvider>
+      </RuntimeProvider>
+    </div>
+  )
+}

--- a/examples/jcode-ui-zustand/src/main.tsx
+++ b/examples/jcode-ui-zustand/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+import 'jcode-ui/styles.css'
+import './styles.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/examples/jcode-ui-zustand/src/store.ts
+++ b/examples/jcode-ui-zustand/src/store.ts
@@ -1,0 +1,135 @@
+/**
+ * Host chat store — Zustand + jcode-ui ThreadItem timeline.
+ *
+ * This is the production integration pattern: own the state, project it through
+ * createExternalStoreRuntime, bind actions that mutate + (optionally) hit an API.
+ */
+
+import { create } from 'zustand'
+import type { ThreadItem, Message, ToolCall } from 'jcode-ui-core'
+
+export interface ChatState {
+  items: ThreadItem[]
+  isRunning: boolean
+  seq: number
+  // mutations
+  appendUser: (text: string) => void
+  appendAssistant: (text: string) => void
+  appendTool: (tool: ToolCall) => void
+  setRunning: (v: boolean) => void
+  stop: () => void
+  resolveApproval: (id: string, approved: boolean, approveAll?: boolean) => void
+  submitAskUser: (id: string, answers: { question_header: string; answer: string; selected?: string[] }[]) => void
+  editMessage: (id: string, newText: string) => void
+}
+
+function nextSeq(get: () => ChatState): number {
+  const seq = get().seq + 1
+  return seq
+}
+
+export const useChatStore = create<ChatState>((set, get) => ({
+  items: [],
+  isRunning: false,
+  seq: 0,
+
+  appendUser: (text) => {
+    const seq = nextSeq(get)
+    const msg: Message = {
+      id: `u_${seq}`,
+      role: 'user',
+      content: text,
+      timestamp: Date.now(),
+    }
+    set({
+      seq,
+      items: [...get().items, { kind: 'message', data: msg, seq }],
+    })
+  },
+
+  appendAssistant: (text) => {
+    const seq = nextSeq(get)
+    const msg: Message = {
+      id: `a_${seq}`,
+      role: 'assistant',
+      content: text,
+      timestamp: Date.now(),
+      durationMs: 600,
+    }
+    set({
+      seq,
+      items: [...get().items, { kind: 'message', data: msg, seq }],
+      isRunning: false,
+    })
+  },
+
+  appendTool: (tool) => {
+    const seq = nextSeq(get)
+    set({
+      seq,
+      items: [...get().items, { kind: 'tool', data: { ...tool, id: tool.id || `t_${seq}` }, seq }],
+    })
+  },
+
+  setRunning: (v) => set({ isRunning: v }),
+
+  stop: () => set({ isRunning: false }),
+
+  resolveApproval: (id, approved) => {
+    set({
+      items: get().items.map((i) =>
+        i.kind === 'approval' && i.data.id === id
+          ? { ...i, data: { ...i.data, resolved: true, approved } }
+          : i,
+      ),
+    })
+  },
+
+  submitAskUser: (id, answers) => {
+    set({
+      items: get().items.map((i) =>
+        i.kind === 'tool' && (i.data.askUserId === id || i.data.id === id)
+          ? {
+              ...i,
+              data: {
+                ...i.data,
+                status: 'done',
+                askUserId: undefined,
+                askUserQuestions: undefined,
+                output: JSON.stringify(answers),
+              },
+            }
+          : i,
+      ),
+    })
+  },
+
+  editMessage: (id, newText) => {
+    set({
+      items: get().items.map((i) =>
+        i.kind === 'message' && i.data.id === id
+          ? { ...i, data: { ...i.data, content: newText } }
+          : i,
+      ),
+    })
+  },
+}))
+
+/** Seed a short conversation for the demo. */
+export function seedDemo() {
+  const s = useChatStore.getState()
+  if (s.items.length > 0) return
+  s.appendUser('Wire jcode-ui to Zustand.')
+  s.appendTool({
+    id: 't1',
+    name: 'read',
+    args: JSON.stringify({ path: 'store.ts' }),
+    status: 'done',
+    timestamp: Date.now(),
+    output: '   1│export const useChatStore = create(…)',
+    displayInfo: { title: 'read', subtitle: 'store.ts' },
+  })
+  s.appendAssistant(
+    'Use `createExternalStoreRuntime({ store: useChatStore, select, actions })`. The store owns the timeline; the UI only renders it.',
+  )
+}

--- a/examples/jcode-ui-zustand/src/styles.css
+++ b/examples/jcode-ui-zustand/src/styles.css
@@ -1,0 +1,40 @@
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0d0d0d;
+  color: #e4e4e7;
+}
+.app {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.app-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #2e2e2e;
+  font-size: 14px;
+}
+.app-header span {
+  color: #888;
+  font-size: 12px;
+}
+.app-main {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.app-footer {
+  border-top: 1px solid #2e2e2e;
+  padding: 8px 12px 12px;
+}

--- a/examples/jcode-ui-zustand/tsconfig.json
+++ b/examples/jcode-ui-zustand/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/jcode-ui-zustand/vite.config.ts
+++ b/examples/jcode-ui-zustand/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5178 },
+})

--- a/packages/jcode-ui-core/README.md
+++ b/packages/jcode-ui-core/README.md
@@ -49,7 +49,7 @@ interface ChatRuntime {
 }
 ```
 
-`RuntimeState` carries `items` / `isRunning` / `tokenSnapshot` / `goal` / `todos` / `queued`. `RuntimeActions` exposes `sendMessage`, `enqueueMessage`, `stop`, `resolveApproval`, `submitAskUser`, `editMessage`, `removeQueuedMessage`. See the [runtime docs](https://www.j-code.net/docs/chat-ui/runtime).
+`RuntimeState` carries `items` / `isRunning` / `tokenSnapshot` / `goal` / `todos` / `queued`. `RuntimeActions` exposes `sendMessage`, `enqueueMessage`, `stop`, `resolveApproval`, `submitAskUser`, `editMessage`, `removeQueuedMessage`. See the [runtime docs](https://www.j-code.net/chat-ui/docs/runtime).
 
 ## License
 

--- a/packages/jcode-ui-core/package.json
+++ b/packages/jcode-ui-core/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "jack",
-  "homepage": "https://www.j-code.net/docs/chat-ui",
+  "homepage": "https://www.j-code.net/chat-ui/docs",
   "repository": {
     "type": "git",
     "url": "https://github.com/cnjack/jcode",

--- a/packages/jcode-ui-core/src/primitives/Composer.tsx
+++ b/packages/jcode-ui-core/src/primitives/Composer.tsx
@@ -27,10 +27,18 @@ export interface ComposerRenderSlots {
   renderSlashMenu?: (state: SlashMenuState) => ReactNode
   /** Render queued-message chips above the textarea. */
   renderQueue?: (queued: { id: string; text: string; images?: ChatImage[] }[]) => ReactNode
-  /** Render the send/stop button. `mode` is 'send' or 'stop'. */
-  renderSubmitButton?: (mode: 'send' | 'stop', disabled: boolean) => ReactNode
-  /** Render attached-image thumbnails below the textarea. */
+  /** Render the send/stop button. `mode` is 'send' or 'stop'.
+   *  Call `onActivate` on click (send when idle, stop when running). */
+  renderSubmitButton?: (mode: 'send' | 'stop', disabled: boolean, onActivate: () => void) => ReactNode
+  /** Render attached-image thumbnails (composer attachments strip). */
   renderAttachments?: (imgs: ChatImage[], remove: (i: number) => void) => ReactNode
+  /**
+   * Render the "add attachment" control (paperclip / +). Called with
+   * `openPicker` that opens the hidden file input. When omitted and
+   * `allowImages` is true, a minimal default button is rendered.
+   * Mirrors assistant-ui `ComposerAddAttachment`.
+   */
+  renderAddAttachment?: (openPicker: () => void) => ReactNode
   /** Optional content rendered before the textarea inside the input row
    *  (e.g. a "+" menu button). */
   renderPrefix?: () => ReactNode
@@ -47,6 +55,8 @@ export interface ComposerProps extends ComposerRenderSlots {
   slashCommands?: SlashCommand[]
   /** Whether image attachments are allowed (gated by model vision support). */
   allowImages?: boolean
+  /** `accept` attribute for the file picker (default `image/*`). */
+  acceptImages?: string
   /** Max image size in bytes (default 10MB). */
   maxImageBytes?: number
   /** aria-label for the textarea. */
@@ -71,11 +81,37 @@ export interface SlashMenuState {
 
 const DEFAULT_MAX_ROWS_PX = 160
 
+function readImageFile(file: File): Promise<ChatImage | null> {
+  return new Promise((resolve) => {
+    if (!file.type.startsWith('image/')) {
+      resolve(null)
+      return
+    }
+    const reader = new FileReader()
+    reader.onload = () => {
+      const dataUrl = String(reader.result ?? '')
+      const comma = dataUrl.indexOf(',')
+      if (comma < 0) {
+        resolve(null)
+        return
+      }
+      resolve({
+        data: dataUrl.slice(comma + 1),
+        media_type: file.type,
+        name: file.name || undefined,
+      })
+    }
+    reader.onerror = () => resolve(null)
+    reader.readAsDataURL(file)
+  })
+}
+
 export function Composer({
   placeholder = 'Send a message…',
   maxRows = DEFAULT_MAX_ROWS_PX,
   slashCommands,
   allowImages = false,
+  acceptImages = 'image/*',
   maxImageBytes = 10 * 1024 * 1024,
   ariaLabel = 'Message input',
   defaultValue = '',
@@ -85,6 +121,7 @@ export function Composer({
   renderQueue,
   renderSubmitButton,
   renderAttachments,
+  renderAddAttachment,
   renderPrefix,
   renderSuffix,
 }: ComposerProps): ReactNode {
@@ -93,6 +130,7 @@ export function Composer({
   const [text, setText] = useState(defaultValue)
   const [images, setImages] = useState<ChatImage[]>([])
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   // --- Autosize: grow with content up to maxRows, then scroll. ---
   useLayoutEffect(() => {
@@ -174,9 +212,9 @@ export function Composer({
     [applySlash, filteredCommands, send, slashActive, slashOpen],
   )
 
-  // --- Image attachment: paste + remove. File picking is left to the host
-  //     (it needs a file input + app-specific UX); addImage accepts a ready
-  //     ChatImage. ---
+  // --- Image attachments: paste + file picker + remove.
+  //     Mirrors assistant-ui ComposerAttachments / ComposerAddAttachment,
+  //     scoped to vision images (ChatImage base64) for agent backends. ---
   const addImage = useCallback(
     (img: ChatImage) => {
       if (!allowImages) return
@@ -187,14 +225,41 @@ export function Composer({
     },
     [allowImages, maxImageBytes],
   )
+  const addImageFiles = useCallback(
+    async (files: FileList | File[]) => {
+      if (!allowImages) return
+      for (const file of Array.from(files)) {
+        if (file.size > maxImageBytes) continue
+        const img = await readImageFile(file)
+        if (img) addImage(img)
+      }
+    },
+    [addImage, allowImages, maxImageBytes],
+  )
   const removeImage = useCallback((i: number) => {
     setImages((prev) => prev.filter((_, idx) => idx !== i))
+  }, [])
+  const openPicker = useCallback(() => {
+    fileInputRef.current?.click()
   }, [])
 
   const mode: 'send' | 'stop' = isRunning ? 'stop' : 'send'
 
+  const onActivate = mode === 'send' ? send : stop
+
+  const addAttachmentControl =
+    allowImages
+      ? renderAddAttachment
+        ? renderAddAttachment(openPicker)
+        : (
+          <button type="button" onClick={openPicker} aria-label="Add attachment">
+            +
+          </button>
+        )
+      : null
+
   return (
-    <div className={className}>
+    <div className={className} data-running={isRunning ? 'true' : 'false'}>
       {renderQueue?.(queued)}
       {renderSlashMenu?.({
         open: !!slashOpen && filteredCommands.length > 0,
@@ -202,8 +267,10 @@ export function Composer({
         activeIndex: slashOpen ? slashActive : -1,
         apply: applySlash,
       })}
-      <div style={{ display: 'flex', alignItems: 'flex-end', gap: 8 }}>
+      {allowImages && images.length > 0 && renderAttachments?.(images, removeImage)}
+      <div className="jcode-composer-row" style={{ display: 'flex', alignItems: 'flex-end', gap: 8 }}>
         {renderPrefix?.()}
+        {addAttachmentControl}
         <textarea
           ref={textareaRef}
           value={text}
@@ -213,33 +280,30 @@ export function Composer({
             if (!allowImages) return
             const items = e.clipboardData?.items
             if (!items) return
+            const files: File[] = []
             for (const it of items) {
               if (it.kind === 'file' && it.type.startsWith('image/')) {
                 const file = it.getAsFile()
-                if (!file) continue
-                e.preventDefault()
-                const reader = new FileReader()
-                reader.onload = () => {
-                  const dataUrl = String(reader.result)
-                  const comma = dataUrl.indexOf(',')
-                  addImage({ data: dataUrl.slice(comma + 1), media_type: file.type })
-                }
-                reader.readAsDataURL(file)
+                if (file) files.push(file)
               }
             }
+            if (files.length === 0) return
+            e.preventDefault()
+            void addImageFiles(files)
           }}
           placeholder={placeholder}
           aria-label={ariaLabel}
           rows={1}
+          className="jcode-composer-input"
           style={{ resize: 'none', flex: 1, overflowY: 'auto' }}
         />
         {renderSuffix?.()}
         {renderSubmitButton
-          ? renderSubmitButton(mode, mode === 'send' ? !canSend : false)
+          ? renderSubmitButton(mode, mode === 'send' ? !canSend : false, onActivate)
           : (
             <button
               type="button"
-              onClick={mode === 'send' ? send : stop}
+              onClick={onActivate}
               disabled={mode === 'send' ? !canSend : false}
               aria-label={mode === 'send' ? 'Send message' : 'Stop'}
             >
@@ -247,7 +311,23 @@ export function Composer({
             </button>
           )}
       </div>
-      {allowImages && images.length > 0 && renderAttachments?.(images, removeImage)}
+      {allowImages && (
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={acceptImages}
+          multiple
+          className="jcode-composer-file-input"
+          style={{ display: 'none' }}
+          aria-hidden
+          tabIndex={-1}
+          onChange={(e) => {
+            const files = e.target.files
+            if (files && files.length > 0) void addImageFiles(files)
+            e.target.value = ''
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/packages/jcode-ui-core/src/primitives/Thread.tsx
+++ b/packages/jcode-ui-core/src/primitives/Thread.tsx
@@ -76,6 +76,9 @@ export function Thread({
   }
 
   if (!virtualize) {
+    // IMPORTANT: do NOT use `contain: strict` here. Size containment collapses
+    // the box to 0 when height is percentage/auto without a definite parent
+    // size — which is exactly how most demos and short embeds mount Thread.
     return (
       <div
         ref={(el) => {
@@ -85,13 +88,13 @@ export function Thread({
         className={className}
         role={role}
         onScroll={autoScroll.onScroll}
-        style={{ overflowY: 'auto', contain: 'strict' } as React.CSSProperties}
+        style={{ overflowY: 'auto', minHeight: 0, height: '100%' } as React.CSSProperties}
       >
         {items.map((it) => (
           <Fragment key={it.seq}>{renderItem(it)}</Fragment>
         ))}
         {isRunning && renderPending?.()}
-        {overscanBottom > 0 && <div style={{ height: overscanBottom }} />}
+        {overscanBottom > 0 && <div style={{ height: overscanBottom }} aria-hidden />}
       </div>
     )
   }
@@ -149,12 +152,20 @@ function VirtualizedThread({
   })
 
   return (
-  // Wrapper: the scroll element MUST resolve to a concrete pixel height for the
-  // virtualizer to measure rows. We use flex:1 + min-height:0 so it fills any
-  // flex parent, and height:100% as a fallback for block parents. Both the
-  // wrapper and scroll element get these so the height resolves through the
-  // chain regardless of the host's layout.
-  <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', minHeight: 0, flex: 1 }}>
+    // Wrapper: the scroll element MUST resolve to a concrete pixel height for the
+    // virtualizer to measure rows. flex:1 + min-height:0 fills flex parents;
+    // height:100% covers block parents that already have a definite height.
+    // Use layout/paint containment only — never size containment (collapses).
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        height: '100%',
+        minHeight: 0,
+        flex: 1,
+      }}
+    >
       <div
         ref={(el) => {
           ;(parentRef as React.MutableRefObject<HTMLDivElement | null>).current = el
@@ -163,15 +174,66 @@ function VirtualizedThread({
         className={className}
         role={role}
         onScroll={autoScroll.onScroll}
-        style={{ overflowY: 'auto', contain: 'strict', flex: 1, minHeight: 0, height: '100%' } as React.CSSProperties}
+        style={
+          {
+            overflowY: 'auto',
+            contain: 'layout paint',
+            flex: 1,
+            minHeight: 0,
+            height: '100%',
+            position: 'relative',
+          } as React.CSSProperties
+        }
       >
-        <div style={{ height: rowVirtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
+        <div
+          style={{
+            height: Math.max(rowVirtualizer.getTotalSize(), 1),
+            position: 'relative',
+            width: '100%',
+          }}
+        >
           {rowVirtualizer.getVirtualItems().map((vi) => {
-          // Trailing rows.
-          if (vi.index === items.length && isRunning && renderPending) {
+            // Trailing rows. Keys must be unique across the whole virtual list.
+            if (vi.index === items.length && isRunning && renderPending) {
+              return (
+                <div
+                  key={`__pending__${vi.index}`}
+                  data-index={vi.index}
+                  ref={rowVirtualizer.measureElement}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${vi.start}px)`,
+                  }}
+                >
+                  {renderPending()}
+                </div>
+              )
+            }
+            if (vi.index >= items.length) {
+              // overscan spacer
+              return (
+                <div
+                  key={`__overscan__${vi.index}`}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: overscanBottom,
+                    transform: `translateY(${vi.start}px)`,
+                  }}
+                />
+              )
+            }
+            const item = items[vi.index]
             return (
               <div
-                key="pending"
+                key={`item-${item.seq}-${item.kind}-${vi.index}`}
+                data-index={vi.index}
+                ref={rowVirtualizer.measureElement}
                 style={{
                   position: 'absolute',
                   top: 0,
@@ -180,44 +242,10 @@ function VirtualizedThread({
                   transform: `translateY(${vi.start}px)`,
                 }}
               >
-                {renderPending()}
+                {renderItem(item)}
               </div>
             )
-          }
-          if (vi.index >= items.length) {
-            // overscan spacer
-            return (
-              <div
-                key="overscan"
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  height: overscanBottom,
-                  transform: `translateY(${vi.start}px)`,
-                }}
-              />
-            )
-          }
-          const item = items[vi.index]
-          return (
-            <div
-              key={item.seq}
-              data-index={vi.index}
-              ref={rowVirtualizer.measureElement}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                transform: `translateY(${vi.start}px)`,
-              }}
-            >
-              {renderItem(item)}
-            </div>
-          )
-        })}
+          })}
         </div>
       </div>
     </div>

--- a/packages/jcode-ui-core/src/runtime/mockRuntime.ts
+++ b/packages/jcode-ui-core/src/runtime/mockRuntime.ts
@@ -1,14 +1,10 @@
 /**
  * MockRuntime — a self-contained, scriptable ChatRuntime for demos, docs, and
  * tests. No backend required: you feed it a "script" of items + a streaming
- * text fragment sequence, and it emits them on a timer. This is what powers the
- * website playground and visual-regression fixtures.
- *
- * It's read-only-ish: action callbacks are captured (so you can assert on them)
- * but don't drive scripted playback — the script is the source of truth.
+ * text fragment sequence, and it emits them on a timer.
  */
 
-import type { ChatRuntime, RuntimeActions, RuntimeState } from './index.js'
+import type { ChatRuntime, PartialRuntimeState, RuntimeActions, RuntimeState } from './index.js'
 import { normalizeState } from './index.js'
 import type { ThreadItem } from '../types/index.js'
 
@@ -17,28 +13,39 @@ export interface MockRuntimeOptions {
   items?: ThreadItem[]
   /** Initial isRunning flag. */
   isRunning?: boolean
+  /** Initial full/partial runtime state (overrides items/isRunning when set). */
+  state?: PartialRuntimeState
   /** Captured-action handlers (defaults are no-ops that record to `.calls`). */
   actions?: Partial<RuntimeActions>
 }
 
+function maxSeq(items: ThreadItem[]): number {
+  let m = 0
+  for (const i of items) {
+    if (i.seq > m) m = i.seq
+  }
+  return m
+}
+
 /**
  * Create a ChatRuntime backed by an in-memory store with pub/sub. Exposes
- * imperative mutators (`setItems`, `push`, `appendText`, `setRunning`) so a
- * script driver (or a test) can evolve the state over time.
+ * imperative mutators (`setItems`, `push`, `appendText`, `setRunning`, `patchState`)
+ * so a script driver (or a test / docs demo) can evolve the state over time.
  */
 export function createMockRuntime(opts: MockRuntimeOptions = {}): ChatRuntime & {
-  /** Mutators for scripts/tests. */
   setItems: (items: ThreadItem[]) => void
   push: (item: ThreadItem) => void
   setRunning: (running: boolean) => void
-  /** Append to the content of the last message item. */
+  patchState: (partial: PartialRuntimeState) => void
   appendText: (delta: string) => void
-  /** Recorded action calls (most-recent-last). */
+  /** Allocate a fresh seq higher than any current item (and any previously seen). */
+  nextSeq: () => number
   calls: { action: string; args: unknown[] }[]
 } {
   let state: RuntimeState = normalizeState({
     items: opts.items,
     isRunning: opts.isRunning,
+    ...opts.state,
   })
   const listeners = new Set<() => void>()
   const calls: { action: string; args: unknown[] }[] = []
@@ -46,12 +53,17 @@ export function createMockRuntime(opts: MockRuntimeOptions = {}): ChatRuntime & 
   function emit() {
     for (const l of listeners) l()
   }
-  function setState(next: RuntimeState) {
+  function replaceState(next: RuntimeState) {
     state = next
+    // Keep the seq counter ahead of anything in the timeline so push/appendText
+    // never collide with caller-assigned seq values (e.g. demo scripts).
+    const m = maxSeq(next.items)
+    if (m > seq) seq = m
     emit()
   }
 
-  let seq = state.items.reduce((m, i) => Math.max(m, i.seq), 0)
+  // Monotonic counter for auto-allocated seqs. Always stays >= max item.seq.
+  let seq = maxSeq(state.items)
   const nextSeq = () => ++seq
 
   const noop = (action: string) => (...args: unknown[]) => {
@@ -63,8 +75,41 @@ export function createMockRuntime(opts: MockRuntimeOptions = {}): ChatRuntime & 
     enqueueMessage: opts.actions?.enqueueMessage ?? noop('enqueueMessage'),
     removeQueuedMessage: opts.actions?.removeQueuedMessage ?? noop('removeQueuedMessage'),
     stop: opts.actions?.stop ?? noop('stop'),
-    resolveApproval: opts.actions?.resolveApproval ?? noop('resolveApproval'),
-    submitAskUser: opts.actions?.submitAskUser ?? noop('submitAskUser'),
+    resolveApproval:
+      opts.actions?.resolveApproval ??
+      ((id, approved, approveAll) => {
+        calls.push({ action: 'resolveApproval', args: [id, approved, approveAll] })
+        replaceState({
+          ...state,
+          items: state.items.map((i) =>
+            i.kind === 'approval' && i.data.id === id
+              ? { ...i, data: { ...i.data, resolved: true, approved } }
+              : i,
+          ),
+        })
+      }),
+    submitAskUser:
+      opts.actions?.submitAskUser ??
+      ((id, answers) => {
+        calls.push({ action: 'submitAskUser', args: [id, answers] })
+        replaceState({
+          ...state,
+          items: state.items.map((i) =>
+            i.kind === 'tool' && (i.data.askUserId === id || i.data.id === id)
+              ? {
+                  ...i,
+                  data: {
+                    ...i.data,
+                    status: 'done',
+                    askUserId: undefined,
+                    askUserQuestions: undefined,
+                    output: JSON.stringify(answers),
+                  },
+                }
+              : i,
+          ),
+        })
+      }),
     editMessage: opts.actions?.editMessage ?? noop('editMessage'),
   }
 
@@ -75,20 +120,38 @@ export function createMockRuntime(opts: MockRuntimeOptions = {}): ChatRuntime & 
       return () => listeners.delete(l)
     },
     actions,
-    setItems: (items) => setState({ ...state, items }),
-    push: (item) => setState({ ...state, items: [...state.items, item] }),
-    setRunning: (isRunning) => setState({ ...state, isRunning }),
+    setItems: (items) => replaceState({ ...state, items }),
+    push: (item) => {
+      // If the caller omitted a meaningful seq (0 / negative), assign one.
+      const withSeq =
+        item.seq > 0
+          ? item
+          : { ...item, seq: nextSeq() }
+      if (withSeq.seq > seq) seq = withSeq.seq
+      replaceState({ ...state, items: [...state.items, withSeq] })
+    },
+    setRunning: (isRunning) => replaceState({ ...state, isRunning }),
+    patchState: (partial) => {
+      const next = { ...state, ...partial }
+      if (partial.items) {
+        replaceState(next)
+      } else {
+        state = next
+        emit()
+      }
+    },
+    nextSeq,
     appendText: (delta) => {
       const items = [...state.items]
       for (let i = items.length - 1; i >= 0; i--) {
         const it = items[i]
         if (it.kind === 'message' && it.data.role === 'assistant') {
           items[i] = { ...it, data: { ...it.data, content: it.data.content + delta } }
-          setState({ ...state, items })
+          replaceState({ ...state, items })
           return
         }
       }
-      // No assistant message yet — create one.
+      // No assistant message yet — create one with a non-colliding seq.
       const msg: ThreadItem = {
         kind: 'message',
         seq: nextSeq(),
@@ -99,7 +162,7 @@ export function createMockRuntime(opts: MockRuntimeOptions = {}): ChatRuntime & 
           timestamp: Date.now(),
         },
       }
-      setState({ ...state, items: [...state.items, msg] })
+      replaceState({ ...state, items: [...state.items, msg] })
     },
     calls,
   }

--- a/packages/jcode-ui-core/src/types/index.ts
+++ b/packages/jcode-ui-core/src/types/index.ts
@@ -9,10 +9,18 @@
 /** Who authored a message. */
 export type Role = 'user' | 'assistant' | 'system'
 
-/** A base64-encoded image attached to a message (no `data:` prefix). */
+/**
+ * A base64-encoded image attached to a message (no `data:` prefix).
+ *
+ * Image-first (vision models). Generic file/PDF adapters are host concerns —
+ * see docs/chat-ui attachments guide. Optional `name` is used for tooltips and
+ * a11y labels (mirrors assistant-ui Attachment.name).
+ */
 export interface ChatImage {
   data: string
   media_type: string
+  /** Original filename when known (file picker / drag-drop). */
+  name?: string
 }
 
 /** Severity for `system` messages. Undefined → default neutral styling. */

--- a/packages/jcode-ui/README.md
+++ b/packages/jcode-ui/README.md
@@ -2,7 +2,7 @@
 
 React components for AI chat interfaces — streaming messages, tool calls, approvals, and ask-user interactions. Backend-agnostic, token-driven, and tree-shakeable. Powers [jcode](https://github.com/cnjack/jcode)'s Web + Desktop UIs.
 
-[**Live demo**](https://www.j-code.net/chat-ui) · [**Docs**](https://www.j-code.net/docs/chat-ui)
+[**Live demo**](https://www.j-code.net/chat-ui) · [**Docs**](https://www.j-code.net/chat-ui/docs) · [**llms.txt**](https://www.j-code.net/llms.txt)
 
 ## Why
 
@@ -92,7 +92,7 @@ registry.register('my_custom_tool', MyRenderer)
 registry.setFallback(GenericRenderer)
 ```
 
-See the [tool renderers docs](https://www.j-code.net/docs/chat-ui/tool-renderers).
+See the [tool renderers docs](https://www.j-code.net/chat-ui/docs/tool-renderers).
 
 ## Theming
 
@@ -103,12 +103,24 @@ Every color/radius/shadow is a CSS custom property — no hardcoded hex. Re-them
 .dark { --color-primary: #818cf8; }
 ```
 
-Light/dark via a `.dark` class on `<html>`. Generated themes (dracula, nord, …) work too. See the [theming docs](https://www.j-code.net/docs/chat-ui/theming).
+Light/dark via a `.dark` class on `<html>`. Generated themes (dracula, nord, …) work too. See the [theming docs](https://www.j-code.net/chat-ui/docs/theming).
 
 ## Packages
 
 - [`jcode-ui-core`](../jcode-ui-core) — types, `ChatRuntime`, `ExternalStoreRuntime`, `MockRuntime`, `ToolRendererRegistry`, headless primitives (`Thread`, `MessageView`, `Composer`, `ToolCallView`, `ApprovalBlock`, `AskUserBlock`), behavioral hooks.
 - `jcode-ui` — styled wrappers + 9 default tool renderers + markdown pipeline + token CSS.
+
+## Examples
+
+| App | Pattern |
+|-----|---------|
+| [`examples/jcode-ui-minimal`](../../examples/jcode-ui-minimal) | Mock runtime, no backend |
+| [`examples/jcode-ui-zustand`](../../examples/jcode-ui-zustand) | External store + Zustand |
+
+```bash
+cd packages/jcode-ui-core && pnpm build && cd ../jcode-ui && pnpm build
+cd ../../examples/jcode-ui-minimal && pnpm install && pnpm dev
+```
 
 ## License
 

--- a/packages/jcode-ui/package.json
+++ b/packages/jcode-ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "jack",
-  "homepage": "https://www.j-code.net/docs/chat-ui",
+  "homepage": "https://www.j-code.net/chat-ui/docs",
   "repository": {
     "type": "git",
     "url": "https://github.com/cnjack/jcode",
@@ -55,6 +55,7 @@
     "dev:css": "tailwindcss -i src/styles/entry.css -o dist/styles.css --watch",
     "dev": "pnpm dev:css & tsc -p tsconfig.build.json --watch --preserveWatchOutput",
     "typecheck": "tsc --noEmit -p tsconfig.json",
+    "generate:api-docs": "node ../../script/generate_jcode_ui_api_docs.mjs",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "peerDependencies": {

--- a/packages/jcode-ui/src/components/ApprovalBanner.tsx
+++ b/packages/jcode-ui/src/components/ApprovalBanner.tsx
@@ -1,10 +1,8 @@
 /**
- * ApprovalBanner — styled approval gate (wraps headless ApprovalBlock).
+ * ApprovalBanner — human-in-the-loop approval gate.
  *
- * Pending: warning-tinted decision card with a tool-identity tile (icon keyed
- * off tool_name), the primary target pulled from args, an external-path chip,
- * and the 3-tier button ramp (allow once / allow all [armed] / deny). Resolved:
- * collapses to a borderless inline note.
+ * Soft surface card (matches chat surface), neutral chrome, accent only on the
+ * primary action — avoids the "black card + loud orange" clash.
  */
 
 import { memo, useMemo } from 'react'
@@ -26,7 +24,7 @@ export const ApprovalBanner = memo(function ApprovalBanner({ approval }: Approva
   return (
     <ApprovalBlock
       approval={approval}
-      className="jcode-approval px-4 py-1"
+      className="jcode-approval"
       renderPending={(a, acts) => <PendingCard approval={a} {...acts} />}
       renderResolved={(a) => <ResolvedNote approval={a} />}
     />
@@ -54,43 +52,36 @@ function PendingCard({
   const Icon = toolIcon(approval.tool_name)
   const disabled = !!approval.resolving
   return (
-    <div className="my-1 rounded-[var(--radius-lg)] border border-[var(--color-warning-fg)] bg-[var(--color-warning-bg)] px-3.5 py-2.5">
-      <div className="flex items-center gap-2">
-        <Icon className="h-4 w-4 shrink-0 text-[var(--color-warning-fg)]" />
-        <span className="text-[0.82rem] font-medium text-[var(--color-foreground)]">
-          Approve <span className="text-[var(--color-warning-fg)]">{verbOf(approval.tool_name)}</span>
+    <div className={`jcode-approval-card${armed ? ' is-armed' : ''}${approval.is_external ? ' is-external' : ''}`}>
+      <div className="jcode-approval-card__head">
+        <span className="jcode-approval-card__icon" aria-hidden>
+          <Icon className="h-4 w-4" />
         </span>
-        {target && (
-          <code className="ml-1 max-w-[50%] truncate rounded-[var(--radius-xs)] bg-[var(--color-muted)] px-1.5 py-0.5 font-mono text-[0.72rem] text-[var(--color-foreground)]">
-            {target}
-          </code>
-        )}
-        {approval.is_external && (
-          <span className="ml-auto shrink-0 rounded-[var(--radius-xs)] bg-[var(--color-error-bg)] px-1.5 py-0.5 text-[0.66rem] text-[var(--color-error-fg)]">
-            external
+        <div className="jcode-approval-card__titles">
+          <span className="jcode-approval-card__label">Approval needed</span>
+          <span className="jcode-approval-card__verb">
+            {verbOf(approval.tool_name)}
+            {target ? (
+              <code className="jcode-approval-card__target" title={target}>
+                {target}
+              </code>
+            ) : null}
           </span>
-        )}
+        </div>
+        {approval.is_external && <span className="jcode-approval-card__badge">external</span>}
       </div>
-      <details className="mt-1.5">
-        <summary className="cursor-pointer text-[0.7rem] text-[var(--color-muted-foreground)]">full arguments</summary>
-        <pre className="mt-1 overflow-auto rounded-[var(--radius-md)] bg-[var(--code-bg)] px-2 py-1 font-mono text-[0.7rem] text-[var(--color-foreground)]">{prettyArgs(approval.tool_args)}</pre>
+
+      <details className="jcode-approval-card__details">
+        <summary>Arguments</summary>
+        <pre>{prettyArgs(approval.tool_args)}</pre>
       </details>
-      <div className="mt-2.5 flex flex-wrap gap-2">
-        <button
-          type="button"
-          onClick={allowOnce}
-          disabled={disabled}
-          className="rounded-[var(--radius-md)] bg-[var(--color-primary)] px-3 py-1 text-[0.8rem] font-medium text-[var(--color-on-primary)] hover:bg-[var(--accent-wash-strong)] disabled:opacity-50"
-        >
+
+      <div className="jcode-approval-card__actions">
+        <button type="button" onClick={allowOnce} disabled={disabled} className="jcode-btn jcode-btn-allow">
           Allow once
         </button>
         {!armed ? (
-          <button
-            type="button"
-            onClick={allowAllArm}
-            disabled={disabled}
-            className="rounded-[var(--radius-md)] border border-[var(--color-border)] px-3 py-1 text-[0.8rem] text-[var(--color-foreground)] hover:bg-[var(--neutral-wash-soft)] disabled:opacity-50"
-          >
+          <button type="button" onClick={allowAllArm} disabled={disabled} className="jcode-btn jcode-btn-ghost">
             Allow all…
           </button>
         ) : (
@@ -99,26 +90,16 @@ function PendingCard({
               type="button"
               onClick={allowAllConfirm}
               disabled={disabled}
-              className="rounded-[var(--radius-md)] bg-[var(--color-destructive)] px-3 py-1 text-[0.8rem] font-medium text-[var(--color-on-destructive)] hover:opacity-90 disabled:opacity-50"
+              className="jcode-btn jcode-btn-caution"
             >
               Confirm allow all
             </button>
-            <button
-              type="button"
-              onClick={allowAllCancel}
-              disabled={disabled}
-              className="rounded-[var(--radius-md)] px-3 py-1 text-[0.8rem] text-[var(--color-muted-foreground)] hover:bg-[var(--neutral-wash-soft)] disabled:opacity-50"
-            >
+            <button type="button" onClick={allowAllCancel} disabled={disabled} className="jcode-btn jcode-btn-ghost">
               Cancel
             </button>
           </>
         )}
-        <button
-          type="button"
-          onClick={deny}
-          disabled={disabled}
-          className="ml-auto rounded-[var(--radius-md)] px-3 py-1 text-[0.8rem] text-[var(--color-error-fg)] hover:bg-[var(--color-error-bg)] disabled:opacity-50"
-        >
+        <button type="button" onClick={deny} disabled={disabled} className="jcode-btn jcode-btn-deny">
           Deny
         </button>
       </div>
@@ -130,10 +111,12 @@ function ResolvedNote({ approval }: { approval: Approval }) {
   const ok = approval.approved
   const Icon = ok ? ShieldCheckIcon : ShieldExclamationIcon
   return (
-    <div className="flex items-center gap-1.5 px-4 py-0.5 text-[0.78rem]">
-      <Icon className={`h-3.5 w-3.5 ${ok ? 'text-[var(--color-success)]' : 'text-[var(--color-muted-foreground)]'}`} />
-      <span className="text-[var(--color-muted-foreground)]">
-        {ok ? 'allowed' : 'denied'} · {approval.tool_name}
+    <div className={`jcode-approval-resolved${ok ? ' is-ok' : ''}`}>
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span>
+        {ok ? 'Allowed' : 'Denied'}
+        <span className="jcode-approval-resolved__sep">·</span>
+        <span className="jcode-approval-resolved__name">{approval.tool_name}</span>
       </span>
     </div>
   )
@@ -151,12 +134,12 @@ function extractTarget(approval: Approval): string {
 function verbOf(name: string): string {
   switch (name) {
     case 'execute':
-      return 'command'
+      return 'Run command'
     case 'write':
-      return 'write'
+      return 'Write file'
     case 'edit':
     case 'multi_edit':
-      return 'edit'
+      return 'Edit file'
     default:
       return name
   }

--- a/packages/jcode-ui/src/components/AskUserCard.tsx
+++ b/packages/jcode-ui/src/components/AskUserCard.tsx
@@ -28,18 +28,22 @@ export const AskUserCard = memo(function AskUserCard({ tool }: AskUserCardProps)
 
 function PendingCard({ questions, controls }: { questions: AskUserQuestion[]; controls: AskUserControls }) {
   return (
-    <div className="my-1 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3.5 py-2.5">
+    <div className="jcode-interactive-card my-1.5 border border-[var(--color-border)] bg-[var(--color-surface)] px-3.5 py-3">
       {questions.map((q, qi) => {
         const key = q.header ?? q.question
         const sel = controls.selected[key] ?? []
         return (
-          <div key={qi} className={qi > 0 ? 'mt-3 border-t border-[var(--color-border)] pt-3' : ''}>
-            {q.header && <div className="mb-0.5 text-[0.7rem] font-semibold uppercase text-[var(--color-muted-foreground)]">{q.header}</div>}
+          <div key={qi} className={qi > 0 ? 'mt-3.5 border-t border-[var(--color-border)] pt-3.5' : ''}>
+            {q.header && (
+              <div className="mb-1 text-[0.68rem] font-semibold uppercase tracking-wider text-[var(--color-muted-foreground)]">
+                {q.header}
+              </div>
+            )}
             <div
-              className="jcode-prose mb-2 text-[0.88rem] text-[var(--color-foreground)]"
+              className="jcode-prose mb-2.5 text-[0.9rem] text-[var(--color-foreground)]"
               dangerouslySetInnerHTML={{ __html: renderMarkdown(q.question) }}
             />
-            <div className="space-y-1">
+            <div className="space-y-1.5">
               {(q.options ?? []).map((opt, oi) => {
                 const active = sel.includes(opt.label)
                 return (
@@ -47,16 +51,30 @@ function PendingCard({ questions, controls }: { questions: AskUserQuestion[]; co
                     key={opt.label}
                     type="button"
                     onClick={() => controls.toggleOption(q, opt.label)}
-                    className={`flex w-full items-center gap-2 rounded-[var(--radius-md)] border px-2.5 py-1.5 text-left text-[0.82rem] transition-colors ${
+                    className={`flex w-full items-center gap-2.5 rounded-[var(--radius-lg)] border px-3 py-2 text-left text-[0.84rem] transition-all ${
                       active
-                        ? 'border-[var(--color-primary)] bg-[var(--accent-wash)] text-[var(--color-foreground)]'
+                        ? 'border-[var(--color-primary)] bg-[var(--accent-wash)] text-[var(--color-foreground)] shadow-[var(--shadow-sm)]'
                         : 'border-[var(--color-border)] bg-[var(--color-muted)] text-[var(--color-foreground)] hover:bg-[var(--neutral-wash-soft)]'
                     }`}
                   >
-                    {oi < 9 && <span className="w-4 shrink-0 text-[0.7rem] text-[var(--color-muted-foreground)]">{oi + 1}</span>}
+                    {oi < 9 && (
+                      <span
+                        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] font-mono text-[0.68rem] ${
+                          active
+                            ? 'bg-[var(--color-primary)] text-[var(--color-on-primary)]'
+                            : 'bg-[var(--color-surface)] text-[var(--color-muted-foreground)]'
+                        }`}
+                      >
+                        {oi + 1}
+                      </span>
+                    )}
                     <span className="min-w-0 flex-1">
-                      <span className="block truncate">{opt.label}</span>
-                      {opt.description && <span className="block truncate text-[0.72rem] text-[var(--color-muted-foreground)]">{opt.description}</span>}
+                      <span className="block truncate font-medium">{opt.label}</span>
+                      {opt.description && (
+                        <span className="mt-0.5 block truncate text-[0.74rem] text-[var(--color-muted-foreground)]">
+                          {opt.description}
+                        </span>
+                      )}
                     </span>
                   </button>
                 )
@@ -67,24 +85,16 @@ function PendingCard({ questions, controls }: { questions: AskUserQuestion[]; co
               placeholder="Other…"
               value={controls.other[key] ?? ''}
               onChange={(e) => controls.setOther(q, e.target.value)}
-              className="mt-1 w-full rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-muted)] px-2.5 py-1 text-[0.8rem] text-[var(--color-foreground)] outline-none focus:border-[var(--color-primary)]"
+              className="mt-2 w-full rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-muted)] px-3 py-1.5 text-[0.82rem] text-[var(--color-foreground)] outline-none transition-[border-color,box-shadow] focus:border-[var(--color-primary)] focus:shadow-[0_0_0_3px_var(--accent-wash)]"
             />
           </div>
         )
       })}
-      <div className="mt-3 flex gap-2">
-        <button
-          type="button"
-          onClick={controls.submit}
-          className="rounded-[var(--radius-md)] bg-[var(--color-primary)] px-3 py-1 text-[0.8rem] font-medium text-[var(--color-on-primary)] hover:bg-[var(--accent-wash-strong)]"
-        >
+      <div className="mt-3.5 flex gap-2">
+        <button type="button" onClick={controls.submit} className="jcode-btn jcode-btn-primary">
           Submit
         </button>
-        <button
-          type="button"
-          onClick={controls.skip}
-          className="rounded-[var(--radius-md)] px-3 py-1 text-[0.8rem] text-[var(--color-muted-foreground)] hover:bg-[var(--neutral-wash-soft)]"
-        >
+        <button type="button" onClick={controls.skip} className="jcode-btn jcode-btn-secondary">
           Skip
         </button>
       </div>

--- a/packages/jcode-ui/src/components/Attachment.tsx
+++ b/packages/jcode-ui/src/components/Attachment.tsx
@@ -1,42 +1,155 @@
 /**
- * Attachment + AttachmentList — image-attachment thumbnails.
+ * Attachment + AttachmentList — image attachment thumbnails.
  *
- * Mirrors assistant-ui's Attachment component. Used inside ChatInput for paste/
- * picked images, but exported standalone so library users can compose their own
- * attachment UI (drag-drop zones, file pickers, etc.).
+ * Aligns with assistant-ui's attachment UI (composer strip + remove + preview),
+ * scoped to vision images (`ChatImage` base64). Used by ChatInput and Message;
+ * product web reuses the same components for visual parity.
  */
 
-import { memo } from 'react'
+import { memo, useCallback, useEffect, useId, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import type { ChatImage } from 'jcode-ui-core'
 
-export interface AttachmentProps {
-  image: ChatImage
-  /** Optional remove handler — renders the × button when provided. */
-  onRemove?: () => void
-  /** Thumbnail size in px. Default 64. */
-  size?: number
+function imageSrc(image: ChatImage): string {
+  const data = image.data?.trim() ?? ''
+  if (!data) return ''
+  if (data.startsWith('data:')) return data
+  // Percent-encoded SVG payloads (rare host form).
+  if (data.startsWith('<svg') || data.startsWith('<?xml')) {
+    return `data:${image.media_type || 'image/svg+xml'};charset=utf-8,${encodeURIComponent(data)}`
+  }
+  return `data:${image.media_type || 'image/*'};base64,${data}`
 }
 
-export const Attachment = memo(function Attachment({ image, onRemove, size = 64 }: AttachmentProps) {
+export interface AttachmentProps {
+  image: ChatImage
+  /** Optional remove handler — renders the × button when provided (composer). */
+  onRemove?: () => void
+  /** Thumbnail size in px. Default 56 (assistant-ui tile is ~56). */
+  size?: number
+  /** Allow click-to-preview lightbox. Default true. */
+  preview?: boolean
+}
+
+export const Attachment = memo(function Attachment({
+  image,
+  onRemove,
+  size = 56,
+  preview = true,
+}: AttachmentProps) {
+  const [open, setOpen] = useState(false)
+  const [broken, setBroken] = useState(false)
+  const title = image.name || 'Image attachment'
+  const src = imageSrc(image)
+  const dialogTitleId = useId()
+
+  const close = useCallback(() => setOpen(false), [])
+
+  useEffect(() => {
+    setBroken(false)
+  }, [src])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [close, open])
+
   return (
-    <div className="jcode-attachment relative inline-block" style={{ width: size, height: size }}>
-      <img
-        src={`data:${image.media_type};base64,${image.data}`}
-        alt="attachment"
-        className="h-full w-full rounded-[var(--radius-md)] border border-[var(--color-border)] object-cover"
-      />
-      {onRemove && (
+    <>
+      <div
+        className="jcode-attachment"
+        style={{ width: size, height: size }}
+        title={title}
+      >
         <button
           type="button"
-          onClick={onRemove}
-          className="absolute -right-1 -top-1 rounded-full bg-[var(--color-surface)] p-0.5 text-[var(--color-muted-foreground)] shadow-[var(--shadow-sm)] hover:text-[var(--color-foreground)]"
-          aria-label="Remove attachment"
+          className="jcode-attachment__thumb"
+          onClick={() => preview && !broken && setOpen(true)}
+          aria-label={preview ? `Preview ${title}` : title}
+          disabled={!preview || broken || !src}
         >
-          <XMarkIcon className="h-3 w-3" />
+          {!src || broken ? (
+            <span
+              aria-hidden
+              style={{
+                display: 'flex',
+                height: '100%',
+                width: '100%',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 10,
+                color: 'var(--color-muted-foreground)',
+                background: 'var(--color-muted)',
+              }}
+            >
+              img
+            </span>
+          ) : (
+            <img
+              src={src}
+              alt={title}
+              draggable={false}
+              onError={() => setBroken(true)}
+            />
+          )}
         </button>
-      )}
-    </div>
+        {onRemove && (
+          <button
+            type="button"
+            className="jcode-attachment__remove"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onRemove()
+            }}
+            aria-label={`Remove ${title}`}
+          >
+            <XMarkIcon />
+          </button>
+        )}
+      </div>
+
+      {open &&
+        src &&
+        !broken &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            className="jcode-attachment-preview"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={dialogTitleId}
+            onClick={close}
+          >
+            <div className="jcode-attachment-preview__scrim" />
+            <div
+              className="jcode-attachment-preview__panel"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="jcode-attachment-preview__bar">
+                <span id={dialogTitleId} className="jcode-attachment-preview__name">
+                  {title}
+                </span>
+                <button
+                  type="button"
+                  className="jcode-attachment-preview__close"
+                  onClick={close}
+                  aria-label="Close preview"
+                >
+                  <XMarkIcon className="h-4 w-4" />
+                </button>
+              </div>
+              <img src={src} alt={title} className="jcode-attachment-preview__img" />
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
   )
 })
 
@@ -44,14 +157,32 @@ export interface AttachmentListProps {
   images: ChatImage[]
   onRemove?: (index: number) => void
   size?: number
+  /** Click-to-preview. Default true. */
+  preview?: boolean
+  className?: string
 }
 
-export const AttachmentList = memo(function AttachmentList({ images, onRemove, size }: AttachmentListProps) {
+export const AttachmentList = memo(function AttachmentList({
+  images,
+  onRemove,
+  size,
+  preview = true,
+  className,
+}: AttachmentListProps) {
   if (!images || images.length === 0) return null
   return (
-    <div className="jcode-attachment-list flex flex-wrap gap-1">
+    <div
+      className={['jcode-attachment-list', className].filter(Boolean).join(' ')}
+      data-count={images.length}
+    >
       {images.map((img, i) => (
-        <Attachment key={i} image={img} size={size} onRemove={onRemove ? () => onRemove(i) : undefined} />
+        <Attachment
+          key={`${img.media_type}-${img.name ?? i}-${String(img.data).slice(0, 24)}-${i}`}
+          image={img}
+          size={size}
+          preview={preview}
+          onRemove={onRemove ? () => onRemove(i) : undefined}
+        />
       ))}
     </div>
   )

--- a/packages/jcode-ui/src/components/ChatInput.tsx
+++ b/packages/jcode-ui/src/components/ChatInput.tsx
@@ -1,20 +1,23 @@
 /**
  * ChatInput — styled composer (wraps headless Composer primitive).
  *
- * Renders the autosizing textarea, the send/stop button (swaps on isRunning),
- * the type-ahead queue chips, slash-command dropdown, and image attachments.
- * App-specific pickers (model/mode/workspace) are NOT included — the product
- * app layers those on top. This keeps the component reusable across agents.
+ * Floating surface with focus ring, queue chips, slash palette, attachments,
+ * and a circular send/stop control. App-specific pickers (model/mode/workspace)
+ * stay in the host product.
+ *
+ * Attachments follow assistant-ui's ComposerAttachments / ComposerAddAttachment
+ * pattern, image-first via `ChatImage` + `AttachmentList`.
  */
 
 import { memo } from 'react'
 import {
   PaperAirplaneIcon,
-  StopCircleIcon,
-  XMarkIcon,
+  PaperClipIcon,
+  StopIcon,
 } from '@heroicons/react/24/outline'
 import { Composer } from 'jcode-ui-core/primitives'
 import type { SlashCommand } from 'jcode-ui-core/primitives'
+import { AttachmentList } from './Attachment.js'
 import { ContextBar } from './ContextBar.js'
 
 export interface ChatInputProps {
@@ -22,6 +25,8 @@ export interface ChatInputProps {
   slashCommands?: SlashCommand[]
   /** Allow image attachments (gated by model vision support). */
   allowImages?: boolean
+  /** `accept` for the file picker. Default `image/*`. */
+  acceptImages?: string
   /** Placeholder text. */
   placeholder?: string
   /** Show the context bar suffix. Default true. */
@@ -33,6 +38,7 @@ export interface ChatInputProps {
 export const ChatInput = memo(function ChatInput({
   slashCommands,
   allowImages = false,
+  acceptImages = 'image/*',
   placeholder = 'Send a message…',
   showContextBar = true,
   onSent,
@@ -41,17 +47,19 @@ export const ChatInput = memo(function ChatInput({
     <Composer
       slashCommands={slashCommands}
       allowImages={allowImages}
+      acceptImages={acceptImages}
       placeholder={placeholder}
       onSent={onSent}
       className="jcode-chat-input"
       renderQueue={(queued) =>
         queued.length > 0 ? (
-          <div className="mb-1 flex flex-wrap gap-1">
+          <div className="jcode-chat-input__queue mb-2 flex flex-wrap gap-1.5">
             {queued.map((q) => (
               <span
                 key={q.id}
-                className="inline-flex items-center gap-1 rounded-[var(--radius-pill)] bg-[var(--accent-wash)] px-2 py-0.5 text-[0.72rem] text-[var(--color-foreground)]"
+                className="inline-flex items-center gap-1 rounded-[var(--radius-pill)] border border-[var(--accent-border)] bg-[var(--accent-wash)] px-2.5 py-0.5 text-[0.72rem] text-[var(--color-foreground)] shadow-[var(--shadow-sm)]"
               >
+                <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-primary)]" aria-hidden />
                 <span className="max-w-[200px] truncate">{q.text}</span>
               </span>
             ))}
@@ -60,66 +68,64 @@ export const ChatInput = memo(function ChatInput({
       }
       renderSlashMenu={(state) =>
         state.open ? (
-          <div className="mb-1 max-h-64 overflow-auto rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-[var(--shadow-md)]">
+          <div className="jcode-chat-input__slash mb-2 max-h-64 overflow-auto rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] py-1.5 shadow-[var(--shadow-lg)]">
             {state.commands.map((cmd, i) => (
               <button
                 key={cmd.slash}
                 type="button"
-                onMouseEnter={() => {
-                  // selection highlight is driven by keyboard; clicking applies
-                }}
                 onClick={() => state.apply(cmd)}
-                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[0.8rem] ${
+                className={`flex w-full items-center gap-2.5 px-3.5 py-2 text-left text-[0.8rem] transition-colors ${
                   i === state.activeIndex
                     ? 'bg-[var(--accent-wash)] text-[var(--color-foreground)]'
                     : 'text-[var(--color-foreground)] hover:bg-[var(--neutral-wash-soft)]'
                 }`}
               >
-                <code className="font-mono text-[var(--color-primary)]">{cmd.slash}</code>
-                {cmd.description && <span className="truncate text-[var(--color-muted-foreground)]">{cmd.description}</span>}
+                <code className="rounded-[var(--radius-sm)] bg-[var(--color-muted)] px-1.5 py-0.5 font-mono text-[0.75rem] font-medium text-[var(--color-primary)]">
+                  {cmd.slash}
+                </code>
+                {cmd.description && (
+                  <span className="truncate text-[var(--color-muted-foreground)]">{cmd.description}</span>
+                )}
               </button>
             ))}
           </div>
         ) : null
       }
       renderAttachments={(imgs, remove) => (
-        <div className="mt-1 flex flex-wrap gap-1">
-          {imgs.map((img, i) => (
-            <div key={i} className="relative">
-              <img
-                src={`data:${img.media_type};base64,${img.data}`}
-                alt={`attachment ${i + 1}`}
-                className="h-16 w-16 rounded-[var(--radius-md)] border border-[var(--color-border)] object-cover"
-              />
-              <button
-                type="button"
-                onClick={() => remove(i)}
-                className="absolute -right-1 -top-1 rounded-full bg-[var(--color-surface)] p-0.5 text-[var(--color-muted-foreground)] shadow-[var(--shadow-sm)] hover:text-[var(--color-foreground)]"
-                aria-label="Remove attachment"
-              >
-                <XMarkIcon className="h-3 w-3" />
-              </button>
-            </div>
-          ))}
+        <div className="jcode-chat-input__attachments">
+          <AttachmentList images={imgs} onRemove={remove} size={56} />
         </div>
       )}
-      renderSubmitButton={(mode, disabled) =>
+      renderAddAttachment={(openPicker) => (
+        <button
+          type="button"
+          onClick={openPicker}
+          className="jcode-chat-input__add-att"
+          aria-label="Add attachment"
+          title="Add image"
+        >
+          <PaperClipIcon className="h-4 w-4" />
+        </button>
+      )}
+      renderSubmitButton={(mode, disabled, onActivate) =>
         mode === 'send' ? (
           <button
             type="button"
+            onClick={onActivate}
             disabled={disabled}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-primary)] text-[var(--color-on-primary)] transition-colors hover:bg-[var(--accent-wash-strong)] disabled:opacity-40"
+            className="jcode-chat-input__send flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--color-primary)] text-[var(--color-on-primary)] shadow-[var(--shadow-sm)] transition-all duration-[var(--duration-fast)] hover:brightness-110 hover:shadow-[var(--shadow-md)] active:scale-95 disabled:opacity-35 disabled:shadow-none disabled:hover:brightness-100"
             aria-label="Send message"
           >
-            <PaperAirplaneIcon className="h-4 w-4" />
+            <PaperAirplaneIcon className="h-4 w-4 -translate-x-px translate-y-px" />
           </button>
         ) : (
           <button
             type="button"
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-muted)] text-[var(--color-foreground)] transition-colors hover:bg-[var(--neutral-wash-soft)]"
+            onClick={onActivate}
+            className="jcode-chat-input__stop flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--color-foreground)] text-[var(--color-surface)] shadow-[var(--shadow-sm)] transition-all duration-[var(--duration-fast)] hover:opacity-90 active:scale-95"
             aria-label="Stop"
           >
-            <StopCircleIcon className="h-4 w-4" />
+            <StopIcon className="h-3.5 w-3.5" />
           </button>
         )
       }

--- a/packages/jcode-ui/src/components/Message.tsx
+++ b/packages/jcode-ui/src/components/Message.tsx
@@ -3,7 +3,7 @@
  *
  * Layout (NOT chat-bubble cards):
  *   [avatar] Role label
- *            markdown content (pl-9, no bg / no border)
+ *            markdown content (jcode-gutter, no bg / no border)
  *            duration · copy / edit (hover)
  *
  * User and assistant share the same left-aligned structure; only the avatar
@@ -16,6 +16,7 @@ import { CheckIcon, PencilSquareIcon, Square2StackIcon } from '@heroicons/react/
 import type { Message as MessageData } from 'jcode-ui-core'
 import { useRuntimeActions } from 'jcode-ui-core/runtime'
 import { renderMarkdown } from '../lib/markdown.js'
+import { AttachmentList } from './Attachment.js'
 import { Reasoning } from './Reasoning.js'
 import { Sources } from './Sources.js'
 
@@ -98,7 +99,7 @@ export const Message = memo(function Message({ message, canEdit }: MessageProps)
 
   return (
     <div
-      className="jcode-message chat-col group/msg animate-fade-in py-3"
+      className="jcode-message jcode-chat-col group/msg animate-fade-in py-3"
       data-role={message.role}
       data-source={message.source}
       data-level={message.level}
@@ -106,44 +107,33 @@ export const Message = memo(function Message({ message, canEdit }: MessageProps)
       {/* Role label + avatar — always left-aligned, no bubble chrome. */}
       <div className="mb-2 flex items-center gap-2.5">
         <div
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-bold"
+          className="jcode-msg-avatar flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-bold"
           style={{ background: avatarBg, color: 'var(--color-surface)' }}
           aria-hidden
         >
           {avatarGlyph}
         </div>
-        <span className="text-[11px] font-semibold" style={{ color: labelColor }}>
+        <span className="text-[11px] font-semibold tracking-wide" style={{ color: labelColor }}>
           {roleLabel}
         </span>
       </div>
 
-      {/* Attachments */}
+      {/* Attachments — same Attachment tiles as composer (assistant-ui UserMessageAttachments). */}
       {message.images && message.images.length > 0 && (
-        <div className="mb-2 flex flex-wrap gap-2 pl-9">
-          {message.images.map((img, i) => (
-            <img
-              key={i}
-              src={`data:${img.media_type};base64,${img.data}`}
-              alt={`attachment ${i + 1}`}
-              className="max-h-48 max-w-64 cursor-pointer object-contain transition-opacity hover:opacity-90"
-              style={{
-                borderRadius: 'var(--radius-lg)',
-                border: '1px solid var(--color-border)',
-              }}
-            />
-          ))}
+        <div className="jcode-gutter mb-2">
+          <AttachmentList images={message.images} size={96} preview />
         </div>
       )}
 
       {message.reasoning && (
-        <div className="pl-9">
+        <div className="jcode-gutter">
           <Reasoning reasoning={message.reasoning} durationMs={message.durationMs} />
         </div>
       )}
 
       {/* Body or inline edit — flat prose, no card bg/border. */}
       {editing ? (
-        <div className="pl-9">
+        <div className="jcode-gutter">
           <textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
@@ -156,39 +146,22 @@ export const Message = memo(function Message({ message, canEdit }: MessageProps)
                 cancelEdit()
               }
             }}
-            className="min-h-20 max-h-80 w-full resize-y px-3 py-2 text-sm transition-colors"
+            className="min-h-20 max-h-80 w-full resize-y px-3 py-2.5 text-sm shadow-[var(--shadow-sm)] transition-[border-color,box-shadow] outline-none focus:border-[var(--color-primary)] focus:shadow-[0_0_0_3px_var(--accent-wash)]"
             style={{
-              borderRadius: 'var(--radius-lg)',
+              borderRadius: 'var(--radius-xl)',
               border: '1px solid var(--color-border)',
               background: 'var(--color-surface)',
               color: 'var(--color-foreground)',
+              fontFamily: 'var(--font-sans)',
             }}
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
           />
           <div className="mt-2 flex items-center gap-2">
-            <button
-              type="button"
-              onClick={saveEdit}
-              className="cursor-pointer px-3 py-1 text-xs font-semibold transition-all active:scale-95"
-              style={{
-                background: 'var(--color-accent-neutral)',
-                color: 'var(--color-surface)',
-                borderRadius: 'var(--radius-md)',
-              }}
-            >
+            <button type="button" onClick={saveEdit} className="jcode-btn jcode-btn-primary">
               Save
             </button>
-            <button
-              type="button"
-              onClick={cancelEdit}
-              className="cursor-pointer px-3 py-1 text-xs font-medium transition-all active:scale-95"
-              style={{
-                background: 'var(--color-secondary)',
-                color: 'var(--color-foreground)',
-                borderRadius: 'var(--radius-md)',
-              }}
-            >
+            <button type="button" onClick={cancelEdit} className="jcode-btn jcode-btn-secondary">
               Cancel
             </button>
             <span className="text-[10px]" style={{ color: 'var(--color-muted-foreground)' }}>
@@ -201,14 +174,14 @@ export const Message = memo(function Message({ message, canEdit }: MessageProps)
       )}
 
       {message.sources && message.sources.length > 0 && (
-        <div className="pl-9">
+        <div className="jcode-gutter">
           <Sources sources={message.sources} />
         </div>
       )}
 
       {/* Action footer: duration (assistant) + hover copy/edit. */}
       {!editing && (
-        <div className="mt-1.5 flex items-center gap-2 pl-9">
+        <div className="jcode-gutter mt-1.5 flex items-center gap-2">
           {durationLabel && message.role === 'assistant' && (
             <span
               className="text-[10px] tabular-nums"
@@ -222,19 +195,18 @@ export const Message = memo(function Message({ message, canEdit }: MessageProps)
               {durationLabel}
             </span>
           )}
-          <div className="flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 group-focus-within/msg:opacity-100">
+          <div className="jcode-msg-actions flex items-center gap-0.5">
             <button
               type="button"
               onClick={copy}
               title={copied ? 'Copied' : 'Copy'}
               aria-label={copied ? 'Copied' : 'Copy'}
-              className="flex h-5 w-5 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] transition-all hover:bg-[var(--color-secondary)] active:scale-90"
-              style={{ color: 'var(--color-muted-foreground)' }}
+              className="jcode-msg-action-btn flex h-6 w-6 cursor-pointer items-center justify-center rounded-[var(--radius-md)]"
             >
               {copied ? (
-                <CheckIcon className="h-3 w-3" style={{ color: 'var(--color-accent-neutral)' }} />
+                <CheckIcon className="h-3.5 w-3.5" style={{ color: 'var(--color-success)' }} />
               ) : (
-                <Square2StackIcon className="h-3 w-3" />
+                <Square2StackIcon className="h-3.5 w-3.5" />
               )}
             </button>
             {canEdit && (
@@ -243,10 +215,9 @@ export const Message = memo(function Message({ message, canEdit }: MessageProps)
                 onClick={startEdit}
                 title="Edit"
                 aria-label="Edit"
-                className="flex h-5 w-5 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] transition-all hover:bg-[var(--color-secondary)] active:scale-90"
-                style={{ color: 'var(--color-muted-foreground)' }}
+                className="jcode-msg-action-btn flex h-6 w-6 cursor-pointer items-center justify-center rounded-[var(--radius-md)]"
               >
-                <PencilSquareIcon className="h-3 w-3" />
+                <PencilSquareIcon className="h-3.5 w-3.5" />
               </button>
             )}
           </div>
@@ -255,7 +226,7 @@ export const Message = memo(function Message({ message, canEdit }: MessageProps)
 
       {/* System error detail */}
       {isSystem && message.level === 'error' && message.detail && (
-        <details className="mt-1 pl-9">
+        <details className="jcode-gutter mt-1">
           <summary className="cursor-pointer text-[11px] text-[var(--color-muted-foreground)]">
             details
           </summary>
@@ -279,7 +250,7 @@ const MarkdownBody = memo(function MarkdownBody({ html }: { html: string }) {
   const sanitized = useMemo(() => renderMarkdown(html), [html])
   return (
     <div
-      className="jcode-prose jcode-selectable max-w-none break-words pl-9"
+      className="jcode-prose jcode-selectable jcode-gutter max-w-none break-words"
       dangerouslySetInnerHTML={{ __html: sanitized }}
     />
   )

--- a/packages/jcode-ui/src/components/Reasoning.tsx
+++ b/packages/jcode-ui/src/components/Reasoning.tsx
@@ -23,18 +23,21 @@ export function Reasoning({ reasoning, defaultExpanded = false, durationMs }: Re
   const [expanded, setExpanded] = useState(defaultExpanded)
   const label = durationMs != null ? `Thought for ${(durationMs / 1000).toFixed(1)}s` : 'Thought process'
   return (
-    <div className="jcode-reasoning my-1">
+    <div className="jcode-reasoning my-1.5">
       <button
         type="button"
         onClick={() => setExpanded((e) => !e)}
-        className="flex items-center gap-1.5 rounded-[var(--radius-md)] px-2 py-1 text-[0.75rem] italic text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--neutral-wash-soft)]"
+        className="jcode-reasoning__trigger flex items-center gap-1.5 rounded-[var(--radius-md)] px-2 py-1 text-[0.75rem] text-[var(--color-muted-foreground)] hover:bg-[var(--neutral-wash-soft)] hover:text-[var(--color-foreground)]"
+        aria-expanded={expanded}
       >
-        <ChevronDownIcon className={`h-3 w-3 transition-transform ${expanded ? 'rotate-180' : ''}`} />
-        {label}
+        <ChevronDownIcon
+          className={`h-3 w-3 transition-transform duration-[var(--duration-normal)] ${expanded ? 'rotate-180' : ''}`}
+        />
+        <span className="font-medium not-italic tracking-wide">{label}</span>
       </button>
       {expanded && (
         <div
-          className="jcode-prose mt-1 border-l-2 border-[var(--color-border)] pl-3 text-[0.82rem] italic leading-relaxed text-[var(--color-muted-foreground)]"
+          className="jcode-reasoning__body jcode-prose mt-1.5 border-l-2 border-[var(--color-border)] pl-3.5 text-[0.82rem] leading-relaxed text-[var(--color-muted-foreground)]"
           dangerouslySetInnerHTML={{ __html: renderMarkdown(reasoning) }}
         />
       )}

--- a/packages/jcode-ui/src/components/Sources.tsx
+++ b/packages/jcode-ui/src/components/Sources.tsx
@@ -17,26 +17,35 @@ export function Sources({ sources }: SourcesProps) {
   const [openId, setOpenId] = useState<string | null>(null)
   if (!sources || sources.length === 0) return null
   return (
-    <div className="jcode-sources mt-2 flex flex-wrap items-center gap-1.5">
-      <span className="text-[0.7rem] text-[var(--color-muted-foreground)]">Sources:</span>
+    <div className="jcode-sources mt-2.5 flex flex-wrap items-center gap-1.5">
+      <span className="text-[0.68rem] font-medium uppercase tracking-wider text-[var(--color-muted-foreground)]">
+        Sources
+      </span>
       {sources.map((s, i) => (
         <span key={s.id} className="relative">
           <button
             type="button"
             onClick={() => setOpenId((id) => (id === s.id ? null : s.id))}
-            className="inline-flex items-center gap-1 rounded-[var(--radius-pill)] border border-[var(--color-border)] bg-[var(--color-muted)] px-2 py-0.5 text-[0.7rem] text-[var(--color-foreground)] transition-colors hover:bg-[var(--neutral-wash-soft)]"
+            className="inline-flex items-center gap-1 rounded-[var(--radius-pill)] border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-0.5 text-[0.72rem] text-[var(--color-foreground)] shadow-[var(--shadow-sm)] transition-all hover:border-[var(--accent-border)] hover:bg-[var(--accent-wash-soft)]"
           >
-            {s.url && <LinkIcon className="h-2.5 w-2.5" />}
-            <span className="max-w-[180px] truncate">{i + 1}. {s.title}</span>
+            {s.url && <LinkIcon className="h-2.5 w-2.5 text-[var(--color-primary)]" />}
+            <span className="max-w-[180px] truncate">
+              {i + 1}. {s.title}
+            </span>
           </button>
           {openId === s.id && s.snippet && (
-            <div className="absolute left-0 top-full z-[var(--z-dropdown)] mt-1 w-72 max-w-[80vw] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] p-2 text-[0.72rem] shadow-[var(--shadow-md)]">
+            <div className="absolute left-0 top-full z-[var(--z-dropdown)] mt-1.5 w-72 max-w-[80vw] animate-fade-up rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] p-2.5 text-[0.74rem] shadow-[var(--shadow-lg)]">
               {s.url && (
-                <a href={s.url} target="_blank" rel="noreferrer" className="mb-1 block truncate font-medium text-[var(--color-primary)]">
+                <a
+                  href={s.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mb-1 block truncate font-medium text-[var(--color-primary)]"
+                >
                   {s.title}
                 </a>
               )}
-              <p className="text-[var(--color-muted-foreground)]">{s.snippet}</p>
+              <p className="leading-relaxed text-[var(--color-muted-foreground)]">{s.snippet}</p>
             </div>
           )}
         </span>

--- a/packages/jcode-ui/src/components/Thread.tsx
+++ b/packages/jcode-ui/src/components/Thread.tsx
@@ -37,10 +37,12 @@ export function Thread({
   overscanBottom,
 }: ThreadProps): ReactNode {
   const { isRunning } = useRuntimeState()
+  // min-h-0 is required for flex children to shrink and scroll; h-full fills
+  // definite parents. Avoid forcing height when the host uses content-sized embeds.
   return (
     <ThreadPrimitive
       virtualize={virtualize}
-      className={`jcode-thread messages-feather h-full scroll-smooth rounded-t-[13px] ${className ?? ''}`}
+      className={`jcode-thread messages-feather min-h-0 w-full flex-1 scroll-smooth ${className ?? ''}`}
       overscanBottom={overscanBottom ?? 24}
       renderItem={(item) => renderItem(item, isRunning)}
       renderPending={renderPending ?? DefaultPending}
@@ -50,27 +52,28 @@ export function Thread({
 }
 
 function renderItem(item: ThreadItem, isRunning: boolean): ReactNode {
+  // Keys live on the Thread list containers (virtualizer / map) — do not set
+  // keys here or React warns about duplicate sibling keys when seq collides.
   if (isMessageItem(item)) {
     return (
       <Message
-        key={item.seq}
         message={item.data}
         canEdit={item.data.role === 'user' && !isRunning}
       />
     )
   }
   if (isToolItem(item)) {
-    // pl-9 matches Vue App.vue: tools indent under the message content column.
+    // Indent under the avatar gutter so tools line up with message body.
     return (
-      <div key={item.seq} className="chat-col">
-        <ToolCallCard tool={item.data} className="pl-9" />
+      <div className="jcode-chat-col">
+        <ToolCallCard tool={item.data} className="jcode-gutter" />
       </div>
     )
   }
   if (isApprovalItem(item)) {
     return (
-      <div key={item.seq} className="chat-col">
-        <div className="pl-9">
+      <div className="jcode-chat-col">
+        <div className="jcode-gutter jcode-approval-slot">
           <ApprovalBanner approval={item.data} />
         </div>
       </div>
@@ -80,31 +83,22 @@ function renderItem(item: ThreadItem, isRunning: boolean): ReactNode {
 }
 
 function DefaultPending(): ReactNode {
-  // Matches Vue's thinking footer: three pulsing dots + label, indented pl-9.
+  // Align with message body / tools (chat-col + gutter under the avatar).
   return (
     <div
-      className="jcode-pending chat-col flex select-none items-center gap-2.5 py-3 pl-[3.25rem]"
+      className="jcode-pending jcode-chat-col"
       role="status"
       aria-live="polite"
       aria-label="Thinking…"
     >
-      <span className="flex gap-1" aria-hidden="true">
-        <span
-          className="h-1.5 w-1.5 animate-pulse rounded-full"
-          style={{ background: 'var(--color-accent-neutral)', animationDelay: '0ms' }}
-        />
-        <span
-          className="h-1.5 w-1.5 animate-pulse rounded-full"
-          style={{ background: 'var(--color-accent-neutral)', animationDelay: '160ms' }}
-        />
-        <span
-          className="h-1.5 w-1.5 animate-pulse rounded-full"
-          style={{ background: 'var(--color-accent-neutral)', animationDelay: '320ms' }}
-        />
-      </span>
-      <span className="text-[13px]" style={{ fontFamily: 'var(--font-sans)', color: 'var(--color-muted-foreground)' }}>
-        Thinking…
-      </span>
+      <div className="jcode-pending__inner jcode-gutter">
+        <span className="jcode-pending__dots" aria-hidden="true">
+          <span className="jcode-pending-dot" />
+          <span className="jcode-pending-dot" />
+          <span className="jcode-pending-dot" />
+        </span>
+        <span className="jcode-pending__label">Thinking</span>
+      </div>
     </div>
   )
 }

--- a/packages/jcode-ui/src/components/ToolCallCard.tsx
+++ b/packages/jcode-ui/src/components/ToolCallCard.tsx
@@ -106,10 +106,11 @@ function ToolHeader({
     <button
       type="button"
       onClick={onToggle}
-      className="flex w-full cursor-pointer items-center gap-1.5 bg-transparent py-1 pl-0 pr-1 text-left transition-opacity hover:opacity-70"
+      className="flex w-full max-w-full cursor-pointer items-center gap-1.5 bg-transparent text-left"
     >
+      {/* Title cluster packs left — no ml-auto gap that leaves a hollow middle. */}
       <span
-        className={`shrink-0 text-xs font-medium ${isRunning ? 'shimmer-running' : ''}`}
+        className={`shrink-0 text-xs font-medium tracking-wide ${isRunning ? 'shimmer-running' : ''}`}
         style={{
           color: isError ? 'var(--color-destructive, var(--color-error-fg))' : 'var(--color-muted-foreground)',
         }}
@@ -118,21 +119,26 @@ function ToolHeader({
       </span>
       {subtitle && (
         <span
-          className="truncate font-mono text-xs"
+          className="jcode-toolcall__subtitle min-w-0 truncate font-mono text-[0.72rem]"
           style={{
-            color: isContext ? 'var(--color-muted-foreground)' : 'var(--color-accent-neutral)',
+            // Use foreground/muted directly — not --color-accent-neutral, which
+            // freezes to light #111 when only defined on :root (inherited computed).
+            color: isContext
+              ? 'var(--color-muted-foreground)'
+              : 'var(--color-foreground)',
+            opacity: 0.88,
           }}
           // Subtitle may contain backend-escaped HTML (path highlights).
           dangerouslySetInnerHTML={{ __html: subtitle }}
         />
       )}
       <ChevronDownIcon
-        className={`h-3 w-3 shrink-0 text-[var(--color-muted-foreground)] transition-transform ${
+        className={`h-3 w-3 shrink-0 text-[var(--color-muted-foreground)] transition-transform duration-[var(--duration-normal)] ${
           expanded ? 'rotate-180' : ''
         }`}
       />
       {diff && (diff.added > 0 || diff.deleted > 0) && (
-        <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums">
+        <span className="jcode-toolcall__diff shrink-0 rounded-[var(--radius-sm)] bg-[var(--color-muted)] px-1.5 py-0.5 font-mono text-[10px] tabular-nums">
           {diff.added > 0 && (
             <span style={{ color: 'var(--color-success-fg)' }}>+{diff.added}</span>
           )}

--- a/packages/jcode-ui/src/index.ts
+++ b/packages/jcode-ui/src/index.ts
@@ -44,6 +44,9 @@ export { Reasoning } from './components/Reasoning.js'
 export { Sources } from './components/Sources.js'
 export { Attachment, AttachmentList } from './components/Attachment.js'
 
+// Markdown pipeline (same renderer Message uses).
+export { renderMarkdown } from './lib/markdown.js'
+
 // Re-export the core types + primitives so consumers have a single import.
 export type {
   Message as MessageData,

--- a/packages/jcode-ui/src/styles/animations.css
+++ b/packages/jcode-ui/src/styles/animations.css
@@ -144,25 +144,9 @@
   animation: dot-pulse 1.4s ease-in-out infinite both;
 }
 
-/* "Thinking…" label — same text-sweep idiom as ToolCallCard's .shimmer-running,
-   so the global working cue and running tools share one motion vocabulary. */
-@keyframes thinking-sweep {
-  0%   { background-position: -200% center; }
-  100% { background-position: 200% center; }
-}
+/* Soft thinking label — no flashy orange sweep. */
 .thinking-label {
-  background: linear-gradient(
-    90deg,
-    var(--color-muted-foreground) 20%,
-    var(--color-foreground) 50%,
-    var(--color-muted-foreground) 80%
-  );
-  background-size: 200% auto;
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent; /* non-webkit fallback */
-  animation: thinking-sweep 1.8s linear infinite;
+  color: var(--color-muted-foreground);
   letter-spacing: 0.01em;
 }
 
@@ -195,11 +179,5 @@
   .thinking-label,
   .stagger-children > * {
     animation: none !important;
-  }
-  /* Repaint the clipped-gradient label as solid muted text so the word stays
-     visible once the sweep is frozen. */
-  .thinking-label {
-    -webkit-text-fill-color: var(--color-muted-foreground);
-    color: var(--color-muted-foreground);
   }
 }

--- a/packages/jcode-ui/src/styles/components.css
+++ b/packages/jcode-ui/src/styles/components.css
@@ -4,36 +4,439 @@
  * Everything here is driven by design tokens (var(--color-*), --radius-*, …) —
  * never hardcoded hex/rgb. Tailwind utility classes cover most styling in the
  * components themselves; this file holds the few things utilities can't express
- * cleanly (code-block surfaces, diff row tinting, shimmer keyframes wiring).
+ * cleanly (composer shell, code-block surfaces, diff tinting, focus rings).
  */
 
-/* ─── Markdown code blocks ───
- * A distinct inset surface so a <pre> reads as its own block (matches the
- * Vue app's --code-bg / --code-border tokens). */
-.jcode-prose pre {
-  background: var(--code-bg);
-  border: 1px solid var(--code-border);
+/* ─── Scoped element resets (no global preflight) ─── */
+.jcode-thread button,
+.jcode-chat-input button,
+.jcode-message button,
+.jcode-toolcall button,
+.jcode-approval button,
+.jcode-ask-user button,
+.jcode-sources button,
+.jcode-reasoning button,
+.jcode-attachment button,
+.jcode-attachment-list button,
+.jcode-attachment-preview button {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+.jcode-thread textarea,
+.jcode-chat-input textarea,
+.jcode-message textarea,
+.jcode-ask-user input {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  margin: 0;
+}
+
+/* ─── Conversation column ───
+ * Shared by Message / tools / pending / composer so edges line up.
+ * Width fills the thread; max-width is overridable via --jcode-col-max. */
+.jcode-chat-col,
+.chat-col {
+  width: 100%;
+  max-width: var(--jcode-col-max, min(56rem, 100%));
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: var(--jcode-col-pad-x, 1rem);
+  padding-right: var(--jcode-col-pad-x, 1rem);
+  box-sizing: border-box;
+}
+
+/* Indent under the avatar column (replaces hard-coded pl-9). */
+.jcode-gutter {
+  padding-left: var(--jcode-gutter, 2.25rem);
+}
+
+/* Thread root — always fill host; never inherit host max-width quirks. */
+.jcode-thread {
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
+  font-family: var(--font-sans);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--color-foreground);
+}
+
+/* ─── Composer shell ───
+ * Same column geometry as .jcode-chat-col so it lines up with messages. */
+.jcode-chat-input {
+  position: relative;
+  width: 100%;
+  max-width: var(--jcode-col-max, min(56rem, 100%));
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0.65rem var(--jcode-col-pad-x, 0.75rem) 0.7rem;
+  box-sizing: border-box;
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-sans);
+  transition:
+    border-color var(--duration-normal) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out);
+}
+.jcode-chat-input:focus-within {
+  border-color: color-mix(in srgb, var(--color-primary) 55%, var(--color-border));
+  box-shadow:
+    var(--shadow-md),
+    0 0 0 3px var(--accent-wash);
+}
+.jcode-chat-input .jcode-composer-input {
+  min-height: 1.5rem;
+  max-height: inherit;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  padding: 0.35rem 0.25rem;
+  caret-color: var(--color-primary);
+}
+.jcode-chat-input .jcode-composer-input::placeholder {
+  color: var(--color-muted-foreground);
+  opacity: 0.75;
+}
+.jcode-chat-input .jcode-composer-row {
+  align-items: flex-end;
+}
+.jcode-chat-input__attachments {
+  margin-bottom: 0.55rem;
+}
+.jcode-chat-input__add-att {
+  display: flex;
+  height: 2rem;
+  width: 2rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
   border-radius: var(--radius-md);
-  padding: 0.75rem 1rem;
-  overflow-x: auto;
+  border: 0;
+  background: transparent;
+  color: var(--color-muted-foreground);
+  transition:
+    background-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+.jcode-chat-input__add-att:hover {
+  background: var(--neutral-wash-soft);
+  color: var(--color-foreground);
+}
+
+/* ─── Attachment tiles + lightbox (assistant-ui-inspired) ─── */
+.jcode-attachment-list {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.65rem;
+  /* Room for the remove chip that hangs outside each tile. */
+  padding: 0.4rem 0.55rem 0.25rem 0.15rem;
+  box-sizing: border-box;
+  width: 100%;
+}
+.jcode-attachment {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+  overflow: visible;
+  vertical-align: top;
+  line-height: 0;
+}
+.jcode-attachment__thumb {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: 1px solid var(--color-border) !important;
+  border-radius: var(--radius-md);
+  background: var(--color-muted) !important;
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+.jcode-attachment__thumb:disabled {
+  cursor: default;
+  pointer-events: none;
+}
+.jcode-attachment__thumb img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border: 0;
+  margin: 0;
+  pointer-events: none;
+  /* Kill host prose/img margins (docs .doc-article img, tailwind preflight gaps). */
+  max-width: none !important;
+}
+.jcode-attachment__remove {
+  position: absolute !important;
+  top: -0.4rem !important;
+  right: -0.4rem !important;
+  z-index: 2;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem !important;
+  height: 1.25rem !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: 1px solid var(--color-border) !important;
+  border-radius: 9999px !important;
+  background: var(--color-surface) !important;
+  color: var(--color-muted-foreground) !important;
+  box-shadow: var(--shadow-sm);
+  line-height: 0;
+  appearance: none;
+  -webkit-appearance: none;
+}
+.jcode-attachment__remove:hover {
+  border-color: var(--color-foreground) !important;
+  color: var(--color-foreground) !important;
+  background: var(--color-surface) !important;
+}
+.jcode-attachment__remove svg {
+  width: 0.7rem;
+  height: 0.7rem;
+  display: block;
+  flex-shrink: 0;
+}
+.jcode-attachment-preview {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal, 50);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+}
+.jcode-attachment-preview__scrim {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, #000 55%, transparent);
+  backdrop-filter: blur(2px);
+}
+.jcode-attachment-preview__panel {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  max-height: min(85dvh, 900px);
+  max-width: min(56rem, 100%);
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-xl);
+}
+.jcode-attachment-preview__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.55rem 0.75rem;
+}
+.jcode-attachment-preview__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-family: var(--font-mono);
-  font-size: 0.85em;
-  margin: 0.5rem 0;
+  font-size: 0.75rem;
+  color: var(--color-muted-foreground);
+}
+.jcode-attachment-preview__close {
+  display: flex;
+  height: 1.75rem;
+  width: 1.75rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-muted-foreground);
+}
+.jcode-attachment-preview__close:hover {
+  background: var(--neutral-wash-soft);
+  color: var(--color-foreground);
+}
+.jcode-attachment-preview__img {
+  display: block;
+  max-height: min(75dvh, 820px);
+  max-width: 100%;
+  object-fit: contain;
+  margin: 0 auto;
+  padding: 0.75rem;
+}
+
+/* ─── Message polish ─── */
+.jcode-message {
+  transition: background-color var(--duration-normal) var(--ease-out);
+}
+.jcode-message .jcode-msg-avatar {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--color-foreground) 8%, transparent),
+    var(--shadow-sm);
+  letter-spacing: 0.02em;
+}
+.jcode-message .jcode-msg-actions {
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-out);
+}
+.jcode-message:hover .jcode-msg-actions,
+.jcode-message:focus-within .jcode-msg-actions {
+  opacity: 1;
+}
+@media (pointer: coarse) {
+  .jcode-message .jcode-msg-actions {
+    opacity: 0.85;
+  }
+}
+.jcode-message .jcode-msg-action-btn {
+  color: var(--color-muted-foreground);
+  transition:
+    color var(--duration-fast) var(--ease-out),
+    background-color var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out);
+}
+.jcode-message .jcode-msg-action-btn:hover {
+  color: var(--color-foreground);
+  background: var(--neutral-wash-soft);
+}
+.jcode-message .jcode-msg-action-btn:active {
+  transform: scale(0.92);
+}
+
+/* Prose rhythm — denser, calmer markdown inside chat. */
+.jcode-prose {
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--color-foreground);
+}
+.jcode-prose p {
+  margin: 0.45em 0;
+}
+.jcode-prose p:first-child {
+  margin-top: 0;
+}
+.jcode-prose p:last-child {
+  margin-bottom: 0;
+}
+.jcode-prose ul,
+.jcode-prose ol {
+  margin: 0.5em 0;
+  padding-left: 1.35em;
+}
+.jcode-prose li + li {
+  margin-top: 0.2em;
+}
+.jcode-prose h1,
+.jcode-prose h2,
+.jcode-prose h3,
+.jcode-prose h4 {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  margin: 0.9em 0 0.4em;
+}
+.jcode-prose h1 { font-size: 1.25em; }
+.jcode-prose h2 { font-size: 1.12em; }
+.jcode-prose h3 { font-size: 1.05em; }
+.jcode-prose blockquote {
+  margin: 0.6em 0;
+  padding: 0.15em 0 0.15em 0.9em;
+  border-left: 3px solid var(--accent-border);
+  color: var(--color-muted-foreground);
+}
+.jcode-prose hr {
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: 1em 0;
+}
+
+/* ─── Markdown code blocks ───
+ * Elevated "card" that must contrast with message/tool surfaces.
+ * Hard fallbacks so hosts that redefine tokens poorly still stay readable.
+ * !important on pre>code bg/border/padding beats host article `code { … }`
+ * rules (e.g. docs `.doc-article code { background: paper }`) which otherwise
+ * paint a light chip under light syntax text → invisible code. */
+.jcode-prose pre {
+  background: var(--code-bg, #222228) !important;
+  color: var(--code-fg, var(--hljs-fg, #f0f0f4)) !important;
+  border: 1px solid var(--code-border, #3f3f48) !important;
+  border-radius: var(--radius-lg);
+  padding: 0.85rem 1rem !important;
+  /* Wrap long lines — avoid horizontal scroll in narrow demo/message columns. */
+  overflow-x: hidden;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: pre-wrap;
+  font-family: var(--font-mono);
+  font-size: 0.84em;
+  line-height: 1.55;
+  margin: 0.65rem 0;
+  max-width: 100%;
+  box-sizing: border-box;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-foreground) 6%, transparent),
+    0 1px 2px color-mix(in srgb, #000 18%, transparent);
+}
+.jcode-prose pre code,
+.jcode-prose pre .hljs,
+.jcode-prose pre code.hljs {
+  background: transparent !important;
+  background-color: transparent !important;
+  color: inherit !important;
+  font-family: inherit !important;
+  font-size: inherit !important;
+  padding: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
 }
 .jcode-prose code {
   font-family: var(--font-mono);
 }
 .jcode-prose :not(pre) > code {
-  background: var(--code-bg);
-  border: 1px solid var(--code-border);
-  border-radius: var(--radius-xs);
-  padding: 0.1em 0.35em;
-  font-size: 0.85em;
+  background: var(--code-inline-bg, var(--code-bg, #2c2c34)) !important;
+  color: var(--code-fg, var(--color-foreground, #f0f0f4)) !important;
+  border: 1px solid var(--code-border, #3f3f48) !important;
+  border-radius: var(--radius-sm);
+  padding: 0.12em 0.45em !important;
+  font-size: 0.86em;
+  font-weight: 500;
 }
 .jcode-prose a {
   color: var(--color-primary);
   text-decoration: underline;
+  text-decoration-thickness: 1px;
   text-underline-offset: 2px;
+  transition: opacity var(--duration-fast) var(--ease-out);
+}
+.jcode-prose a:hover {
+  opacity: 0.85;
 }
 
 /* ─── Markdown tables (GFM) ───
@@ -107,42 +510,62 @@
   font-size: 0.9em;
 }
 
-/* ─── Shared conversation column ───
- * Messages, tools, and the docked composer all use this so their outer edges
- * line up (max-w-4xl + 20px horizontal inset — Vue App.vue column geometry). */
-.chat-col {
-  width: 100%;
-  max-width: 56rem;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 1.25rem;
-  padding-right: 1.25rem;
-  box-sizing: border-box;
-}
-
 /* ─── Tool call shell (matches Vue ToolCallCard.vue) ───
  * Header stays outside; ONLY the expanded body gets a frame. The top edge of
  * `.toolcall-body` is the visual divider between title and content. */
+.jcode-toolcall {
+  transition: opacity var(--duration-fast) var(--ease-out);
+}
+.jcode-toolcall > button {
+  border-radius: var(--radius-md);
+  padding: 0.3rem 0.35rem 0.3rem 0;
+  margin-left: -0.15rem;
+  transition:
+    background-color var(--duration-fast) var(--ease-out),
+    opacity var(--duration-fast) var(--ease-out);
+}
+.jcode-toolcall > button:hover {
+  opacity: 1;
+  background: var(--neutral-wash-soft);
+}
+.jcode-toolcall > button:focus-visible {
+  outline: 2px solid var(--accent-border);
+  outline-offset: 1px;
+}
 .jcode-toolcall .toolcall-body {
   overflow: hidden;
   /* Vue: ml-0 mr-2 mt-1.5 mb-1.5 */
   margin: 0.375rem 0.5rem 0.375rem 0;
   border-radius: var(--radius-xl);
   border: 1px solid var(--color-border);
+  /* Slightly lifted from thread bg so inner code/terminal can contrast further. */
   background: var(--color-surface);
-  /* Stronger top edge so title ↔ content separation reads as a 横线. */
-  box-shadow: 0 -1px 0 0 transparent;
+  box-shadow: var(--shadow-sm);
+  animation: scale-in var(--duration-normal) var(--ease-out) both;
+  color: var(--color-foreground);
+}
+
+/* Shared code-panel look for tool bodies (terminal / file / diff). */
+.jcode-terminal,
+.jcode-file-viewer,
+.jcode-diff {
+  background: var(--code-bg, #222228) !important;
+  color: var(--code-fg, var(--hljs-fg, #f0f0f4)) !important;
 }
 .jcode-toolcall .toolcall-body[data-tool-status='error'] {
-  border-color: var(--color-destructive, var(--color-error-fg));
+  border-color: color-mix(in srgb, var(--color-destructive, var(--color-error-fg)) 55%, var(--color-border));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-error-fg) 12%, transparent);
+}
+.jcode-toolcall .toolcall-body[data-tool-status='running'] {
+  border-color: color-mix(in srgb, var(--color-primary) 28%, var(--color-border));
 }
 
 /* When expanded, a hairline under the header row reinforces the title/content split
    even before the content box edge is noticed. */
 .jcode-toolcall[data-expanded='true'] > button {
-  border-bottom: 1px solid var(--color-border);
-  padding-bottom: 6px;
-  margin-bottom: 2px;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 4px;
+  margin-bottom: 0;
 }
 
 /* Subagent: children under a plain indent; output is a framed markdown block. */
@@ -191,21 +614,23 @@
   border-collapse: collapse;
   font-family: var(--font-mono);
   font-size: 0.75rem;
+  color: var(--code-fg, var(--hljs-fg));
 }
 .jcode-diff-table td {
-  padding: 0 0.5rem;
+  padding: 0.08rem 0.5rem;
   white-space: pre-wrap;
   word-break: break-word;
   vertical-align: top;
 }
 .jcode-diff-table .jcode-diff-ln {
   width: 1px;
-  padding-left: 0.5rem;
+  padding-left: 0.65rem;
   padding-right: 0.5rem;
   text-align: right;
   white-space: nowrap;
   user-select: none;
-  opacity: 0.6;
+  opacity: 0.55;
+  color: var(--code-fg, var(--hljs-fg));
 }
 .jcode-diff-table .jcode-diff-sign {
   width: 1rem;
@@ -214,15 +639,23 @@
   font-weight: 700;
 }
 .jcode-diff-line-add {
-  background: var(--color-success-bg);
+  background: color-mix(in srgb, var(--color-success) 14%, var(--code-bg));
   color: var(--color-success-fg);
 }
+.dark .jcode-diff-line-add {
+  background: color-mix(in srgb, #22c55e 16%, var(--code-bg));
+  color: #bbf7d0;
+}
 .jcode-diff-line-del {
-  background: var(--color-error-bg);
+  background: color-mix(in srgb, var(--color-error-fg) 14%, var(--code-bg));
   color: var(--color-error-fg);
 }
+.dark .jcode-diff-line-del {
+  background: color-mix(in srgb, #ef4444 16%, var(--code-bg));
+  color: #fecaca;
+}
 .jcode-diff-line-meta {
-  color: var(--color-muted-foreground);
+  color: color-mix(in srgb, var(--code-fg) 55%, transparent);
 }
 
 /* ─── Tool-call file viewer (line-numbered) ─── */
@@ -231,23 +664,47 @@
   border-collapse: collapse;
   font-family: var(--font-mono);
   font-size: 0.75rem;
+  color: var(--code-fg, var(--hljs-fg));
 }
 .jcode-file-table td {
-  padding: 0 0.75rem 0 0;
+  padding: 0.05rem 0.75rem 0.05rem 0;
   white-space: pre-wrap;
   word-break: break-all;
   vertical-align: top;
 }
 .jcode-file-table tr:hover {
-  background: var(--neutral-wash-soft);
+  background: color-mix(in srgb, var(--color-foreground) 4%, transparent);
 }
 .jcode-file-lineno {
-  color: color-mix(in srgb, var(--color-muted-foreground), transparent 40%);
+  color: color-mix(in srgb, var(--code-fg, var(--color-muted-foreground)) 45%, transparent);
   user-select: none;
   text-align: right;
   white-space: nowrap;
   width: 1px;
-  padding: 0 0.75rem 0 0.5rem;
+  padding: 0.05rem 0.75rem 0.05rem 0.65rem;
+  border-right: 1px solid var(--code-border);
+}
+.jcode-file-text {
+  color: var(--code-fg, var(--hljs-fg));
+  padding-left: 0.75rem !important;
+}
+
+/* Terminal tool body */
+.jcode-terminal__prompt {
+  color: color-mix(in srgb, var(--code-fg, var(--color-muted-foreground)) 55%, transparent);
+}
+.jcode-terminal__command {
+  color: var(--code-fg, var(--hljs-fg));
+  font-weight: 500;
+}
+.jcode-terminal__out {
+  color: color-mix(in srgb, var(--code-fg, var(--hljs-fg)) 78%, transparent);
+}
+.jcode-terminal__err {
+  color: var(--color-error-fg);
+}
+.jcode-terminal__run {
+  color: color-mix(in srgb, var(--code-fg, var(--color-muted-foreground)) 60%, transparent);
 }
 
 /* ─── Tool running shimmer (text gradient, matches Vue ToolCallCard) ─── */
@@ -289,4 +746,394 @@
 }
 .jcode-selectable {
   user-select: text;
+}
+
+/* ─── Buttons ─── */
+.jcode-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border-radius: var(--radius-md);
+  font-size: 0.8rem;
+  font-weight: 500;
+  line-height: 1.25;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid transparent;
+  transition:
+    background-color var(--duration-normal) var(--ease-out),
+    border-color var(--duration-normal) var(--ease-out),
+    color var(--duration-normal) var(--ease-out),
+    opacity var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out);
+  cursor: pointer;
+}
+.jcode-btn:active:not(:disabled) {
+  transform: scale(0.98);
+}
+.jcode-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.jcode-btn:focus-visible {
+  outline: 2px solid var(--accent-border);
+  outline-offset: 2px;
+}
+/* Soft accent — not a loud solid orange block on dark */
+.jcode-btn-allow {
+  background: var(--accent-wash-strong);
+  color: var(--color-foreground);
+  border-color: var(--accent-border);
+}
+.jcode-btn-allow:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-primary) 22%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--color-primary) 40%, var(--color-border));
+}
+.jcode-btn-ghost {
+  background: transparent;
+  color: var(--color-muted-foreground);
+  border-color: var(--color-border);
+}
+.jcode-btn-ghost:hover:not(:disabled) {
+  background: var(--neutral-wash-soft);
+  color: var(--color-foreground);
+}
+.jcode-btn-deny {
+  margin-left: auto;
+  background: transparent;
+  color: var(--color-muted-foreground);
+  border-color: transparent;
+}
+.jcode-btn-deny:hover:not(:disabled) {
+  color: var(--color-error-fg);
+  background: var(--color-error-bg);
+}
+.jcode-btn-caution {
+  background: color-mix(in srgb, var(--color-warning-fg) 14%, var(--color-surface));
+  color: var(--color-foreground);
+  border-color: color-mix(in srgb, var(--color-warning-fg) 28%, var(--color-border));
+}
+.jcode-btn-caution:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-warning-fg) 20%, var(--color-surface));
+}
+/* Legacy aliases used by ask-user / edit UI */
+.jcode-btn-primary {
+  background: var(--accent-wash-strong);
+  color: var(--color-foreground);
+  border-color: var(--accent-border);
+}
+.jcode-btn-primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-primary) 22%, var(--color-surface));
+}
+.jcode-btn-secondary {
+  background: transparent;
+  color: var(--color-muted-foreground);
+  border-color: var(--color-border);
+}
+.jcode-btn-secondary:hover:not(:disabled) {
+  background: var(--neutral-wash-soft);
+  color: var(--color-foreground);
+}
+.jcode-btn-danger {
+  background: transparent;
+  color: var(--color-muted-foreground);
+  border-color: transparent;
+}
+.jcode-btn-danger:hover:not(:disabled) {
+  color: var(--color-error-fg);
+  background: var(--color-error-bg);
+}
+.jcode-btn-danger-solid {
+  background: color-mix(in srgb, var(--color-error-fg) 16%, var(--color-surface));
+  color: var(--color-error-fg);
+  border-color: color-mix(in srgb, var(--color-error-fg) 28%, var(--color-border));
+}
+
+/* ─── Approval card ───
+ * Same surface as chat, soft edge — no black+orange "alert panel". */
+.jcode-approval {
+  width: 100%;
+}
+.jcode-approval-card {
+  margin: 0.35rem 0 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  animation: jcode-card-in var(--duration-slow) var(--ease-out) both;
+}
+.jcode-approval-card.is-external {
+  border-color: color-mix(in srgb, var(--color-error-fg) 28%, var(--color-border));
+}
+.jcode-approval-card.is-armed {
+  border-color: color-mix(in srgb, var(--color-warning-fg) 30%, var(--color-border));
+}
+.jcode-approval-card__head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+}
+.jcode-approval-card__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+  border-radius: var(--radius-md);
+  background: var(--neutral-wash);
+  color: var(--color-muted-foreground);
+}
+.jcode-approval-card__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+  flex: 1;
+}
+.jcode-approval-card__label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-muted-foreground);
+}
+.jcode-approval-card__verb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--color-foreground);
+  line-height: 1.35;
+}
+.jcode-approval-card__target {
+  display: inline-block;
+  max-width: min(100%, 22rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0.12rem 0.45rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 400;
+  color: var(--color-muted-foreground);
+  vertical-align: middle;
+}
+.jcode-approval-card__badge {
+  flex-shrink: 0;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-error-bg);
+  color: var(--color-error-fg);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.jcode-approval-card__details {
+  margin-top: 0.65rem;
+}
+.jcode-approval-card__details summary {
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.74rem;
+  color: var(--color-muted-foreground);
+  list-style: none;
+  transition: color var(--duration-fast) var(--ease-out);
+}
+.jcode-approval-card__details summary::-webkit-details-marker {
+  display: none;
+}
+.jcode-approval-card__details summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.35rem;
+  transition: transform var(--duration-fast) var(--ease-out);
+  opacity: 0.7;
+}
+.jcode-approval-card__details[open] summary::before {
+  transform: rotate(90deg);
+}
+.jcode-approval-card__details summary:hover {
+  color: var(--color-foreground);
+}
+.jcode-approval-card__details pre {
+  margin: 0.45rem 0 0;
+  max-height: 10rem;
+  overflow: auto;
+  padding: 0.55rem 0.7rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--code-border);
+  background: var(--code-bg);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  line-height: 1.45;
+  color: var(--color-muted-foreground);
+}
+.jcode-approval-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.85rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+}
+.jcode-approval-resolved {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0;
+  font-size: 0.78rem;
+  color: var(--color-muted-foreground);
+  animation: fade-in var(--duration-normal) var(--ease-out) both;
+}
+.jcode-approval-resolved.is-ok {
+  color: color-mix(in srgb, var(--color-success) 70%, var(--color-muted-foreground));
+}
+.jcode-approval-resolved__sep {
+  margin: 0 0.25rem;
+  opacity: 0.4;
+}
+.jcode-approval-resolved__name {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  opacity: 0.85;
+}
+
+@keyframes jcode-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Ask-user keeps a soft surface card (no warning paint) */
+.jcode-ask-user .jcode-interactive-card {
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  animation: jcode-card-in var(--duration-slow) var(--ease-out) both;
+}
+
+/* ─── Reasoning disclosure ─── */
+.jcode-reasoning {
+  border-radius: var(--radius-lg);
+}
+.jcode-reasoning__trigger {
+  transition:
+    background-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+.jcode-reasoning__body {
+  animation: fade-down var(--duration-normal) var(--ease-out) both;
+  border-left-color: color-mix(in srgb, var(--color-border) 80%, transparent) !important;
+}
+
+/* ─── Thread pending ("Thinking") ───
+ * Align under message body gutter; neutral dots (not brand orange). */
+.jcode-pending {
+  padding-top: 0.35rem;
+  padding-bottom: 0.85rem;
+}
+.jcode-pending__inner {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 1.5rem;
+}
+.jcode-pending__dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+}
+.jcode-pending-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-muted-foreground);
+  opacity: 0.45;
+  animation: jcode-think-dot 1.2s ease-in-out infinite both;
+}
+.jcode-pending-dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.jcode-pending-dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+.jcode-pending__label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: var(--color-muted-foreground);
+  opacity: 0.9;
+}
+
+@keyframes jcode-think-dot {
+  0%,
+  80%,
+  100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+  40% {
+    opacity: 0.95;
+    transform: translateY(-1.5px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jcode-approval-card,
+  .jcode-ask-user .jcode-interactive-card {
+    animation: none;
+  }
+  .jcode-pending-dot {
+    animation: none;
+    opacity: 0.6;
+  }
+}
+
+/* ─── Thread scroll surface ─── */
+.jcode-thread {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--color-muted-foreground) 35%, transparent) transparent;
+}
+.jcode-thread::-webkit-scrollbar {
+  width: 8px;
+}
+.jcode-thread::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-muted-foreground) 28%, transparent);
+  border-radius: var(--radius-pill);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.jcode-thread::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--color-muted-foreground) 48%, transparent);
+  background-clip: padding-box;
+}
+
+/* Soft top fade for long threads — only when the host opts into a filled panel.
+ * Avoid mask on short/content-sized embeds (it can look like "missing" content). */
+.jcode-thread.messages-feather-active {
+  mask-image: linear-gradient(to bottom, transparent 0, #000 10px, #000 100%);
+}
+
+/* Focus-visible baseline for interactive controls inside the library. */
+.jcode-toolcall button:focus-visible,
+.jcode-message button:focus-visible,
+.jcode-sources button:focus-visible,
+.jcode-reasoning button:focus-visible {
+  outline: 2px solid var(--accent-border);
+  outline-offset: 2px;
 }

--- a/packages/jcode-ui/src/styles/entry.css
+++ b/packages/jcode-ui/src/styles/entry.css
@@ -1,36 +1,27 @@
 /*
  * jcode-ui — single CSS entry.
  *
- * Consumers import this once: `import 'jcode-ui/styles.css'`.
+ * Consumers: `import 'jcode-ui/styles.css'`
  *
- * Layers (in order):
- *   1. Tailwind CSS 4 (utilities — used by the styled components below).
- *   2. Design tokens (CSS custom properties for color/radius/shadow/…). The
- *      generated-theme variants (jcode-dark, dracula, …) are produced by the
- *      Go theme generator and shipped by the host app, not here — this file
- *      only defines the base :root (light) + .dark (dark) so the components
- *      have sensible defaults even without a generated theme.
- *   3. Animations (shimmer/pulse used by tool-running states).
- *   4. Component styles (the small amount of non-utility CSS for xterm-style
- *      code blocks, diff tables, etc.).
- *
- * Dark mode: toggled by a `.dark` class on <html> (matches the Vue app and the
- * Go theme generator). Generated themes additionally key off
- * `html[data-theme="<id>"]`.
+ * IMPORTANT: We intentionally do NOT import Tailwind's preflight/base layer.
+ * Shipping a global reset would clobber host apps (marketing site docs,
+ * product shells). Hosts own the document reset; we only ship:
+ *   - theme tokens (for utilities)
+ *   - utilities used by components
+ *   - component CSS + design tokens
  */
 
-@import 'tailwindcss';
+@import 'tailwindcss/theme' layer(theme);
+@import 'tailwindcss/utilities' layer(utilities);
 
-/* Dark mode variant keyed off the .dark class (Tailwind 4 in-CSS config). */
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Typography plugin for markdown prose (assistant messages). */
 @plugin '@tailwindcss/typography';
 
 /* ─── Design tokens (base light + .dark) ─── */
 @import './tokens.css';
 
-/* ─── Animations (shimmer/pulse for running states) ─── */
+/* ─── Animations ─── */
 @import './animations.css';
 
 /* ─── Component-local styles ─── */

--- a/packages/jcode-ui/src/styles/tokens.css
+++ b/packages/jcode-ui/src/styles/tokens.css
@@ -4,6 +4,15 @@
  */
 
 :root {
+  /* ─── Layout (conversation column) ───
+   * Hosts/embeds can override on a parent:
+   *   .jcode-demo { --jcode-col-max: 100%; --jcode-col-pad-x: 0.75rem; }
+   * Product full-screen keeps the wide reading column. */
+  --jcode-col-max: min(56rem, 100%);
+  --jcode-col-pad-x: 1rem;
+  /* Avatar + gap → content indent (was hard-coded Tailwind pl-9 = 2.25rem). */
+  --jcode-gutter: 2.25rem;
+
   /* ─── Fonts ─── */
   --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -21,13 +30,12 @@
   --radius-2xl: 16px;
   --radius-pill: 9999px;
 
-  /* ─── Shadows & elevation ─── one warm-tinted scale (near-invisible on dark
-   * surfaces, which is correct). sm = resting card · md = dropdown/menu ·
-   * lg = dialog/modal · xl = floating hero (the centered composer). */
-  --shadow-sm: 0 1px 2px rgba(24, 20, 16, 0.06);
-  --shadow-md: 0 4px 14px -4px rgba(24, 20, 16, 0.12);
-  --shadow-lg: 0 14px 36px -14px rgba(24, 20, 16, 0.20);
-  --shadow-xl: 0 1px 2px rgba(24, 20, 16, 0.04), 0 24px 56px -28px rgba(24, 20, 16, 0.26);
+  /* ─── Shadows & elevation ─── warm-tinted scale.
+   * sm = resting card · md = composer/dropdown · lg = popover · xl = hero. */
+  --shadow-sm: 0 1px 2px rgba(24, 20, 16, 0.05), 0 1px 1px rgba(24, 20, 16, 0.03);
+  --shadow-md: 0 2px 4px rgba(24, 20, 16, 0.04), 0 8px 24px -8px rgba(24, 20, 16, 0.14);
+  --shadow-lg: 0 4px 8px rgba(24, 20, 16, 0.04), 0 18px 40px -14px rgba(24, 20, 16, 0.22);
+  --shadow-xl: 0 1px 2px rgba(24, 20, 16, 0.04), 0 28px 64px -28px rgba(24, 20, 16, 0.28);
 
   /* Modal scrim — one backdrop for every dialog/popover overlay. */
   --backdrop: rgba(20, 18, 16, 0.5);
@@ -52,6 +60,9 @@
    * tint instead, so the UI reads as calm and monochrome rather than flooded
    * with orange. It's a single alias so the whole de-emphasis can be retuned
    * (e.g. to muted-foreground) by editing one line. */
+  /* Re-declared on .dark — custom props inherit *computed* values, so a
+   * :root-only `var(--color-foreground)` freezes to light #111 and never
+   * tracks dark foreground (breaks tool subtitles, neutral washes, etc.). */
   --color-accent-neutral: var(--color-foreground);
   --neutral-wash-soft: color-mix(in srgb, var(--color-foreground) 8%, transparent);
   --neutral-wash: color-mix(in srgb, var(--color-foreground) 11%, transparent);
@@ -117,11 +128,12 @@
   --color-on-primary: #FFFFFF;
   --color-on-destructive: #FFFFFF;
 
-  /* Code-block surface (markdown <pre>). Distinct from --color-surface so a code
-   * block reads as its own inset surface; matches GitHub's light code bg and the
-   * dark terminal/code tone. */
-  --code-bg: #f6f8fa;
-  --code-border: #d0d7de;
+  /* Code surfaces — elevated "card" that must contrast with surface/background.
+   * Light: soft gray panel on cream/white. Never equal surface or paper. */
+  --code-bg: #e8ebf0;
+  --code-border: #c8cdd5;
+  --code-fg: #1f2328;
+  --code-inline-bg: #e2e6ec;
 
   /* Terminal (xterm) palette — single source for the JS theme object in
    * TerminalInstance.vue (read via getComputedStyle). Cursor uses the brand
@@ -166,6 +178,12 @@
 
 /* ─── Dark Mode ─── */
 .dark {
+  /* Elevation reads as light-on-dark, not warm brown. */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.28), 0 0 0 1px rgba(255, 255, 255, 0.03);
+  --shadow-md: 0 4px 16px -4px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  --shadow-lg: 0 12px 36px -12px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  --shadow-xl: 0 24px 56px -20px rgba(0, 0, 0, 0.65), 0 0 0 1px rgba(255, 255, 255, 0.06);
+
   --color-primary: #FF8400;
   --color-background: #111111;
   --color-surface: #1A1A1A;
@@ -191,10 +209,19 @@
   --color-on-primary: #FFFFFF;
   --color-on-destructive: #FFFFFF;
 
-  /* Code-block surface (dark). #1A1A1A matches --color-surface here, but kept as
-   * its own token so a generated theme can diverge the code tone independently. */
-  --code-bg: #1A1A1A;
-  --code-border: var(--color-border);
+  /* Re-bind aliases that reference --color-foreground (see light-mode note). */
+  --color-accent-neutral: var(--color-foreground);
+  --neutral-wash-soft: color-mix(in srgb, var(--color-foreground) 8%, transparent);
+  --neutral-wash: color-mix(in srgb, var(--color-foreground) 11%, transparent);
+  --neutral-wash-strong: color-mix(in srgb, var(--color-foreground) 16%, transparent);
+  --neutral-border: color-mix(in srgb, var(--color-foreground) 30%, transparent);
+
+  /* Code surfaces (dark) — elevated card ABOVE background (#111) / surface (#1A1A1A).
+   * Sunken near-black (#0c0c0e) looked like "no card". Prefer a lifted panel. */
+  --code-bg: #222228;
+  --code-border: #3f3f48;
+  --code-fg: #f0f0f4;
+  --code-inline-bg: #2c2c34;
 
   /* Terminal (xterm) palette — dark variant. */
   --term-bg: #18181b;
@@ -218,26 +245,28 @@
   --term-bright-cyan: #22d3ee;
   --term-bright-white: #fafafa;
 
-  /* ─── Syntax highlighting (dark) ─── */
-  --hljs-fg: #e4e4e7;
+  /* ─── Syntax highlighting (dark) — high contrast on --code-bg ─── */
+  --hljs-fg: #e8e8ec;
   --hljs-keyword: #7dd3fc;
-  --hljs-string: #6ee7b7;
-  --hljs-comment: #52525b;
-  --hljs-number: #fbbf24;
-  --hljs-title: #c4b5fd;
+  --hljs-string: #86efac;
+  --hljs-comment: #8b8b96;
+  --hljs-number: #fcd34d;
+  --hljs-title: #d8b4fe;
   --hljs-type: #fca5a5;
   --hljs-params: #f0abfc;
   --hljs-variable: #fde68a;
   --hljs-function: #c4b5fd;
-  --hljs-meta: #71717a;
+  --hljs-meta: #a1a1aa;
   --hljs-property: #93c5fd;
-  --hljs-punctuation: #71717a;
+  --hljs-punctuation: #a1a1aa;
 }
 
 /* ─── Code Syntax Highlighting ─── */
 .hljs {
   color: var(--hljs-fg);
   background: transparent;
+  display: block;
+  overflow-x: auto;
 }
 .hljs-keyword,
 .hljs-selector-tag,

--- a/packages/jcode-ui/src/toolRenderers/diff.tsx
+++ b/packages/jcode-ui/src/toolRenderers/diff.tsx
@@ -23,7 +23,7 @@ export const DiffRenderer = memo(function DiffRenderer({
 
   if (sections.length > 0) {
     return (
-      <div className="jcode-diff max-h-72 overflow-y-auto" style={{ background: 'var(--color-surface)' }}>
+      <div className="jcode-diff max-h-72 overflow-y-auto">
         <table className="jcode-diff-table w-full border-collapse">
           <tbody>
             {sections.map((section, si) =>

--- a/packages/jcode-ui/src/toolRenderers/fileViewer.tsx
+++ b/packages/jcode-ui/src/toolRenderers/fileViewer.tsx
@@ -23,13 +23,13 @@ export const FileViewerRenderer = memo(function FileViewerRenderer({
 
   if (lines.length > 0) {
     return (
-      <div className="jcode-file-viewer max-h-72 overflow-y-auto" style={{ background: 'var(--color-surface)' }}>
+      <div className="jcode-file-viewer max-h-72 overflow-y-auto">
         <table className="jcode-file-table w-full border-collapse">
           <tbody>
             {lines.map((l) => (
               <tr key={l.num}>
                 <td className="jcode-file-lineno">{l.num}</td>
-                <td style={{ color: 'var(--color-foreground)' }}>{l.text}</td>
+                <td className="jcode-file-text">{l.text}</td>
               </tr>
             ))}
           </tbody>

--- a/packages/jcode-ui/src/toolRenderers/terminal.tsx
+++ b/packages/jcode-ui/src/toolRenderers/terminal.tsx
@@ -23,36 +23,16 @@ export const TerminalRenderer = memo(function TerminalRenderer({
   }
   const body = displayOutput || output || ''
   return (
-    <div
-      className="jcode-terminal max-h-72 overflow-y-auto px-3 py-2 font-mono text-xs"
-      style={{ background: 'var(--color-muted)' }}
-    >
+    <div className="jcode-terminal max-h-72 overflow-y-auto px-3 py-2.5 font-mono text-xs leading-relaxed">
       {command && (
-        <div>
-          <span className="select-none" style={{ color: 'var(--color-muted-foreground)' }}>
-            ${' '}
-          </span>
-          <span style={{ color: 'var(--color-foreground)' }}>{command}</span>
+        <div className="jcode-terminal__cmd">
+          <span className="jcode-terminal__prompt select-none">$ </span>
+          <span className="jcode-terminal__command">{command}</span>
         </div>
       )}
-      {body && (
-        <div
-          className="mt-1 whitespace-pre-wrap break-all"
-          style={{ color: 'var(--color-muted-foreground)' }}
-        >
-          {truncate(body, 2000)}
-        </div>
-      )}
-      {error && (
-        <div className="mt-1 whitespace-pre-wrap" style={{ color: 'var(--color-error-fg)' }}>
-          {error}
-        </div>
-      )}
-      {status === 'running' && (
-        <div className="mt-1 animate-pulse" style={{ color: 'var(--color-muted-foreground)' }}>
-          Running…
-        </div>
-      )}
+      {body && <div className="jcode-terminal__out mt-1.5 whitespace-pre-wrap break-all">{truncate(body, 2000)}</div>}
+      {error && <div className="jcode-terminal__err mt-1 whitespace-pre-wrap">{error}</div>}
+      {status === 'running' && <div className="jcode-terminal__run mt-1 animate-pulse">Running…</div>}
     </div>
   )
 })

--- a/script/generate_jcode_ui_api_docs.mjs
+++ b/script/generate_jcode_ui_api_docs.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * Generate site/docs/chat-ui/api/generated.md from jcode-ui source.
+ *
+ * Scans packages/jcode-ui/src and packages/jcode-ui-core/src for .ts/.tsx.
+ * Extracts export interface|type|class|function declarations (with leading
+ * JSDoc) and writes a single markdown page the docs site ships.
+ *
+ * Usage:
+ *   node script/generate_jcode_ui_api_docs.mjs
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(__dirname, '..')
+const outFile = path.join(root, 'site/docs/chat-ui/api/generated.md')
+
+const SCAN = [
+  'packages/jcode-ui/src',
+  'packages/jcode-ui-core/src',
+]
+
+/** @param {string} dir */
+function walk(dir) {
+  /** @type {string[]} */
+  const out = []
+  if (!fs.existsSync(dir)) return out
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, ent.name)
+    if (ent.isDirectory()) {
+      if (ent.name === 'node_modules' || ent.name === 'dist') continue
+      out.push(...walk(p))
+    } else if (/\.(ts|tsx)$/.test(ent.name) && !ent.name.endsWith('.test.ts') && !ent.name.endsWith('.test.tsx')) {
+      out.push(p)
+    }
+  }
+  return out
+}
+
+/**
+ * @typedef {{ kind: string, name: string, signature: string, doc: string, file: string, pkg: string }} Symbol
+ */
+
+/**
+ * @param {string} file
+ * @param {string} src
+ * @returns {Symbol[]}
+ */
+function extractSymbols(file, src) {
+  const rel = path.relative(root, file)
+  const pkg = rel.startsWith('packages/jcode-ui-core') ? 'jcode-ui-core' : 'jcode-ui'
+  /** @type {Symbol[]} */
+  const symbols = []
+
+  // Match export interface / type / class / function with optional JSDoc above.
+  const re =
+    /(?:\/\*\*([\s\S]*?)\*\/\s*)?export\s+(?:declare\s+)?(interface|type|class|function|const)\s+([A-Za-z0-9_]+)/g
+
+  let m
+  while ((m = re.exec(src))) {
+    const docRaw = m[1] ?? ''
+    const kind = m[2]
+    const name = m[3]
+    // Skip internal re-export noise / React memo wrappers named oddly
+    if (name === 'default') continue
+
+    const start = m.index + m[0].length
+    let signature = ''
+
+    if (kind === 'interface' || kind === 'class') {
+      // Capture until matching brace depth returns to 0 from first {
+      const braceStart = src.indexOf('{', start - 1)
+      if (braceStart === -1) continue
+      let depth = 0
+      let i = braceStart
+      for (; i < src.length; i++) {
+        const ch = src[i]
+        if (ch === '{') depth++
+        else if (ch === '}') {
+          depth--
+          if (depth === 0) {
+            i++
+            break
+          }
+        }
+      }
+      signature = src.slice(m.index + (m[1] ? m[0].indexOf('export') : 0), i).replace(/^[\s\S]*?export\s+/, 'export ')
+      // Prefer from "export interface" only
+      const expIdx = src.lastIndexOf('export', braceStart)
+      signature = src.slice(expIdx, i).trim()
+    } else if (kind === 'type') {
+      // type Foo = ... until unbracketed semicolon or newline-double
+      let i = start
+      let depth = 0
+      let angle = 0
+      for (; i < src.length; i++) {
+        const ch = src[i]
+        if (ch === '{' || ch === '(' || ch === '[') depth++
+        else if (ch === '}' || ch === ')' || ch === ']') depth--
+        else if (ch === '<') angle++
+        else if (ch === '>') angle--
+        else if (ch === ';' && depth <= 0 && angle <= 0) {
+          i++
+          break
+        }
+        else if (ch === '\n' && depth <= 0 && angle <= 0 && src[i + 1] === '\n') break
+      }
+      const expIdx = src.lastIndexOf('export', start)
+      signature = src.slice(expIdx, i).trim()
+      if (!signature.endsWith(';')) signature += ';'
+    } else if (kind === 'function') {
+      // function name(...) : Ret { or ;
+      let i = start
+      let depth = 0
+      for (; i < src.length; i++) {
+        const ch = src[i]
+        if (ch === '(' || ch === '<' || ch === '{') depth++
+        else if (ch === ')' || ch === '>' || ch === '}') {
+          depth--
+          if (ch === '{' && depth === 0) break
+          if (ch === ')' && depth <= 0) {
+            // keep going for return type until { or ;
+          }
+        }
+        if (ch === '{' && depth === 1) {
+          // signature ends before body
+          break
+        }
+        if (ch === ';' && depth <= 0) {
+          i++
+          break
+        }
+      }
+      const expIdx = src.lastIndexOf('export', start)
+      signature = src.slice(expIdx, i).trim()
+      if (signature.endsWith('{')) signature = signature.slice(0, -1).trim() + ' { … }'
+      else if (!signature.endsWith(';') && !signature.endsWith('}')) signature += ' { … }'
+    } else if (kind === 'const') {
+      // Only keep function-like consts: export const X = memo( or (
+      const snippet = src.slice(m.index, m.index + 200)
+      if (!/=\s*(?:memo\s*)?\(/.test(snippet) && !/=\s*function/.test(snippet)) continue
+      const expIdx = m.index
+      // Take first line-ish of const export
+      const lineEnd = src.indexOf('\n', start)
+      signature = src.slice(expIdx, lineEnd === -1 ? start + 80 : lineEnd).trim()
+      if (!signature.includes('(')) continue
+      signature = signature.replace(/=\s*memo\(.*/, '= …')
+      signature = signature.replace(/=\s*\(.*/, '= …')
+    }
+
+    // Normalize signature length
+    if (signature.length > 4000) signature = signature.slice(0, 4000) + '\n  /* … truncated */\n}'
+
+    const doc = cleanDoc(docRaw)
+    symbols.push({ kind, name, signature, doc, file: rel, pkg })
+  }
+
+  return symbols
+}
+
+/** @param {string} raw */
+function cleanDoc(raw) {
+  return raw
+    .split('\n')
+    .map((l) => l.replace(/^\s*\*\s?/, '').replace(/^\s*\*/, ''))
+    .join('\n')
+    .trim()
+}
+
+/** @param {string} s */
+function esc(s) {
+  return s.replace(/\|/g, '\\|')
+}
+
+function main() {
+  /** @type {Symbol[]} */
+  const all = []
+  for (const dir of SCAN) {
+    for (const file of walk(path.join(root, dir))) {
+      const src = fs.readFileSync(file, 'utf8')
+      all.push(...extractSymbols(file, src))
+    }
+  }
+
+  // Dedupe by pkg+kind+name (prefer longer signature / with doc)
+  /** @type {Map<string, Symbol>} */
+  const map = new Map()
+  for (const s of all) {
+    const key = `${s.pkg}::${s.kind}::${s.name}`
+    const prev = map.get(key)
+    if (!prev || (s.doc && !prev.doc) || s.signature.length > prev.signature.length) {
+      map.set(key, s)
+    }
+  }
+  const symbols = [...map.values()].sort((a, b) => {
+    if (a.pkg !== b.pkg) return a.pkg.localeCompare(b.pkg)
+    if (a.kind !== b.kind) return a.kind.localeCompare(b.kind)
+    return a.name.localeCompare(b.name)
+  })
+
+  const byPkg = {
+    'jcode-ui': symbols.filter((s) => s.pkg === 'jcode-ui'),
+    'jcode-ui-core': symbols.filter((s) => s.pkg === 'jcode-ui-core'),
+  }
+
+  const generatedAt = new Date().toISOString().slice(0, 10)
+
+  let md = `---
+title: Generated API
+parent: API Reference
+nav_order: 6
+---
+
+# Generated API
+
+> Auto-generated from TypeScript sources on **${generatedAt}**.
+> Do not edit by hand — run \`node script/generate_jcode_ui_api_docs.mjs\`.
+>
+> Human-written guides: [Types](/chat-ui/docs/api/types) · [Runtime](/chat-ui/docs/api/runtime) · [Hooks](/chat-ui/docs/api/hooks) · [Primitives](/chat-ui/docs/api/primitives) · [Components](/chat-ui/docs/api/components).
+
+**${symbols.length}** public symbols extracted.
+
+`
+
+  for (const [pkg, list] of Object.entries(byPkg)) {
+    md += `## \`${pkg}\`\n\n`
+    md += `| Symbol | Kind | Source |\n|--------|------|--------|\n`
+    for (const s of list) {
+      const anchor = s.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+      md += `| [\`${esc(s.name)}\`](#${pkg.replace(/[^a-z0-9]+/g, '-')}-${anchor}) | ${s.kind} | \`${esc(s.file)}\` |\n`
+    }
+    md += `\n`
+
+    for (const s of list) {
+      const headingId = `${pkg}-${s.name}`.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+      md += `### \`${s.name}\`\n\n`
+      md += `<!-- ${headingId} -->\n\n`
+      md += `\`${s.kind}\` · \`${s.file}\`\n\n`
+      if (s.doc) {
+        md += `${s.doc}\n\n`
+      }
+      md += '```ts\n' + s.signature + '\n```\n\n'
+    }
+  }
+
+  fs.mkdirSync(path.dirname(outFile), { recursive: true })
+  fs.writeFileSync(outFile, md)
+  console.log(`Wrote ${symbols.length} symbols → ${path.relative(root, outFile)}`)
+}
+
+main()

--- a/site/docs/chat-ui/api.md
+++ b/site/docs/chat-ui/api.md
@@ -1,0 +1,43 @@
+---
+title: API Reference
+nav_order: 7
+has_children: true
+---
+
+# API Reference
+
+Programmatic surface of `jcode-ui` and `jcode-ui-core`. Prefer these pages for prop tables and type contracts; component docs focus on usage + live previews.
+
+## Sections
+
+| Page | Contents |
+|------|----------|
+| [Types](/chat-ui/docs/api/types) | `Message`, `ToolCall`, `Approval`, `ThreadItem`, … |
+| [Runtime](/chat-ui/docs/api/runtime) | `ChatRuntime`, `createExternalStoreRuntime`, `createMockRuntime` |
+| [Hooks](/chat-ui/docs/api/hooks) | Runtime hooks + behavioral hooks |
+| [Primitives](/chat-ui/docs/api/primitives) | Headless components + slots |
+| [Components](/chat-ui/docs/api/components) | Styled component props summary |
+| [Generated API](/chat-ui/docs/api/generated) | Full symbol dump from TypeScript sources (auto-generated) |
+
+Regenerate the dump after API changes:
+
+```bash
+node script/generate_jcode_ui_api_docs.mjs
+# or: pnpm --dir packages/jcode-ui generate:api-docs
+```
+
+## Package entry points
+
+```ts
+// Styled + convenience re-exports
+import { Thread, ChatInput, createExternalStoreRuntime, renderMarkdown } from 'jcode-ui'
+import 'jcode-ui/styles.css'
+import { TerminalRenderer } from 'jcode-ui/tool-renderers'
+
+// Core (tree-shakeable)
+import type { Message, ToolCall } from 'jcode-ui-core'
+import { createMockRuntime } from 'jcode-ui-core/runtime'
+import { Composer } from 'jcode-ui-core/primitives'
+import { createToolRendererRegistry } from 'jcode-ui-core/adapters'
+import { useAutoScroll } from 'jcode-ui-core/hooks'
+```

--- a/site/docs/chat-ui/api/components.md
+++ b/site/docs/chat-ui/api/components.md
@@ -1,0 +1,30 @@
+---
+title: Components API
+parent: API Reference
+nav_order: 5
+---
+
+# Components API (summary)
+
+Styled exports from `jcode-ui`. Detailed docs + live previews live under [Components](/chat-ui/docs/components).
+
+| Export | Key props |
+|--------|-----------|
+| `Thread` | `virtualize`, `overscanBottom`, `emptyState`, `renderPending`, `className` |
+| `ChatInput` | `slashCommands`, `allowImages`, `placeholder`, `showContextBar`, `onSent` |
+| `Message` | `message`, `canEdit` |
+| `ToolCallCard` | `tool`, `registry?`, `className?` |
+| `ApprovalBanner` | `approval` |
+| `AskUserCard` | `tool` |
+| `Reasoning` | `reasoning`, `defaultExpanded?`, `durationMs?` |
+| `Sources` | `sources` |
+| `Attachment` | `image`, `onRemove?`, `size?`, `preview?` |
+| `AttachmentList` | `images`, `onRemove?`, `size?`, `preview?`, `className?` |
+| `ContextBar` | `breakdown?`, `size?`, `dangerThreshold?`, `showPopover?` |
+| `RuntimeProvider` | `runtime` |
+| `ToolRegistryProvider` | `registry` |
+| `ApiBaseProvider` | `apiBase` |
+| `createDefaultToolRegistry` | `()` → registry with 9 defaults |
+| `renderMarkdown` | `(text: string) => string` |
+
+Type re-exports: `MessageData`, `ToolCall`, `Approval`, `ThreadItem`, `TokenSnapshot`, `TaskContextBreakdown`, `AskUserQuestion`, `AskUserAnswer`, `TodoItem`, `Goal`, `Role`, guards `isMessageItem` / `isToolItem` / `isApprovalItem`.

--- a/site/docs/chat-ui/api/generated.md
+++ b/site/docs/chat-ui/api/generated.md
@@ -1,0 +1,2379 @@
+---
+title: Generated API
+parent: API Reference
+nav_order: 6
+---
+
+# Generated API
+
+> Auto-generated from TypeScript sources on **2026-07-09**.
+> Do not edit by hand — run `node script/generate_jcode_ui_api_docs.mjs`.
+>
+> Human-written guides: [Types](/chat-ui/docs/api/types) · [Runtime](/chat-ui/docs/api/runtime) · [Hooks](/chat-ui/docs/api/hooks) · [Primitives](/chat-ui/docs/api/primitives) · [Components](/chat-ui/docs/api/components).
+
+**104** public symbols extracted.
+
+## `jcode-ui`
+
+| Symbol | Kind | Source |
+|--------|------|--------|
+| [`ApprovalBanner`](#jcode-ui-approvalbanner) | const | `packages/jcode-ui/src/components/ApprovalBanner.tsx` |
+| [`AskUserCard`](#jcode-ui-askusercard) | const | `packages/jcode-ui/src/components/AskUserCard.tsx` |
+| [`Attachment`](#jcode-ui-attachment) | const | `packages/jcode-ui/src/components/Attachment.tsx` |
+| [`AttachmentList`](#jcode-ui-attachmentlist) | const | `packages/jcode-ui/src/components/Attachment.tsx` |
+| [`BrowserShotRenderer`](#jcode-ui-browsershotrenderer) | const | `packages/jcode-ui/src/toolRenderers/browserShot.tsx` |
+| [`ChatInput`](#jcode-ui-chatinput) | const | `packages/jcode-ui/src/components/ChatInput.tsx` |
+| [`ContextBar`](#jcode-ui-contextbar) | const | `packages/jcode-ui/src/components/ContextBar.tsx` |
+| [`DiffRenderer`](#jcode-ui-diffrenderer) | const | `packages/jcode-ui/src/toolRenderers/diff.tsx` |
+| [`FileViewerRenderer`](#jcode-ui-fileviewerrenderer) | const | `packages/jcode-ui/src/toolRenderers/fileViewer.tsx` |
+| [`GenericRenderer`](#jcode-ui-genericrenderer) | const | `packages/jcode-ui/src/toolRenderers/generic.tsx` |
+| [`Message`](#jcode-ui-message) | const | `packages/jcode-ui/src/components/Message.tsx` |
+| [`SearchRenderer`](#jcode-ui-searchrenderer) | const | `packages/jcode-ui/src/toolRenderers/search.tsx` |
+| [`SkillRenderer`](#jcode-ui-skillrenderer) | const | `packages/jcode-ui/src/toolRenderers/skill.tsx` |
+| [`TeamCreateRenderer`](#jcode-ui-teamcreaterenderer) | const | `packages/jcode-ui/src/toolRenderers/team.tsx` |
+| [`TeamListRenderer`](#jcode-ui-teamlistrenderer) | const | `packages/jcode-ui/src/toolRenderers/team.tsx` |
+| [`TeamMessageRenderer`](#jcode-ui-teammessagerenderer) | const | `packages/jcode-ui/src/toolRenderers/team.tsx` |
+| [`TeamSpawnRenderer`](#jcode-ui-teamspawnrenderer) | const | `packages/jcode-ui/src/toolRenderers/team.tsx` |
+| [`TodoRenderer`](#jcode-ui-todorenderer) | const | `packages/jcode-ui/src/toolRenderers/todo.tsx` |
+| [`ToolCallCard`](#jcode-ui-toolcallcard) | const | `packages/jcode-ui/src/components/ToolCallCard.tsx` |
+| [`ApiBaseProvider`](#jcode-ui-apibaseprovider) | function | `packages/jcode-ui/src/lib/apiBaseContext.tsx` |
+| [`createDefaultToolRegistry`](#jcode-ui-createdefaulttoolregistry) | function | `packages/jcode-ui/src/components/ToolRegistryContext.tsx` |
+| [`Reasoning`](#jcode-ui-reasoning) | function | `packages/jcode-ui/src/components/Reasoning.tsx` |
+| [`renderMarkdown`](#jcode-ui-rendermarkdown) | function | `packages/jcode-ui/src/lib/markdown.ts` |
+| [`Sources`](#jcode-ui-sources) | function | `packages/jcode-ui/src/components/Sources.tsx` |
+| [`Thread`](#jcode-ui-thread) | function | `packages/jcode-ui/src/components/Thread.tsx` |
+| [`ToolRegistryProvider`](#jcode-ui-toolregistryprovider) | function | `packages/jcode-ui/src/components/ToolRegistryContext.tsx` |
+| [`truncate`](#jcode-ui-truncate) | function | `packages/jcode-ui/src/toolRenderers/terminal.tsx` |
+| [`useToolRegistry`](#jcode-ui-usetoolregistry) | function | `packages/jcode-ui/src/components/ToolRegistryContext.tsx` |
+| [`ApiBaseProviderProps`](#jcode-ui-apibaseproviderprops) | interface | `packages/jcode-ui/src/lib/apiBaseContext.tsx` |
+| [`ApprovalBannerProps`](#jcode-ui-approvalbannerprops) | interface | `packages/jcode-ui/src/components/ApprovalBanner.tsx` |
+| [`AskUserCardProps`](#jcode-ui-askusercardprops) | interface | `packages/jcode-ui/src/components/AskUserCard.tsx` |
+| [`AttachmentListProps`](#jcode-ui-attachmentlistprops) | interface | `packages/jcode-ui/src/components/Attachment.tsx` |
+| [`AttachmentProps`](#jcode-ui-attachmentprops) | interface | `packages/jcode-ui/src/components/Attachment.tsx` |
+| [`ChatInputProps`](#jcode-ui-chatinputprops) | interface | `packages/jcode-ui/src/components/ChatInput.tsx` |
+| [`ContextBarProps`](#jcode-ui-contextbarprops) | interface | `packages/jcode-ui/src/components/ContextBar.tsx` |
+| [`MessageProps`](#jcode-ui-messageprops) | interface | `packages/jcode-ui/src/components/Message.tsx` |
+| [`ReasoningProps`](#jcode-ui-reasoningprops) | interface | `packages/jcode-ui/src/components/Reasoning.tsx` |
+| [`SourcesProps`](#jcode-ui-sourcesprops) | interface | `packages/jcode-ui/src/components/Sources.tsx` |
+| [`ThreadProps`](#jcode-ui-threadprops) | interface | `packages/jcode-ui/src/components/Thread.tsx` |
+| [`ToolCallCardProps`](#jcode-ui-toolcallcardprops) | interface | `packages/jcode-ui/src/components/ToolCallCard.tsx` |
+| [`ToolRegistryProviderProps`](#jcode-ui-toolregistryproviderprops) | interface | `packages/jcode-ui/src/components/ToolRegistryContext.tsx` |
+
+### `ApprovalBanner`
+
+<!-- jcode-ui-approvalbanner -->
+
+`const` · `packages/jcode-ui/src/components/ApprovalBanner.tsx`
+
+```ts
+export const ApprovalBanner = …
+```
+
+### `AskUserCard`
+
+<!-- jcode-ui-askusercard -->
+
+`const` · `packages/jcode-ui/src/components/AskUserCard.tsx`
+
+```ts
+export const AskUserCard = …
+```
+
+### `Attachment`
+
+<!-- jcode-ui-attachment -->
+
+`const` · `packages/jcode-ui/src/components/Attachment.tsx`
+
+```ts
+export const Attachment = …
+```
+
+### `AttachmentList`
+
+<!-- jcode-ui-attachmentlist -->
+
+`const` · `packages/jcode-ui/src/components/Attachment.tsx`
+
+```ts
+export const AttachmentList = …
+```
+
+### `BrowserShotRenderer`
+
+<!-- jcode-ui-browsershotrenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/browserShot.tsx`
+
+```ts
+export const BrowserShotRenderer = …
+```
+
+### `ChatInput`
+
+<!-- jcode-ui-chatinput -->
+
+`const` · `packages/jcode-ui/src/components/ChatInput.tsx`
+
+```ts
+export const ChatInput = …
+```
+
+### `ContextBar`
+
+<!-- jcode-ui-contextbar -->
+
+`const` · `packages/jcode-ui/src/components/ContextBar.tsx`
+
+```ts
+export const ContextBar = …
+```
+
+### `DiffRenderer`
+
+<!-- jcode-ui-diffrenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/diff.tsx`
+
+```ts
+export const DiffRenderer = …
+```
+
+### `FileViewerRenderer`
+
+<!-- jcode-ui-fileviewerrenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/fileViewer.tsx`
+
+```ts
+export const FileViewerRenderer = …
+```
+
+### `GenericRenderer`
+
+<!-- jcode-ui-genericrenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/generic.tsx`
+
+```ts
+export const GenericRenderer = …
+```
+
+### `Message`
+
+<!-- jcode-ui-message -->
+
+`const` · `packages/jcode-ui/src/components/Message.tsx`
+
+```ts
+export const Message = …
+```
+
+### `SearchRenderer`
+
+<!-- jcode-ui-searchrenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/search.tsx`
+
+```ts
+export const SearchRenderer = …
+```
+
+### `SkillRenderer`
+
+<!-- jcode-ui-skillrenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/skill.tsx`
+
+```ts
+export const SkillRenderer = …
+```
+
+### `TeamCreateRenderer`
+
+<!-- jcode-ui-teamcreaterenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/team.tsx`
+
+```ts
+export const TeamCreateRenderer = …
+```
+
+### `TeamListRenderer`
+
+<!-- jcode-ui-teamlistrenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/team.tsx`
+
+```ts
+export const TeamListRenderer = …
+```
+
+### `TeamMessageRenderer`
+
+<!-- jcode-ui-teammessagerenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/team.tsx`
+
+```ts
+export const TeamMessageRenderer = …
+```
+
+### `TeamSpawnRenderer`
+
+<!-- jcode-ui-teamspawnrenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/team.tsx`
+
+```ts
+export const TeamSpawnRenderer = …
+```
+
+### `TodoRenderer`
+
+<!-- jcode-ui-todorenderer -->
+
+`const` · `packages/jcode-ui/src/toolRenderers/todo.tsx`
+
+```ts
+export const TodoRenderer = …
+```
+
+### `ToolCallCard`
+
+<!-- jcode-ui-toolcallcard -->
+
+`const` · `packages/jcode-ui/src/components/ToolCallCard.tsx`
+
+```ts
+export const ToolCallCard = …
+```
+
+### `ApiBaseProvider`
+
+<!-- jcode-ui-apibaseprovider -->
+
+`function` · `packages/jcode-ui/src/lib/apiBaseContext.tsx`
+
+```ts
+export function ApiBaseProvider({ apiBase, children }: ApiBaseProviderProps) { … }
+```
+
+### `createDefaultToolRegistry`
+
+<!-- jcode-ui-createdefaulttoolregistry -->
+
+`function` · `packages/jcode-ui/src/components/ToolRegistryContext.tsx`
+
+ToolRendererRegistry context — the host provides a registry (built with
+createDefaultToolRegistry or a custom one) once at the app root, and every
+ToolCallCard reads from it. This avoids prop-drilling the registry through
+every component.
+/
+
+import { createContext, useContext } from 'react'
+import type { ReactNode } from 'react'
+import { createToolRendererRegistry } from 'jcode-ui-core/adapters'
+import type { ToolRendererRegistry, ToolRenderer } from 'jcode-ui-core/adapters'
+import { TerminalRenderer } from '../toolRenderers/terminal.js'
+import { FileViewerRenderer } from '../toolRenderers/fileViewer.js'
+import { DiffRenderer } from '../toolRenderers/diff.js'
+import { SearchRenderer } from '../toolRenderers/search.js'
+import { TodoRenderer } from '../toolRenderers/todo.js'
+import { SkillRenderer } from '../toolRenderers/skill.js'
+import {
+  TeamListRenderer,
+  TeamMessageRenderer,
+  TeamCreateRenderer,
+  TeamSpawnRenderer,
+} from '../toolRenderers/team.js'
+import { BrowserShotRenderer } from '../toolRenderers/browserShot.js'
+import { GenericRenderer } from '../toolRenderers/generic.js'
+
+const Ctx = createContext<ToolRendererRegistry | null>(null)
+
+/** Build the jcode default registry (matches Vue ToolCallCard renderType map).
+
+```ts
+export function createDefaultToolRegistry(): ToolRendererRegistry { … }
+```
+
+### `Reasoning`
+
+<!-- jcode-ui-reasoning -->
+
+`function` · `packages/jcode-ui/src/components/Reasoning.tsx`
+
+```ts
+export function Reasoning({ reasoning, defaultExpanded = false, durationMs }: ReasoningProps) { … }
+```
+
+### `renderMarkdown`
+
+<!-- jcode-ui-rendermarkdown -->
+
+`function` · `packages/jcode-ui/src/lib/markdown.ts`
+
+```ts
+export function renderMarkdown(text: string): string { … }
+```
+
+### `Sources`
+
+<!-- jcode-ui-sources -->
+
+`function` · `packages/jcode-ui/src/components/Sources.tsx`
+
+```ts
+export function Sources({ sources }: SourcesProps) { … }
+```
+
+### `Thread`
+
+<!-- jcode-ui-thread -->
+
+`function` · `packages/jcode-ui/src/components/Thread.tsx`
+
+```ts
+export function Thread({
+  virtualize,
+  emptyState,
+  renderPending,
+  className,
+  overscanBottom,
+}: ThreadProps): ReactNode { … }
+```
+
+### `ToolRegistryProvider`
+
+<!-- jcode-ui-toolregistryprovider -->
+
+`function` · `packages/jcode-ui/src/components/ToolRegistryContext.tsx`
+
+```ts
+export function ToolRegistryProvider({ registry, children }: ToolRegistryProviderProps) { … }
+```
+
+### `truncate`
+
+<!-- jcode-ui-truncate -->
+
+`function` · `packages/jcode-ui/src/toolRenderers/terminal.tsx`
+
+TerminalRenderer — `execute` tool (matches Vue ToolCallCard terminal block).
+Renders inside `.toolcall-body` — no outer border of its own.
+Background is muted (not code-bg); `$ ` prefix is muted-foreground.
+/
+
+import { memo } from 'react'
+import type { ToolRendererProps } from 'jcode-ui-core/adapters'
+
+export const TerminalRenderer = memo(function TerminalRenderer({
+  args,
+  output,
+  displayOutput,
+  error,
+  status,
+}: ToolRendererProps) {
+  let command = ''
+  try {
+    const parsed = JSON.parse(args)
+    command = parsed.command ?? ''
+  } catch {
+    // ignore
+  }
+  const body = displayOutput || output || ''
+  return (
+    <div
+      className="jcode-terminal max-h-72 overflow-y-auto px-3 py-2 font-mono text-xs"
+      style={{ background: 'var(--color-muted)' }}
+    >
+      {command && (
+        <div>
+          <span className="select-none" style={{ color: 'var(--color-muted-foreground)' }}>
+            ${' '}
+          </span>
+          <span style={{ color: 'var(--color-foreground)' }}>{command}</span>
+        </div>
+      )}
+      {body && (
+        <div
+          className="mt-1 whitespace-pre-wrap break-all"
+          style={{ color: 'var(--color-muted-foreground)' }}
+        >
+          {truncate(body, 2000)}
+        </div>
+      )}
+      {error && (
+        <div className="mt-1 whitespace-pre-wrap" style={{ color: 'var(--color-error-fg)' }}>
+          {error}
+        </div>
+      )}
+      {status === 'running' && (
+        <div className="mt-1 animate-pulse" style={{ color: 'var(--color-muted-foreground)' }}>
+          Running…
+        </div>
+      )}
+    </div>
+  )
+})
+
+/** Count code points (not UTF-16 units) so CJK truncation is fair.
+
+```ts
+export function truncate(text: string, max: number): string { … }
+```
+
+### `useToolRegistry`
+
+<!-- jcode-ui-usetoolregistry -->
+
+`function` · `packages/jcode-ui/src/components/ToolRegistryContext.tsx`
+
+```ts
+export function useToolRegistry(): ToolRendererRegistry { … }
+```
+
+### `ApiBaseProviderProps`
+
+<!-- jcode-ui-apibaseproviderprops -->
+
+`interface` · `packages/jcode-ui/src/lib/apiBaseContext.tsx`
+
+```ts
+export interface ApiBaseProviderProps {
+  /** API base URL with no trailing slash. */
+  apiBase: string
+  children: React.ReactNode
+}
+```
+
+### `ApprovalBannerProps`
+
+<!-- jcode-ui-approvalbannerprops -->
+
+`interface` · `packages/jcode-ui/src/components/ApprovalBanner.tsx`
+
+```ts
+export interface ApprovalBannerProps {
+  approval: Approval
+}
+```
+
+### `AskUserCardProps`
+
+<!-- jcode-ui-askusercardprops -->
+
+`interface` · `packages/jcode-ui/src/components/AskUserCard.tsx`
+
+```ts
+export interface AskUserCardProps {
+  tool: ToolCall
+}
+```
+
+### `AttachmentListProps`
+
+<!-- jcode-ui-attachmentlistprops -->
+
+`interface` · `packages/jcode-ui/src/components/Attachment.tsx`
+
+```ts
+export interface AttachmentListProps {
+  images: ChatImage[]
+  onRemove?: (index: number) => void
+  size?: number
+}
+```
+
+### `AttachmentProps`
+
+<!-- jcode-ui-attachmentprops -->
+
+`interface` · `packages/jcode-ui/src/components/Attachment.tsx`
+
+```ts
+export interface AttachmentProps {
+  image: ChatImage
+  /** Optional remove handler — renders the × button when provided. */
+  onRemove?: () => void
+  /** Thumbnail size in px. Default 64. */
+  size?: number
+}
+```
+
+### `ChatInputProps`
+
+<!-- jcode-ui-chatinputprops -->
+
+`interface` · `packages/jcode-ui/src/components/ChatInput.tsx`
+
+```ts
+export interface ChatInputProps {
+  /** Slash commands (host-fetched). */
+  slashCommands?: SlashCommand[]
+  /** Allow image attachments (gated by model vision support). */
+  allowImages?: boolean
+  /** Placeholder text. */
+  placeholder?: string
+  /** Show the context bar suffix. Default true. */
+  showContextBar?: boolean
+  /** Callback after a message is sent/queued (host snaps timeline to bottom). */
+  onSent?: () => void
+}
+```
+
+### `ContextBarProps`
+
+<!-- jcode-ui-contextbarprops -->
+
+`interface` · `packages/jcode-ui/src/components/ContextBar.tsx`
+
+```ts
+export interface ContextBarProps {
+  /** Optional host-provided context breakdown for the popover. */
+  breakdown?: TaskContextBreakdown | null
+  /** Diameter of the ring in px. Default 20. */
+  size?: number
+  /** Threshold (0-1) above which the ring turns red. Default 0.9. */
+  dangerThreshold?: number
+  /** Show the popover on hover. Default true. */
+  showPopover?: boolean
+}
+```
+
+### `MessageProps`
+
+<!-- jcode-ui-messageprops -->
+
+`interface` · `packages/jcode-ui/src/components/Message.tsx`
+
+```ts
+export interface MessageProps {
+  message: MessageData
+  /** Allow editing (typically user messages when idle). */
+  canEdit?: boolean
+}
+```
+
+### `ReasoningProps`
+
+<!-- jcode-ui-reasoningprops -->
+
+`interface` · `packages/jcode-ui/src/components/Reasoning.tsx`
+
+```ts
+export interface ReasoningProps {
+  /** The reasoning text (markdown). */
+  reasoning: string
+  /** Default expanded. Default false. */
+  defaultExpanded?: boolean
+  /** Show a "Thought for Ns" label using the message duration. */
+  durationMs?: number
+}
+```
+
+### `SourcesProps`
+
+<!-- jcode-ui-sourcesprops -->
+
+`interface` · `packages/jcode-ui/src/components/Sources.tsx`
+
+```ts
+export interface SourcesProps {
+  sources: MessageSource[]
+}
+```
+
+### `ThreadProps`
+
+<!-- jcode-ui-threadprops -->
+
+`interface` · `packages/jcode-ui/src/components/Thread.tsx`
+
+```ts
+export interface ThreadProps {
+  /** Disable virtualization (short/replay timelines). Default true. */
+  virtualize?: boolean
+  /** Empty-state node. */
+  emptyState?: ReactNode
+  /** Override the pending ("Thinking…") indicator. */
+  renderPending?: () => ReactNode
+  /** className passthrough for the scroll container. */
+  className?: string
+  /** Extra bottom padding (px) to clear a sticky composer. */
+  overscanBottom?: number
+}
+```
+
+### `ToolCallCardProps`
+
+<!-- jcode-ui-toolcallcardprops -->
+
+`interface` · `packages/jcode-ui/src/components/ToolCallCard.tsx`
+
+```ts
+export interface ToolCallCardProps {
+  tool: ToolCall
+  /** Override the registry (defaults to the context-provided one). */
+  registry?: ToolRendererRegistry
+  /** Extra classes (e.g. pl-9 to indent under the message content column). */
+  className?: string
+  /** Nesting depth for subagent children. */
+  depth?: number
+}
+```
+
+### `ToolRegistryProviderProps`
+
+<!-- jcode-ui-toolregistryproviderprops -->
+
+`interface` · `packages/jcode-ui/src/components/ToolRegistryContext.tsx`
+
+```ts
+export interface ToolRegistryProviderProps {
+  /** Defaults to createDefaultToolRegistry() if omitted. */
+  registry?: ToolRendererRegistry
+  children: ReactNode
+}
+```
+
+## `jcode-ui-core`
+
+| Symbol | Kind | Source |
+|--------|------|--------|
+| [`ToolRendererRegistry`](#jcode-ui-core-toolrendererregistry) | class | `packages/jcode-ui-core/src/adapters/index.ts` |
+| [`ApprovalBlock`](#jcode-ui-core-approvalblock) | function | `packages/jcode-ui-core/src/primitives/ApprovalBlock.tsx` |
+| [`Composer`](#jcode-ui-core-composer) | function | `packages/jcode-ui-core/src/primitives/Composer.tsx` |
+| [`createExternalStoreRuntime`](#jcode-ui-core-createexternalstoreruntime) | function | `packages/jcode-ui-core/src/runtime/externalStore.ts` |
+| [`createMockRuntime`](#jcode-ui-core-createmockruntime) | function | `packages/jcode-ui-core/src/runtime/mockRuntime.ts` |
+| [`createToolRendererRegistry`](#jcode-ui-core-createtoolrendererregistry) | function | `packages/jcode-ui-core/src/adapters/index.ts` |
+| [`isApprovalItem`](#jcode-ui-core-isapprovalitem) | function | `packages/jcode-ui-core/src/types/index.ts` |
+| [`isMessageItem`](#jcode-ui-core-ismessageitem) | function | `packages/jcode-ui-core/src/types/index.ts` |
+| [`isToolItem`](#jcode-ui-core-istoolitem) | function | `packages/jcode-ui-core/src/types/index.ts` |
+| [`MessageView`](#jcode-ui-core-messageview) | function | `packages/jcode-ui-core/src/primitives/MessageView.tsx` |
+| [`normalizeState`](#jcode-ui-core-normalizestate) | function | `packages/jcode-ui-core/src/runtime/index.ts` |
+| [`parseResolvedAnswers`](#jcode-ui-core-parseresolvedanswers) | function | `packages/jcode-ui-core/src/primitives/AskUserBlock.tsx` |
+| [`RuntimeProvider`](#jcode-ui-core-runtimeprovider) | function | `packages/jcode-ui-core/src/runtime/context.tsx` |
+| [`Thread`](#jcode-ui-core-thread) | function | `packages/jcode-ui-core/src/primitives/Thread.tsx` |
+| [`ToolCallProvider`](#jcode-ui-core-toolcallprovider) | function | `packages/jcode-ui-core/src/primitives/ToolCallView.tsx` |
+| [`ToolCallView`](#jcode-ui-core-toolcallview) | function | `packages/jcode-ui-core/src/primitives/ToolCallView.tsx` |
+| [`useAutoScroll`](#jcode-ui-core-useautoscroll) | function | `packages/jcode-ui-core/src/hooks/index.ts` |
+| [`useFocusOnIdle`](#jcode-ui-core-usefocusonidle) | function | `packages/jcode-ui-core/src/hooks/index.ts` |
+| [`useIsAtBottom`](#jcode-ui-core-useisatbottom) | function | `packages/jcode-ui-core/src/hooks/index.ts` |
+| [`useQueuedMessages`](#jcode-ui-core-usequeuedmessages) | function | `packages/jcode-ui-core/src/hooks/index.ts` |
+| [`useRuntimeActions`](#jcode-ui-core-useruntimeactions) | function | `packages/jcode-ui-core/src/runtime/context.tsx` |
+| [`useRuntimeSelector`](#jcode-ui-core-useruntimeselector) | function | `packages/jcode-ui-core/src/runtime/context.tsx` |
+| [`useRuntimeState`](#jcode-ui-core-useruntimestate) | function | `packages/jcode-ui-core/src/runtime/context.tsx` |
+| [`useStreamFollow`](#jcode-ui-core-usestreamfollow) | function | `packages/jcode-ui-core/src/hooks/index.ts` |
+| [`useToolCallContext`](#jcode-ui-core-usetoolcallcontext) | function | `packages/jcode-ui-core/src/primitives/ToolCallView.tsx` |
+| [`Approval`](#jcode-ui-core-approval) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ApprovalBlockProps`](#jcode-ui-core-approvalblockprops) | interface | `packages/jcode-ui-core/src/primitives/ApprovalBlock.tsx` |
+| [`ApprovalBlockRenderSlots`](#jcode-ui-core-approvalblockrenderslots) | interface | `packages/jcode-ui-core/src/primitives/ApprovalBlock.tsx` |
+| [`AskUserAnswer`](#jcode-ui-core-askuseranswer) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`AskUserControls`](#jcode-ui-core-askusercontrols) | interface | `packages/jcode-ui-core/src/primitives/AskUserBlock.tsx` |
+| [`AskUserOption`](#jcode-ui-core-askuseroption) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`AskUserQuestion`](#jcode-ui-core-askuserquestion) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ChatImage`](#jcode-ui-core-chatimage) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ChatRuntime`](#jcode-ui-core-chatruntime) | interface | `packages/jcode-ui-core/src/runtime/index.ts` |
+| [`ComposerProps`](#jcode-ui-core-composerprops) | interface | `packages/jcode-ui-core/src/primitives/Composer.tsx` |
+| [`ComposerRenderSlots`](#jcode-ui-core-composerrenderslots) | interface | `packages/jcode-ui-core/src/primitives/Composer.tsx` |
+| [`Goal`](#jcode-ui-core-goal) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`Message`](#jcode-ui-core-message) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`MessageActions`](#jcode-ui-core-messageactions) | interface | `packages/jcode-ui-core/src/primitives/MessageView.tsx` |
+| [`MessageSource`](#jcode-ui-core-messagesource) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`MessageViewProps`](#jcode-ui-core-messageviewprops) | interface | `packages/jcode-ui-core/src/primitives/MessageView.tsx` |
+| [`QueuedMessage`](#jcode-ui-core-queuedmessage) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`RuntimeActions`](#jcode-ui-core-runtimeactions) | interface | `packages/jcode-ui-core/src/runtime/index.ts` |
+| [`RuntimeState`](#jcode-ui-core-runtimestate) | interface | `packages/jcode-ui-core/src/runtime/index.ts` |
+| [`SlashCommand`](#jcode-ui-core-slashcommand) | interface | `packages/jcode-ui-core/src/primitives/Composer.tsx` |
+| [`SlashMenuState`](#jcode-ui-core-slashmenustate) | interface | `packages/jcode-ui-core/src/primitives/Composer.tsx` |
+| [`TaskContextBreakdown`](#jcode-ui-core-taskcontextbreakdown) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ThreadProps`](#jcode-ui-core-threadprops) | interface | `packages/jcode-ui-core/src/primitives/Thread.tsx` |
+| [`ThreadRenderSlots`](#jcode-ui-core-threadrenderslots) | interface | `packages/jcode-ui-core/src/primitives/Thread.tsx` |
+| [`TodoItem`](#jcode-ui-core-todoitem) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`TokenSnapshot`](#jcode-ui-core-tokensnapshot) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ToolCall`](#jcode-ui-core-toolcall) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ToolCallContextValue`](#jcode-ui-core-toolcallcontextvalue) | interface | `packages/jcode-ui-core/src/primitives/ToolCallView.tsx` |
+| [`ToolCallViewProps`](#jcode-ui-core-toolcallviewprops) | interface | `packages/jcode-ui-core/src/primitives/ToolCallView.tsx` |
+| [`ToolDisplayInfo`](#jcode-ui-core-tooldisplayinfo) | interface | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ToolRendererProps`](#jcode-ui-core-toolrendererprops) | interface | `packages/jcode-ui-core/src/adapters/index.ts` |
+| [`GoalStatus`](#jcode-ui-core-goalstatus) | type | `packages/jcode-ui-core/src/types/index.ts` |
+| [`PartialRuntimeState`](#jcode-ui-core-partialruntimestate) | type | `packages/jcode-ui-core/src/runtime/index.ts` |
+| [`Role`](#jcode-ui-core-role) | type | `packages/jcode-ui-core/src/types/index.ts` |
+| [`SystemLevel`](#jcode-ui-core-systemlevel) | type | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ThreadItem`](#jcode-ui-core-threaditem) | type | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ThreadItemKind`](#jcode-ui-core-threaditemkind) | type | `packages/jcode-ui-core/src/types/index.ts` |
+| [`ToolRenderer`](#jcode-ui-core-toolrenderer) | type | `packages/jcode-ui-core/src/adapters/index.ts` |
+
+### `ToolRendererRegistry`
+
+<!-- jcode-ui-core-toolrendererregistry -->
+
+`class` · `packages/jcode-ui-core/src/adapters/index.ts`
+
+Name-keyed registry of tool renderers, with a fallback. Lookups are
+case-sensitive and exact (no globbing) — keep tool names stable.
+
+Register a single renderer, or a whole map at once. The registry is mutable
+so consumers can register at app bootstrap and add more later.
+
+```ts
+export class ToolRendererRegistry {
+  private renderers = new Map<string, ToolRenderer>()
+  private fallback: ToolRenderer | null = null
+
+  /** Register a renderer for one or more tool names (later writes win). */
+  register(name: string, renderer: ToolRenderer): this
+  register(names: string[], renderer: ToolRenderer): this
+  register(nameOrNames: string | string[], renderer: ToolRenderer): this {
+    const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames]
+    for (const n of names) this.renderers.set(n, renderer)
+    return this
+  }
+
+  /** Register a batch of { name → renderer } entries. */
+  registerAll(entries: Record<string, ToolRenderer>): this {
+    for (const [name, renderer] of Object.entries(entries)) {
+      this.renderers.set(name, renderer)
+    }
+    return this
+  }
+
+  /** Set the renderer used when no name-specific match exists. */
+  setFallback(renderer: ToolRenderer): this {
+    this.fallback = renderer
+    return this
+  }
+
+  /** Look up a renderer by tool name, falling back if absent. Returns null
+   *  only when nothing is registered AND no fallback is set. */
+  get(name: string): ToolRenderer | null {
+    return this.renderers.get(name) ?? this.fallback
+  }
+
+  /** True if a name-specific renderer is registered. */
+  has(name: string): boolean {
+    return this.renderers.has(name)
+  }
+}
+```
+
+### `ApprovalBlock`
+
+<!-- jcode-ui-core-approvalblock -->
+
+`function` · `packages/jcode-ui-core/src/primitives/ApprovalBlock.tsx`
+
+```ts
+export function ApprovalBlock({ approval, className, renderPending, renderResolved }: ApprovalBlockProps): ReactNode { … }
+```
+
+### `Composer`
+
+<!-- jcode-ui-core-composer -->
+
+`function` · `packages/jcode-ui-core/src/primitives/Composer.tsx`
+
+```ts
+export function Composer({
+  placeholder = 'Send a message…',
+  maxRows = DEFAULT_MAX_ROWS_PX,
+  slashCommands,
+  allowImages = false,
+  maxImageBytes = 10 * 1024 * 1024,
+  ariaLabel = 'Message input',
+  defaultValue = '',
+  className,
+  onSent,
+  renderSlashMenu,
+  renderQueue,
+  renderSubmitButton,
+  renderAttachments,
+  renderPrefix,
+  renderSuffix,
+}: ComposerProps): ReactNode { … }
+```
+
+### `createExternalStoreRuntime`
+
+<!-- jcode-ui-core-createexternalstoreruntime -->
+
+`function` · `packages/jcode-ui-core/src/runtime/externalStore.ts`
+
+ExternalStoreRuntime — wrap any Redux-shaped external store as a ChatRuntime.
+
+The host store holds the *full* app state (e.g. an RTK root state with many
+slices). We select just the `RuntimeState` slice out of it via a provided
+selector, and bind the action callbacks. The resulting `ChatRuntime` is what
+jcode-ui components consume.
+
+Snapshot caching: the host store's state reference changes only when a reducer
+dispatches. We cache the normalized RuntimeState keyed on that raw reference,
+so `getState()` returns a stable identity between dispatches — a hard
+requirement for React's `useSyncExternalStore` (which loops otherwise).
+/
+
+import type { ChatRuntime, PartialRuntimeState, RuntimeActions } from './index.js'
+import { normalizeState } from './index.js'
+
+export interface ExternalStoreRuntimeOptions<THostState> {
+  /** The external store. Must expose Redux-compatible getState/subscribe. */
+  store: {
+    getState: () => THostState
+    subscribe: (listener: () => void) => () => void
+  }
+  /** Project the host state down to a (possibly partial) RuntimeState. */
+  select: (state: THostState) => PartialRuntimeState
+  /** Action bag. Identity should be stable across renders. */
+  actions: RuntimeActions
+}
+
+/**
+Wrap an external store as a ChatRuntime. The returned object's `getState`
+always returns a fully-populated RuntimeState (missing slices defaulted), and
+returns the SAME object reference between dispatches (so it's safe to pass to
+useSyncExternalStore's getSnapshot).
+
+```ts
+export function createExternalStoreRuntime<THostState>(
+  opts: ExternalStoreRuntimeOptions<THostState>,
+): ChatRuntime { … }
+```
+
+### `createMockRuntime`
+
+<!-- jcode-ui-core-createmockruntime -->
+
+`function` · `packages/jcode-ui-core/src/runtime/mockRuntime.ts`
+
+MockRuntime — a self-contained, scriptable ChatRuntime for demos, docs, and
+tests. No backend required: you feed it a "script" of items + a streaming
+text fragment sequence, and it emits them on a timer. This is what powers the
+website playground and visual-regression fixtures.
+
+It's read-only-ish: action callbacks are captured (so you can assert on them)
+but don't drive scripted playback — the script is the source of truth.
+/
+
+import type { ChatRuntime, PartialRuntimeState, RuntimeActions, RuntimeState } from './index.js'
+import { normalizeState } from './index.js'
+import type { ThreadItem } from '../types/index.js'
+
+export interface MockRuntimeOptions {
+  /** Initial items. */
+  items?: ThreadItem[]
+  /** Initial isRunning flag. */
+  isRunning?: boolean
+  /** Initial full/partial runtime state (overrides items/isRunning when set). */
+  state?: PartialRuntimeState
+  /** Captured-action handlers (defaults are no-ops that record to `.calls`). */
+  actions?: Partial<RuntimeActions>
+}
+
+/**
+Create a ChatRuntime backed by an in-memory store with pub/sub. Exposes
+imperative mutators (`setItems`, `push`, `appendText`, `setRunning`, `patchState`)
+so a script driver (or a test / docs demo) can evolve the state over time.
+
+```ts
+export function createMockRuntime(opts: MockRuntimeOptions = {}): ChatRuntime & { … }
+```
+
+### `createToolRendererRegistry`
+
+<!-- jcode-ui-core-createtoolrendererregistry -->
+
+`function` · `packages/jcode-ui-core/src/adapters/index.ts`
+
+Register a renderer for one or more tool names (later writes win). */
+  register(name: string, renderer: ToolRenderer): this
+  register(names: string[], renderer: ToolRenderer): this
+  register(nameOrNames: string | string[], renderer: ToolRenderer): this {
+    const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames]
+    for (const n of names) this.renderers.set(n, renderer)
+    return this
+  }
+
+  /** Register a batch of { name → renderer } entries. */
+  registerAll(entries: Record<string, ToolRenderer>): this {
+    for (const [name, renderer] of Object.entries(entries)) {
+      this.renderers.set(name, renderer)
+    }
+    return this
+  }
+
+  /** Set the renderer used when no name-specific match exists. */
+  setFallback(renderer: ToolRenderer): this {
+    this.fallback = renderer
+    return this
+  }
+
+  /** Look up a renderer by tool name, falling back if absent. Returns null
+ only when nothing is registered AND no fallback is set. */
+  get(name: string): ToolRenderer | null {
+    return this.renderers.get(name) ?? this.fallback
+  }
+
+  /** True if a name-specific renderer is registered. */
+  has(name: string): boolean {
+    return this.renderers.has(name)
+  }
+}
+
+/** Create a fresh registry. Convenience over `new` for chained registration.
+
+```ts
+export function createToolRendererRegistry(): ToolRendererRegistry { … }
+```
+
+### `isApprovalItem`
+
+<!-- jcode-ui-core-isapprovalitem -->
+
+`function` · `packages/jcode-ui-core/src/types/index.ts`
+
+```ts
+export function isApprovalItem(i: ThreadItem): i is Extract<ThreadItem, { kind: 'approval' }> { … }
+```
+
+### `isMessageItem`
+
+<!-- jcode-ui-core-ismessageitem -->
+
+`function` · `packages/jcode-ui-core/src/types/index.ts`
+
+Type guard helpers (kept generic so consumers can narrow item arrays).
+
+```ts
+export function isMessageItem(i: ThreadItem): i is Extract<ThreadItem, { kind: 'message' }> { … }
+```
+
+### `isToolItem`
+
+<!-- jcode-ui-core-istoolitem -->
+
+`function` · `packages/jcode-ui-core/src/types/index.ts`
+
+```ts
+export function isToolItem(i: ThreadItem): i is Extract<ThreadItem, { kind: 'tool' }> { … }
+```
+
+### `MessageView`
+
+<!-- jcode-ui-core-messageview -->
+
+`function` · `packages/jcode-ui-core/src/primitives/MessageView.tsx`
+
+```ts
+export function MessageView({
+  message,
+  canEdit = false,
+  showCopy = true,
+  className,
+  renderContent,
+  renderAvatar,
+  renderActions,
+}: MessageViewProps): ReactNode { … }
+```
+
+### `normalizeState`
+
+<!-- jcode-ui-core-normalizestate -->
+
+`function` · `packages/jcode-ui-core/src/runtime/index.ts`
+
+Merge a partial state onto the default empty state. Missing slices get
+ safe defaults so components never have to null-check.
+
+```ts
+export function normalizeState(partial: PartialRuntimeState | undefined): RuntimeState { … }
+```
+
+### `parseResolvedAnswers`
+
+<!-- jcode-ui-core-parseresolvedanswers -->
+
+`function` · `packages/jcode-ui-core/src/primitives/AskUserBlock.tsx`
+
+Current selection map (question key → labels). */
+  selected: Record<string, string[]>
+  /** Current "Other" text map (question key → free text). */
+  other: Record<string, string>
+  /** Toggle an option. Honors multi_select. */
+  toggleOption: (question: AskUserQuestion, label: string) => void
+  /** Set the free-text value for a question. */
+  setOther: (question: AskUserQuestion, value: string) => void
+  /** Submit the current selections (no-op if nothing chosen per question). */
+  submit: () => void
+  /** Submit empty answers (skip). */
+  skip: () => void
+}
+
+export interface AskUserBlockRenderSlots {
+  /** Render the pending interactive card. */
+  renderPending?: (questions: AskUserQuestion[], controls: AskUserControls) => ReactNode
+  /** Render the resolved (replay) view. */
+  renderResolved?: (tool: ToolCall, answers: AskUserAnswer[]) => ReactNode
+}
+
+export interface AskUserBlockProps extends AskUserBlockRenderSlots {
+  tool: ToolCall
+  /** className passthrough. */
+  className?: string
+}
+
+const EMPTY_STATE: AskUserState = { selected: {}, other: {} }
+
+export function AskUserBlock({ tool, className, renderPending, renderResolved }: AskUserBlockProps): ReactNode {
+  const actions = useRuntimeActions()
+  const questions = useMemo(() => extractQuestions(tool), [tool])
+  const isPending = !!tool.askUserId && tool.status === 'running' && !tool.output
+
+  const [state, setState] = useState<AskUserState>(EMPTY_STATE)
+
+  const keyOf = useCallback((q: AskUserQuestion) => q.header ?? q.question, [])
+
+  const toggleOption = useCallback(
+    (q: AskUserQuestion, label: string) => {
+      const key = keyOf(q)
+      setState((s) => ({
+        ...s,
+        selected: q.multi_select
+          ? { ...s.selected, [key]: toggle(s.selected[key], label) }
+          : { ...s.selected, [key]: [label] },
+      }))
+    },
+    [keyOf],
+  )
+
+  const setOther = useCallback(
+    (q: AskUserQuestion, value: string) => {
+      const key = keyOf(q)
+      setState((s) => ({ ...s, other: { ...s.other, [key]: value } }))
+    },
+    [keyOf],
+  )
+
+  const submit = useCallback(() => {
+    const answers: AskUserAnswer[] = questions.map((q) => {
+      const key = keyOf(q)
+      const sel = state.selected[key] ?? []
+      const other = state.other[key] ?? ''
+      return {
+        question_header: key,
+        answer: sel.length > 0 ? sel.join(', ') : other,
+        selected: sel.length > 0 ? sel : undefined,
+      }
+    })
+    if (tool.askUserId) actions.submitAskUser(tool.askUserId, answers)
+  }, [actions, keyOf, questions, state, tool.askUserId])
+
+  const skip = useCallback(() => {
+    if (tool.askUserId) actions.submitAskUser(tool.askUserId, [])
+  }, [actions, tool.askUserId])
+
+  // Digit-key shortcuts (1-9) select an option for the first unanswered question.
+  useEffect(() => {
+    if (!isPending) return
+    function onKey(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      const n = Number(e.key)
+      if (!Number.isInteger(n) || n < 1 || n > 9) return
+      const q = questions.find((qq) => (state.selected[keyOf(qq)]?.length ?? 0) === 0)
+      if (!q?.options || n > q.options.length) return
+      e.preventDefault()
+      toggleOption(q, q.options[n - 1].label)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isPending, questions, state.selected, keyOf, toggleOption])
+
+  if (!isPending) {
+    const answers = parseResolvedAnswers(tool)
+    return <div className={className}>{renderResolved?.(tool, answers) ?? <DefaultResolved tool={tool} answers={answers} />}</div>
+  }
+
+  const controls: AskUserControls = {
+    selected: state.selected,
+    other: state.other,
+    toggleOption,
+    setOther,
+    submit,
+    skip,
+  }
+
+  return (
+    <div className={className} data-ask-user-id={tool.askUserId}>
+      {renderPending?.(questions, controls) ?? <DefaultPending questions={questions} controls={controls} />}
+    </div>
+  )
+}
+
+/** Extract the questions list from tool fields (with fallbacks). */
+function extractQuestions(tool: ToolCall): AskUserQuestion[] {
+  if (tool.askUserQuestions && tool.askUserQuestions.length > 0) return tool.askUserQuestions
+  try {
+    const parsed = JSON.parse(tool.args)
+    if (Array.isArray(parsed.questions)) return parsed.questions as AskUserQuestion[]
+    if (parsed.question) {
+      // legacy single-question shape
+      return [{ question: parsed.question, options: parsed.options ?? [] }]
+    }
+  } catch {
+    // ignore
+  }
+  return []
+}
+
+/** Best-effort parse of a resolved tool's output into answers (for replay).
+
+```ts
+export function parseResolvedAnswers(tool: ToolCall): AskUserAnswer[] { … }
+```
+
+### `RuntimeProvider`
+
+<!-- jcode-ui-core-runtimeprovider -->
+
+`function` · `packages/jcode-ui-core/src/runtime/context.tsx`
+
+React binding for ChatRuntime: a Context provider + hooks that subscribe via
+`useSyncExternalStore` (the React 18 idiom for external stores — handles
+tearing and concurrent rendering). Selector memoization is layered on top
+with a ref cache so granular reads don't re-render on unrelated changes.
+
+Stability contract: the ChatRuntime's getState() MUST return a stable
+reference between dispatches (the ExternalStoreRuntime + MockRuntime both
+honor this by caching). Without it, useSyncExternalStore infinite-loops.
+/
+
+import { createContext, useContext, useMemo, useRef, useSyncExternalStore } from 'react'
+import type { ReactNode } from 'react'
+import type { ChatRuntime, RuntimeState } from './index.js'
+
+const RuntimeContext = createContext<ChatRuntime | null>(null)
+
+export interface RuntimeProviderProps {
+  runtime: ChatRuntime
+  children: ReactNode
+}
+
+/** Provide a ChatRuntime to a subtree. Components under it read state/actions
+ via `useRuntimeState` / `useRuntimeSelector` / `useRuntimeActions`.
+
+```ts
+export function RuntimeProvider({ runtime, children }: RuntimeProviderProps): ReactNode { … }
+```
+
+### `Thread`
+
+<!-- jcode-ui-core-thread -->
+
+`function` · `packages/jcode-ui-core/src/primitives/Thread.tsx`
+
+```ts
+export function Thread({
+  renderItem,
+  renderPending,
+  renderEmpty,
+  virtualize = true,
+  estimateSize = 80,
+  scrollThreshold = 80,
+  overscanBottom = 0,
+  className,
+  role = 'log',
+  containerRef,
+}: ThreadProps): ReactNode { … }
+```
+
+### `ToolCallProvider`
+
+<!-- jcode-ui-core-toolcallprovider -->
+
+`function` · `packages/jcode-ui-core/src/primitives/ToolCallView.tsx`
+
+```ts
+export function ToolCallProvider({ value, children }: { value: ToolCallContextValue; children: ReactNode }) { … }
+```
+
+### `ToolCallView`
+
+<!-- jcode-ui-core-toolcallview -->
+
+`function` · `packages/jcode-ui-core/src/primitives/ToolCallView.tsx`
+
+```ts
+export function ToolCallView({
+  tool,
+  depth = 0,
+  maxDepth = 4,
+  defaultExpanded,
+  className,
+  renderHeader,
+  renderSubagentOutput,
+}: ToolCallViewProps): ReactNode { … }
+```
+
+### `useAutoScroll`
+
+<!-- jcode-ui-core-useautoscroll -->
+
+`function` · `packages/jcode-ui-core/src/hooks/index.ts`
+
+Behavioral hooks for chat UI primitives. These contain the interaction logic
+the Vue version baked into App.vue (scroll tracking, type-ahead draining,
+etc.) but framework-correct and reusable.
+/
+
+import { useCallback, useEffect, useRef } from 'react'
+import { useRuntimeState } from '../runtime/context.js'
+
+/**
+Auto-scroll-to-bottom tracking: reports whether the user is "at the bottom"
+of a scroll container (within `threshold` px of the bottom edge). When at the
+bottom, streaming content auto-follows; when scrolled up, it does NOT yank the
+user back down (the core streaming-UX contract from the Vue version).
+
+Returns the container ref to attach, the live `isAtBottom` flag, and a
+`scrollToBottom` imperative. The caller decides when to call the latter
+(typically on send, and on new content if `isAtBottom`).
+
+```ts
+export function useAutoScroll<T extends HTMLElement>(threshold = 80) { … }
+```
+
+### `useFocusOnIdle`
+
+<!-- jcode-ui-core-usefocusonidle -->
+
+`function` · `packages/jcode-ui-core/src/hooks/index.ts`
+
+Auto-focus a ref on mount and when `isRunning` flips false (the Vue version
+refocuses the composer when a turn ends).
+
+```ts
+export function useFocusOnIdle<T extends HTMLElement>(isRunning: boolean) { … }
+```
+
+### `useIsAtBottom`
+
+<!-- jcode-ui-core-useisatbottom -->
+
+`function` · `packages/jcode-ui-core/src/hooks/index.ts`
+
+Imperatively scroll to the bottom edge. `behavior` defaults to 'auto'
+ (instant) since this is called mid-stream. */
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
+    const el = ref.current
+    if (!el) return
+    el.scrollTo({ top: el.scrollHeight, behavior })
+    isAtBottomRef.current = true
+  }, [])
+
+  /** Attach to the container's onScroll (or wire a listener). Updates the flag. */
+  const onScroll = useCallback(() => {
+    const el = ref.current
+    if (!el) return
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight
+    isAtBottomRef.current = distance <= threshold
+  }, [threshold])
+
+  /** Read the current flag. Use this in effects; for render, prefer the
+ `useIsAtBottom` hook below which re-renders on change. */
+  const getIsAtBottom = useCallback(() => isAtBottomRef.current, [])
+
+  return { ref, onScroll, scrollToBottom, getIsAtBottom, isAtBottomRef }
+}
+
+/**
+Re-render-friendly version of the at-bottom flag: re-renders the component
+when the flag flips. Use sparingly (the scroll handler runs a lot); for most
+cases the imperative `getIsAtBottom` + an effect is enough.
+
+NOTE: this intentionally tracks a coarse boolean — it only re-renders on
+crossing the threshold, not on every scroll event.
+
+```ts
+export function useIsAtBottom<T extends HTMLElement>(threshold = 80) { … }
+```
+
+### `useQueuedMessages`
+
+<!-- jcode-ui-core-usequeuedmessages -->
+
+`function` · `packages/jcode-ui-core/src/hooks/index.ts`
+
+Track + drain the type-ahead queue: returns the current queued messages.
+Draining is the runtime's job (it sends the next queued message on each turn
+end); this hook just surfaces the queue for rendering.
+
+```ts
+export function useQueuedMessages() { … }
+```
+
+### `useRuntimeActions`
+
+<!-- jcode-ui-core-useruntimeactions -->
+
+`function` · `packages/jcode-ui-core/src/runtime/context.tsx`
+
+Stable handle to the action bag. Identity is owned by the runtime.
+
+```ts
+export function useRuntimeActions() { … }
+```
+
+### `useRuntimeSelector`
+
+<!-- jcode-ui-core-useruntimeselector -->
+
+`function` · `packages/jcode-ui-core/src/runtime/context.tsx`
+
+Subscribe to a derived slice of RuntimeState. The selector MUST be stable
+(memoize with useCallback) or return a primitive; otherwise React will
+re-render on every store change. For object returns, also pass an `isEqual`
+(e.g. shallow-equal) to avoid identity churn.
+
+```ts
+export function useRuntimeSelector<T>(
+  selector: (state: RuntimeState) => T,
+  isEqual: (a: T, b: T) => boolean = Object.is,
+): T {
+  const runtime = useRuntime()
+  // Subscribe to the raw snapshot (stable identity), then memoize the selected
+  // value in a ref so a stable selector returning a primitive doesn't trigger
+  // spurious re-renders.
+  const snapshot = useSyncExternalStore(runtime.subscribe, runtime.getState, runtime.getState)
+  const cacheRef = useRef< { … }
+```
+
+### `useRuntimeState`
+
+<!-- jcode-ui-core-useruntimestate -->
+
+`function` · `packages/jcode-ui-core/src/runtime/context.tsx`
+
+Subscribe to the full RuntimeState. Re-renders on any store change. Prefer
+`useRuntimeSelector` for granular reads to avoid re-rendering on unrelated
+state changes.
+
+```ts
+export function useRuntimeState(): RuntimeState { … }
+```
+
+### `useStreamFollow`
+
+<!-- jcode-ui-core-usestreamfollow -->
+
+`function` · `packages/jcode-ui-core/src/hooks/index.ts`
+
+Stream-follow effect: when the runtime emits new/changed items, scroll to
+bottom ONLY if the user was already at the bottom. This is the declarative
+form of the Vue watch on `timeline.length + lastMessage.content.length`.
+
+`dep` should be a value that changes whenever there's new content to follow
+(e.g. items length, or last-item content length).
+
+```ts
+export function useStreamFollow<T extends HTMLElement>(
+  autoScroll: ReturnType<typeof useAutoScroll<T>>,
+  dep: unknown,
+) { … }
+```
+
+### `useToolCallContext`
+
+<!-- jcode-ui-core-usetoolcallcontext -->
+
+`function` · `packages/jcode-ui-core/src/primitives/ToolCallView.tsx`
+
+```ts
+export function useToolCallContext(): ToolCallContextValue | null { … }
+```
+
+### `Approval`
+
+<!-- jcode-ui-core-approval -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+single-select label or free text. */
+  answer: string
+  /** multi-select labels. */
+  selected?: string[]
+}
+
+/**
+A pending approval gate. While `resolved` is falsy the UI shows the decision
+controls; once resolved it collapses to an inline note.
+
+```ts
+export interface Approval {
+  id: string
+  tool_name: string
+  tool_args: string
+  /** Target outside the workspace root — UI flags it prominently. */
+  is_external: boolean
+  resolved?: boolean
+  approved?: boolean
+  /** True while a resolve request is in flight (disables controls). */
+  resolving?: boolean
+}
+```
+
+### `ApprovalBlockProps`
+
+<!-- jcode-ui-core-approvalblockprops -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/ApprovalBlock.tsx`
+
+```ts
+export interface ApprovalBlockProps extends ApprovalBlockRenderSlots {
+  approval: Approval
+  /** className passthrough. */
+  className?: string
+}
+```
+
+### `ApprovalBlockRenderSlots`
+
+<!-- jcode-ui-core-approvalblockrenderslots -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/ApprovalBlock.tsx`
+
+```ts
+export interface ApprovalBlockRenderSlots {
+  /** Render the pending decision card. Receives the action callbacks. */
+  renderPending?: (
+    approval: Approval,
+    actions: {
+      allowOnce: () => void
+      allowAllArm: () => void
+      allowAllConfirm: () => void
+      allowAllCancel: () => void
+      deny: () => void
+      armed: boolean
+    },
+  ) => ReactNode
+  /** Render the resolved inline note. */
+  renderResolved?: (approval: Approval) => ReactNode
+}
+```
+
+### `AskUserAnswer`
+
+<!-- jcode-ui-core-askuseranswer -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+A resolved `ask_user` answer (mirrors backend AskUserAnswer).
+
+```ts
+export interface AskUserAnswer {
+  question_header: string
+  /** single-select label or free text. */
+  answer: string
+  /** multi-select labels. */
+  selected?: string[]
+}
+```
+
+### `AskUserControls`
+
+<!-- jcode-ui-core-askusercontrols -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/AskUserBlock.tsx`
+
+AskUserBlock — the headless interactive question block.
+
+Owns: the pending/resolved split, per-question selection state (single +
+multi-select), free-text "Other" input, digit-key shortcuts (1-9), and
+dispatching via runtime actions. Does NOT own styling or the output-format
+parsing for resolved display (those live in the styled wrapper).
+
+The `renderPending` slot receives a `controls` object exposing the live
+`selected`/`other` maps plus mutators (`toggleOption`, `setOther`) and the
+`submit`/`skip` actions — so a styled consumer needs no local state.
+/
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import type { AskUserQuestion, AskUserAnswer, ToolCall } from '../types/index.js'
+import { useRuntimeActions } from '../runtime/context.js'
+
+export interface AskUserState {
+  /** Per-question-header selected labels (single-select: one entry; multi: N). */
+  selected: Record<string, string[]>
+  /** Per-question-header free-text "Other" value. */
+  other: Record<string, string>
+}
+
+/** Controls handed to the pending render-prop.
+
+```ts
+export interface AskUserControls {
+  /** Current selection map (question key → labels). */
+  selected: Record<string, string[]>
+  /** Current "Other" text map (question key → free text). */
+  other: Record<string, string>
+  /** Toggle an option. Honors multi_select. */
+  toggleOption: (question: AskUserQuestion, label: string) => void
+  /** Set the free-text value for a question. */
+  setOther: (question: AskUserQuestion, value: string) => void
+  /** Submit the current selections (no-op if nothing chosen per question). */
+  submit: () => void
+  /** Submit empty answers (skip). */
+  skip: () => void
+}
+```
+
+### `AskUserOption`
+
+<!-- jcode-ui-core-askuseroption -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+Backend tool_call_id for precise result matching. */
+  toolCallID?: string
+  name: string
+  args: string
+  output?: string
+  /** Clean output for UI display (metadata stripped). */
+  displayOutput?: string
+  error?: string
+  status: ToolStatus
+  timestamp: number
+  displayInfo?: ToolDisplayInfo
+  /** Nested tool calls (subagent inner calls). */
+  children?: ToolCall[]
+  /** ask_user: request id while awaiting an answer (live runs only). */
+  askUserId?: string
+  /** ask_user: backend-normalized questions to render. */
+  askUserQuestions?: AskUserQuestion[]
+}
+
+/** An option in an `ask_user` question.
+
+```ts
+export interface AskUserOption {
+  label: string
+  description?: string
+}
+```
+
+### `AskUserQuestion`
+
+<!-- jcode-ui-core-askuserquestion -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+A single interactive question posed by the agent mid-run.
+
+```ts
+export interface AskUserQuestion {
+  question: string
+  header?: string
+  options?: AskUserOption[]
+  multi_select?: boolean
+}
+```
+
+### `ChatImage`
+
+<!-- jcode-ui-core-chatimage -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+A base64-encoded image attached to a message (no `data:` prefix).
+
+```ts
+export interface ChatImage {
+  data: string
+  media_type: string
+}
+```
+
+### `ChatRuntime`
+
+<!-- jcode-ui-core-chatruntime -->
+
+`interface` · `packages/jcode-ui-core/src/runtime/index.ts`
+
+Send a user-authored message. `images` are base64 payloads. */
+  sendMessage: (text: string, images?: { data: string; media_type: string }[]) => void
+  /** Enqueue a message while a turn is running (type-ahead). */
+  enqueueMessage: (text: string, images?: { data: string; media_type: string }[]) => void
+  /** Remove a queued message by id (before it is sent). */
+  removeQueuedMessage: (id: string) => void
+  /** Cancel the in-flight turn. */
+  stop: () => void
+  /** Resolve an approval gate. `approveAll` arms "allow all future" semantics. */
+  resolveApproval: (id: string, approved: boolean, approveAll?: boolean) => void
+  /** Answer an `ask_user` batch. */
+  submitAskUser: (id: string, answers: { question_header: string; answer: string; selected?: string[] }[]) => void
+  /** Edit a past user message and resend from that point. */
+  editMessage: (id: string, newText: string) => void
+}
+
+/**
+The contract every jcode-ui data source implements. `getState`/`subscribe`
+deliberately match the Redux `Store` signature so a real RTK store can be
+wrapped with a thin selector + the actions bound.
+
+```ts
+export interface ChatRuntime {
+  getState: () => RuntimeState
+  subscribe: (listener: () => void) => () => void
+  /** Action bag. Stable identity is recommended (consumers should memoize). */
+  readonly actions: RuntimeActions
+}
+```
+
+### `ComposerProps`
+
+<!-- jcode-ui-core-composerprops -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/Composer.tsx`
+
+```ts
+export interface ComposerProps extends ComposerRenderSlots {
+  /** Placeholder text. */
+  placeholder?: string
+  /** Max textarea height in px before it scrolls internally. */
+  maxRows?: number
+  /** Slash commands (fetched by the host). Empty/undefined disables the menu. */
+  slashCommands?: SlashCommand[]
+  /** Whether image attachments are allowed (gated by model vision support). */
+  allowImages?: boolean
+  /** Max image size in bytes (default 10MB). */
+  maxImageBytes?: number
+  /** aria-label for the textarea. */
+  ariaLabel?: string
+  /** Controlled initial value (uncontrolled thereafter). */
+  defaultValue?: string
+  /** className passthrough. */
+  className?: string
+  /** Callback after a message is sent or queued (host snaps timeline to bottom). */
+  onSent?: () => void
+}
+```
+
+### `ComposerRenderSlots`
+
+<!-- jcode-ui-core-composerrenderslots -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/Composer.tsx`
+
+```ts
+export interface ComposerRenderSlots {
+  /** Render the slash-command dropdown when `slashState` is open. */
+  renderSlashMenu?: (state: SlashMenuState) => ReactNode
+  /** Render queued-message chips above the textarea. */
+  renderQueue?: (queued: { id: string; text: string; images?: ChatImage[] }[]) => ReactNode
+  /** Render the send/stop button. `mode` is 'send' or 'stop'. */
+  renderSubmitButton?: (mode: 'send' | 'stop', disabled: boolean) => ReactNode
+  /** Render attached-image thumbnails below the textarea. */
+  renderAttachments?: (imgs: ChatImage[], remove: (i: number) => void) => ReactNode
+  /** Optional content rendered before the textarea inside the input row
+   *  (e.g. a "+" menu button). */
+  renderPrefix?: () => ReactNode
+  /** Optional content rendered after the textarea (e.g. a context ring). */
+  renderSuffix?: () => ReactNode
+}
+```
+
+### `Goal`
+
+<!-- jcode-ui-core-goal -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+An active agent goal (set via /goal or a dedicated control).
+
+```ts
+export interface Goal {
+  objective: string
+  status: GoalStatus
+  tokens_used?: number
+  created_at?: number
+  updated_at?: number
+}
+```
+
+### `Message`
+
+<!-- jcode-ui-core-message -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+A single chat message. Streaming assistant text is represented as a message
+whose `content` grows over time — the runtime owns the accumulation, not the
+component, so `Message` re-renders idempotently on `content` changes.
+
+```ts
+export interface Message {
+  id: string
+  role: Role
+  content: string
+  timestamp: number
+  /** Origin channel for inbound messages (e.g. 'wechat'). Drives avatar tint. */
+  source?: string
+  images?: ChatImage[]
+  /** system-message severity. */
+  level?: SystemLevel
+  /** Optional raw detail (collapsed by default). */
+  detail?: string
+  /** Assistant turn elapsed (ms), stamped on the final message of a turn. */
+  durationMs?: number
+  /** Optional model reasoning / chain-of-thought text (rendered collapsible).
+   *  Mirrors assistant-ui's Reasoning component + OpenAI/Anthropic thinking. */
+  reasoning?: string
+  /** Optional citation sources for the message (rendered as a Sources list).
+   *  Mirrors assistant-ui's Sources component. */
+  sources?: MessageSource[]
+}
+```
+
+### `MessageActions`
+
+<!-- jcode-ui-core-messageactions -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/MessageView.tsx`
+
+MessageView — the headless chat bubble.
+
+Owns: role-aware structure (avatar + label + body + actions), copy/edit
+interactions, and image toggling. Does NOT own markdown rendering (passed in
+via `renderContent`) or styling — the styled jcode-ui `Message` supplies the
+marked+highlight.js+DOMPurify pipeline and token-driven classes.
+
+Streaming is invisible here: `MessageView` just re-renders when
+`message.content` changes. The runtime owns accumulation.
+/
+
+import { useCallback, useState } from 'react'
+import type { ReactNode } from 'react'
+import type { Message } from '../types/index.js'
+import { useRuntimeActions } from '../runtime/context.js'
+
+export interface MessageViewRenderSlots {
+  /** Render the message body (markdown → sanitized HTML). Default: raw text. */
+  renderContent?: (htmlOrText: string, message: Message) => ReactNode
+  /** Render the avatar glyph for a role. */
+  renderAvatar?: (role: Message['role']) => ReactNode
+  /**
+Render the hover action row (copy / edit). When provided, this replaces the
+default text buttons entirely — the styled wrapper supplies icon buttons
+while MessageView still owns the copy/edit state and handlers.
+/
+  renderActions?: (actions: MessageActions) => ReactNode
+}
+
+/** Action handles passed to `renderActions` so the caller can wire its own UI.
+
+```ts
+export interface MessageActions {
+  /** Whether the copy action just fired (show a "copied" affordance). */
+  copied: boolean
+  /** Copy the message content to the clipboard. */
+  onCopy: () => void
+  /** Whether the user may edit this message (role==='user' && !isRunning). */
+  canEdit: boolean
+  /** Enter edit mode for this message. */
+  onEdit: () => void
+  /** Whether the message is currently being edited (hide actions while true). */
+  editing: boolean
+}
+```
+
+### `MessageSource`
+
+<!-- jcode-ui-core-messagesource -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+Origin channel for inbound messages (e.g. 'wechat'). Drives avatar tint. */
+  source?: string
+  images?: ChatImage[]
+  /** system-message severity. */
+  level?: SystemLevel
+  /** Optional raw detail (collapsed by default). */
+  detail?: string
+  /** Assistant turn elapsed (ms), stamped on the final message of a turn. */
+  durationMs?: number
+  /** Optional model reasoning / chain-of-thought text (rendered collapsible).
+ Mirrors assistant-ui's Reasoning component + OpenAI/Anthropic thinking. */
+  reasoning?: string
+  /** Optional citation sources for the message (rendered as a Sources list).
+ Mirrors assistant-ui's Sources component. */
+  sources?: MessageSource[]
+}
+
+/** A citation source attached to a message (e.g. a retrieved doc or URL).
+
+```ts
+export interface MessageSource {
+  /** Stable id for keying. */
+  id: string
+  /** Display title of the source. */
+  title: string
+  /** Optional URL or deep link. */
+  url?: string
+  /** Optional snippet/excerpt quoted from the source. */
+  snippet?: string
+}
+```
+
+### `MessageViewProps`
+
+<!-- jcode-ui-core-messageviewprops -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/MessageView.tsx`
+
+```ts
+export interface MessageViewProps extends MessageViewRenderSlots {
+  message: Message
+  /** Whether the user may edit (typically role==='user' && !isRunning). */
+  canEdit?: boolean
+  /** Whether to show the copy action on hover. Default true. */
+  showCopy?: boolean
+  /** className passthrough. */
+  className?: string
+}
+```
+
+### `QueuedMessage`
+
+<!-- jcode-ui-core-queuedmessage -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+A message composed while the agent is running; drained turn-by-turn.
+
+```ts
+export interface QueuedMessage {
+  id: string
+  text: string
+  images?: ChatImage[]
+}
+```
+
+### `RuntimeActions`
+
+<!-- jcode-ui-core-runtimeactions -->
+
+`interface` · `packages/jcode-ui-core/src/runtime/index.ts`
+
+The conversation timeline (messages, tool calls, approvals, interleaved). */
+  items: ThreadItem[]
+  /** True while the agent is producing output (drives the "Thinking…" row, the
+ composer's send→stop button swap, and auto-follow behavior). */
+  isRunning: boolean
+  /** Live token/context snapshot, or null when no turn has reported usage yet. */
+  tokenSnapshot: TokenSnapshot | null
+  /** Active goal banner, or null. */
+  goal: Goal | null
+  /** Todo list (also rendered inside `todowrite` tool calls). */
+  todos: TodoItem[]
+  /** Type-ahead queue: messages composed mid-turn, drained on each turn end. */
+  queued: QueuedMessage[]
+}
+
+/**
+Actions the UI dispatches. The runtime forwards these to the host store
+(which may in turn POST to a backend, resolve locally, etc.). Keeping these
+as a flat bag of callbacks (rather than a discriminated union dispatched via
+`runtime.dispatch`) means consumers wiring a Zustand store or plain React
+state don't have to model their actions in our shape — they just hand us the
+functions they already have.
+
+```ts
+export interface RuntimeActions {
+  /** Send a user-authored message. `images` are base64 payloads. */
+  sendMessage: (text: string, images?: { data: string; media_type: string }[]) => void
+  /** Enqueue a message while a turn is running (type-ahead). */
+  enqueueMessage: (text: string, images?: { data: string; media_type: string }[]) => void
+  /** Remove a queued message by id (before it is sent). */
+  removeQueuedMessage: (id: string) => void
+  /** Cancel the in-flight turn. */
+  stop: () => void
+  /** Resolve an approval gate. `approveAll` arms "allow all future" semantics. */
+  resolveApproval: (id: string, approved: boolean, approveAll?: boolean) => void
+  /** Answer an `ask_user` batch. */
+  submitAskUser: (id: string, answers: { question_header: string; answer: string; selected?: string[] }[]) => void
+  /** Edit a past user message and resend from that point. */
+  editMessage: (id: string, newText: string) => void
+}
+```
+
+### `RuntimeState`
+
+<!-- jcode-ui-core-runtimestate -->
+
+`interface` · `packages/jcode-ui-core/src/runtime/index.ts`
+
+ChatRuntime — the host-agnostic data source for jcode-ui.
+
+Components never touch the store directly. They talk to a `ChatRuntime`, which
+is an `ExternalStore`-shaped interface (matching Redux's store signature) so
+it can wrap RTK, Zustand, Pinia-via-snapshot, or a hand-rolled reducer with
+zero adapter code.
+
+Why this abstraction exists: jcode-ui must render the same whether the data
+comes from a live WebSocket-backed RTK store, a replayed JSONL session, or a
+mock playground. The runtime is the single seam.
+/
+
+import type { ThreadItem, TokenSnapshot, Goal, TodoItem, QueuedMessage } from '../types/index.js'
+
+/**
+The read-side state a Thread + Composer render from. Consumers provide an
+object of this shape (or a subset — see `PartialRuntimeState`); the runtime
+normalizes missing slices to safe defaults.
+
+```ts
+export interface RuntimeState {
+  /** The conversation timeline (messages, tool calls, approvals, interleaved). */
+  items: ThreadItem[]
+  /** True while the agent is producing output (drives the "Thinking…" row, the
+   *  composer's send→stop button swap, and auto-follow behavior). */
+  isRunning: boolean
+  /** Live token/context snapshot, or null when no turn has reported usage yet. */
+  tokenSnapshot: TokenSnapshot | null
+  /** Active goal banner, or null. */
+  goal: Goal | null
+  /** Todo list (also rendered inside `todowrite` tool calls). */
+  todos: TodoItem[]
+  /** Type-ahead queue: messages composed mid-turn, drained on each turn end. */
+  queued: QueuedMessage[]
+}
+```
+
+### `SlashCommand`
+
+<!-- jcode-ui-core-slashcommand -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/Composer.tsx`
+
+```ts
+export interface SlashCommand {
+  /** The literal text inserted when chosen (e.g. '/goal'). */
+  slash: string
+  description?: string
+}
+```
+
+### `SlashMenuState`
+
+<!-- jcode-ui-core-slashmenustate -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/Composer.tsx`
+
+```ts
+export interface SlashMenuState {
+  open: boolean
+  /** Filtered commands for the current input. */
+  commands: SlashCommand[]
+  /** Active (highlighted) index, or -1. */
+  activeIndex: number
+  /** Apply a command: inserts its slash text at the caret. */
+  apply: (cmd: SlashCommand) => void
+}
+```
+
+### `TaskContextBreakdown`
+
+<!-- jcode-ui-core-taskcontextbreakdown -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+Per-task context-window breakdown (host-provided; powers the ContextBar popover).
+
+```ts
+export interface TaskContextBreakdown {
+  context_limit: number
+  system_prompt_tokens: number
+  system_tools_tokens: number
+  mcp_tools_tokens: number
+  skills_tokens: number
+  messages_tokens: number
+}
+```
+
+### `ThreadProps`
+
+<!-- jcode-ui-core-threadprops -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/Thread.tsx`
+
+```ts
+export interface ThreadProps extends ThreadRenderSlots {
+  /** Enable windowed virtualization. Default true. Disable for short/replay
+   *  timelines. */
+  virtualize?: boolean
+  /** Estimated row height in px (virtualizer uses this before measure). */
+  estimateSize?: number
+  /** Bottom-edge threshold in px within which we consider the user "at bottom". */
+  scrollThreshold?: number
+  /** Extra padding after the last item (e.g. to clear a sticky composer). */
+  overscanBottom?: number
+  /** className passthrough for the scroll container. */
+  className?: string
+  /** Accessibility role for the scroll container. */
+  role?: string
+  /** Ref callback for the scroll container (for parent scroll control). */
+  containerRef?: (el: HTMLElement | null) => void
+}
+```
+
+### `ThreadRenderSlots`
+
+<!-- jcode-ui-core-threadrenderslots -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/Thread.tsx`
+
+```ts
+export interface ThreadRenderSlots {
+  /** Render a single timeline item. Dispatch on `item.kind` to pick a sub-view. */
+  renderItem: (item: ThreadItem) => ReactNode
+  /** Optional trailing "agent is working" row shown when isRunning. */
+  renderPending?: () => ReactNode
+  /** Optional empty state (no items at all). */
+  renderEmpty?: () => ReactNode
+}
+```
+
+### `TodoItem`
+
+<!-- jcode-ui-core-todoitem -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+A todo/goal tracking item. (id is a number — matches the Go backend.)
+
+```ts
+export interface TodoItem {
+  id: number
+  title: string
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+}
+```
+
+### `TokenSnapshot`
+
+<!-- jcode-ui-core-tokensnapshot -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+Live token/context usage snapshot for a turn.
+
+```ts
+export interface TokenSnapshot {
+  total_tokens: number
+  prompt_tokens: number
+  completion_tokens: number
+  cached_tokens?: number
+  reasoning_tokens?: number
+  cache_write_tokens?: number
+  call_count?: number
+  cache_hit_rate?: number
+  cache_supported?: boolean
+  model_context_limit: number
+}
+```
+
+### `ToolCall`
+
+<!-- jcode-ui-core-toolcall -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+'context' | 'mutation' | 'execution' — informational grouping. */
+  category?: string
+}
+
+export type ToolStatus = 'running' | 'done' | 'error'
+
+/**
+A tool invocation. `args`/`output` are raw JSON strings; renderers parse
+them. `children` carries subagent-nested calls (rendered recursively).
+
+```ts
+export interface ToolCall {
+  id: string
+  /** Backend tool_call_id for precise result matching. */
+  toolCallID?: string
+  name: string
+  args: string
+  output?: string
+  /** Clean output for UI display (metadata stripped). */
+  displayOutput?: string
+  error?: string
+  status: ToolStatus
+  timestamp: number
+  displayInfo?: ToolDisplayInfo
+  /** Nested tool calls (subagent inner calls). */
+  children?: ToolCall[]
+  /** ask_user: request id while awaiting an answer (live runs only). */
+  askUserId?: string
+  /** ask_user: backend-normalized questions to render. */
+  askUserQuestions?: AskUserQuestion[]
+}
+```
+
+### `ToolCallContextValue`
+
+<!-- jcode-ui-core-toolcallcontextvalue -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/ToolCallView.tsx`
+
+ToolCallView — the headless expand/collapse shell for a tool invocation.
+
+Owns: expand/collapse state, renderer lookup via ToolRendererRegistry, and
+subagent recursion. Does NOT own per-tool body chrome — the styled
+`jcode-ui` `ToolCallCard` supplies header styling + CSS for `.toolcall-body`.
+
+Subagent: only `tool.name === 'subagent'` (NOT team_spawn — that has its own
+renderer). Children recurse as nested ToolCallView instances. ask_user tools
+route to the host's renderAskUser slot.
+/
+
+import { createContext, useContext, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import type { ToolCall } from '../types/index.js'
+import type { ToolRendererRegistry, ToolRendererProps } from '../adapters/index.js'
+
+/** Context the host provides to wire the registry + the subagent/askuser slots.
+
+```ts
+export interface ToolCallContextValue {
+  registry: ToolRendererRegistry
+  /** Render nested subagent children. Default: recurses into ToolCallView. */
+  renderChild?: (child: ToolCall, depth: number) => ReactNode
+  /** Render an ask_user tool (interactive question block). */
+  renderAskUser?: (tool: ToolCall) => ReactNode
+}
+```
+
+### `ToolCallViewProps`
+
+<!-- jcode-ui-core-toolcallviewprops -->
+
+`interface` · `packages/jcode-ui-core/src/primitives/ToolCallView.tsx`
+
+```ts
+export interface ToolCallViewProps {
+  tool: ToolCall
+  /** Nesting depth (subagent children). 0 = top-level. */
+  depth?: number
+  /** Max subagent recursion depth. Default 4. */
+  maxDepth?: number
+  /** Default expanded state. Default false (subagents default true). */
+  defaultExpanded?: boolean
+  /** Render-prop for the header. Falls back to a default row. */
+  renderHeader?: (tool: ToolCall, expanded: boolean, toggle: () => void) => ReactNode
+  /**
+   * Optional subagent body (output/error). Styled layer supplies markdown.
+   * Receives only output-related fields — never args.
+   */
+  renderSubagentOutput?: (tool: ToolCall) => ReactNode
+  /** className passthrough. */
+  className?: string
+}
+```
+
+### `ToolDisplayInfo`
+
+<!-- jcode-ui-core-tooldisplayinfo -->
+
+`interface` · `packages/jcode-ui-core/src/types/index.ts`
+
+Stable id for keying. */
+  id: string
+  /** Display title of the source. */
+  title: string
+  /** Optional URL or deep link. */
+  url?: string
+  /** Optional snippet/excerpt quoted from the source. */
+  snippet?: string
+}
+
+/** Display metadata for a tool call, surfaced from the backend or extracted
+ client-side from args. Lets renderers show a title/icon without parsing args.
+
+```ts
+export interface ToolDisplayInfo {
+  title: string
+  subtitle?: string
+  icon?: string
+  /** 'context' | 'mutation' | 'execution' — informational grouping. */
+  category?: string
+}
+```
+
+### `ToolRendererProps`
+
+<!-- jcode-ui-core-toolrendererprops -->
+
+`interface` · `packages/jcode-ui-core/src/adapters/index.ts`
+
+Tool renderer registry — the plugin seam for tool-call visualization.
+
+`ToolCallCard` doesn't know how to render any specific tool. Instead it looks
+up a renderer by `tool.name` in a `ToolRendererRegistry`. jcode-ui ships
+default renderers (terminal/file-viewer/diff/search/…) as a preset; consumers
+override or extend with their own. This is what makes the component reusable
+across agents with completely different tool surfaces.
+/
+
+import type { ComponentType } from 'react'
+import type { ToolCall, ToolDisplayInfo, ToolStatus } from '../types/index.js'
+
+export type { ToolStatus }
+
+/** Props every tool renderer receives.
+
+```ts
+export interface ToolRendererProps {
+  /** Logical tool name (e.g. 'execute', 'read', 'edit', 'grep', …). */
+  name: string
+  /** Raw args JSON string. Renderers parse what they need. */
+  args: string
+  /** Raw output string (may be omitted while running). */
+  output?: string
+  /** Clean display output (backend metadata stripped). */
+  displayOutput?: string
+  /** Error string if the tool failed. */
+  error?: string
+  status: ToolStatus
+  /** Pre-extracted display metadata (title/subtitle/icon). May be absent. */
+  displayInfo?: ToolDisplayInfo
+  /** Nested subagent calls — renderers decide whether to recurse. */
+  children?: ToolCall[]
+}
+```
+
+### `GoalStatus`
+
+<!-- jcode-ui-core-goalstatus -->
+
+`type` · `packages/jcode-ui-core/src/types/index.ts`
+
+```ts
+export type GoalStatus = 'active' | 'complete' | 'blocked';
+```
+
+### `PartialRuntimeState`
+
+<!-- jcode-ui-core-partialruntimestate -->
+
+`type` · `packages/jcode-ui-core/src/runtime/index.ts`
+
+Action bag. Stable identity is recommended (consumers should memoize). */
+  readonly actions: RuntimeActions
+}
+
+/** A `RuntimeState` where every slice is optional; useful for adapters that
+ only implement part of the contract (e.g. a read-only replay runtime).
+
+```ts
+export type PartialRuntimeState = Partial<RuntimeState>;
+```
+
+### `Role`
+
+<!-- jcode-ui-core-role -->
+
+`type` · `packages/jcode-ui-core/src/types/index.ts`
+
+Core message + tool types for jcode-ui.
+
+These mirror the jcode backend contract (see `web/src/types/api.ts`) but are
+framework-agnostic and the single source of truth for both `jcode-ui-core`
+(headless primitives) and `jcode-ui` (styled components).
+/
+
+/** Who authored a message.
+
+```ts
+export type Role = 'user' | 'assistant' | 'system';
+```
+
+### `SystemLevel`
+
+<!-- jcode-ui-core-systemlevel -->
+
+`type` · `packages/jcode-ui-core/src/types/index.ts`
+
+Severity for `system` messages. Undefined → default neutral styling.
+
+```ts
+export type SystemLevel = 'error' | 'notice';
+```
+
+### `ThreadItem`
+
+<!-- jcode-ui-core-threaditem -->
+
+`type` · `packages/jcode-ui-core/src/types/index.ts`
+
+The discriminated union rendered by `Thread`. A `seq` counter keeps DOM
+identity stable across streaming updates and is used as the virtualizer key.
+
+```ts
+export type ThreadItem =
+  | { kind: 'message'; data: Message; seq: number }
+  | { kind: 'tool'; data: ToolCall; seq: number }
+  | { kind: 'approval'; data: Approval; seq: number };
+```
+
+### `ThreadItemKind`
+
+<!-- jcode-ui-core-threaditemkind -->
+
+`type` · `packages/jcode-ui-core/src/types/index.ts`
+
+Target outside the workspace root — UI flags it prominently. */
+  is_external: boolean
+  resolved?: boolean
+  approved?: boolean
+  /** True while a resolve request is in flight (disables controls). */
+  resolving?: boolean
+}
+
+/** The three built-in thread-item kinds.
+
+```ts
+export type ThreadItemKind = 'message' | 'tool' | 'approval';
+```
+
+### `ToolRenderer`
+
+<!-- jcode-ui-core-toolrenderer -->
+
+`type` · `packages/jcode-ui-core/src/adapters/index.ts`
+
+Logical tool name (e.g. 'execute', 'read', 'edit', 'grep', …). */
+  name: string
+  /** Raw args JSON string. Renderers parse what they need. */
+  args: string
+  /** Raw output string (may be omitted while running). */
+  output?: string
+  /** Clean display output (backend metadata stripped). */
+  displayOutput?: string
+  /** Error string if the tool failed. */
+  error?: string
+  status: ToolStatus
+  /** Pre-extracted display metadata (title/subtitle/icon). May be absent. */
+  displayInfo?: ToolDisplayInfo
+  /** Nested subagent calls — renderers decide whether to recurse. */
+  children?: ToolCall[]
+}
+
+/** A tool renderer is just a React component.
+
+```ts
+export type ToolRenderer = ComponentType<ToolRendererProps>;
+```
+

--- a/site/docs/chat-ui/api/hooks.md
+++ b/site/docs/chat-ui/api/hooks.md
@@ -1,0 +1,47 @@
+---
+title: Hooks
+parent: API Reference
+nav_order: 3
+---
+
+# Hooks
+
+## Runtime hooks (`jcode-ui` / `jcode-ui-core/runtime`)
+
+Require `<RuntimeProvider>`.
+
+| Hook | Returns | Notes |
+|------|---------|-------|
+| `useRuntimeState()` | `RuntimeState` | Re-renders on any state change |
+| `useRuntimeSelector(selector)` | `T` | Granular; identity-stable selectors preferred |
+| `useRuntimeActions()` | `RuntimeActions` | Action bag (stable if host memoizes) |
+
+```ts
+const items = useRuntimeSelector((s) => s.items)
+const isRunning = useRuntimeSelector((s) => s.isRunning)
+const { sendMessage, stop } = useRuntimeActions()
+```
+
+## Behavioral hooks (`jcode-ui-core/hooks`)
+
+| Hook | Signature | Purpose |
+|------|-----------|---------|
+| `useAutoScroll` | `(threshold?: number)` | `{ ref, onScroll, scrollToBottom, getIsAtBottom, isAtBottomRef }` |
+| `useIsAtBottom` | `(threshold?: number)` | Re-render-friendly at-bottom tracking |
+| `useStreamFollow` | `(autoScroll, dep)` | Scroll on `dep` change only if at bottom |
+| `useFocusOnIdle` | `(isRunning: boolean)` | Returns ref; focuses when turn ends |
+| `useQueuedMessages` | `()` | Current type-ahead queue |
+
+```ts
+import { useAutoScroll, useStreamFollow } from 'jcode-ui-core/hooks'
+
+const auto = useAutoScroll<HTMLDivElement>(80)
+useStreamFollow(auto, items.length)
+// <div ref={auto.ref} onScroll={auto.onScroll}>…
+```
+
+## Tool registry hooks (`jcode-ui`)
+
+| Hook | Returns |
+|------|---------|
+| `useToolRegistry()` | `ToolRendererRegistry` from nearest provider |

--- a/site/docs/chat-ui/api/primitives.md
+++ b/site/docs/chat-ui/api/primitives.md
@@ -1,0 +1,90 @@
+---
+title: Primitives API
+parent: API Reference
+nav_order: 4
+---
+
+# Primitives API
+
+```ts
+import {
+  Thread,
+  MessageView,
+  Composer,
+  ToolCallView,
+  ToolCallProvider,
+  ApprovalBlock,
+  AskUserBlock,
+} from 'jcode-ui-core/primitives'
+```
+
+## Thread
+
+| Prop | Type | Default |
+|------|------|---------|
+| `renderItem` | `(item: ThreadItem) => ReactNode` | required |
+| `renderPending` | `() => ReactNode` | — |
+| `renderEmpty` | `() => ReactNode` | — |
+| `virtualize` | `boolean` | `true` |
+| `estimateSize` | `number` | `80` |
+| `scrollThreshold` | `number` | `80` |
+| `overscanBottom` | `number` | — |
+| `className` | `string` | — |
+
+## MessageView
+
+| Prop | Type |
+|------|------|
+| `message` | `Message` |
+| `canEdit` | `boolean` |
+| `renderContent` | `(text: string) => ReactNode` |
+| `className` | `string` |
+
+Plus optional action slots (see source `MessageViewRenderSlots`).
+
+## Composer
+
+| Prop | Type | Default |
+|------|------|---------|
+| `placeholder` | `string` | `'Send a message…'` |
+| `maxRows` | `number` | `160` (px) |
+| `slashCommands` | `SlashCommand[]` | — |
+| `allowImages` | `boolean` | `false` |
+| `maxImageBytes` | `number` | `10MB` |
+| `defaultValue` | `string` | `''` |
+| `onSent` | `() => void` | — |
+| `className` | `string` | — |
+
+**Slots:** `renderSlashMenu`, `renderQueue`, `renderSubmitButton`, `renderAttachments`, `renderPrefix`, `renderSuffix`.
+
+## ToolCallView
+
+| Prop | Type |
+|------|------|
+| `tool` | `ToolCall` |
+| `registry` | `ToolRendererRegistry` (optional if context) |
+| `className` | `string` |
+
+Wrap tree with `ToolCallProvider` for registry + `renderAskUser`.
+
+## ApprovalBlock
+
+| Prop | Type |
+|------|------|
+| `approval` | `Approval` |
+| `renderPending` | `(approval, actions) => ReactNode` |
+| `renderResolved` | `(approval) => ReactNode` |
+| `className` | `string` |
+
+Pending actions: `allowOnce`, `allowAllArm`, `allowAllConfirm`, `deny`, `armed`.
+
+## AskUserBlock
+
+| Prop | Type |
+|------|------|
+| `tool` | `ToolCall` |
+| `renderPending` | `(questions, controls) => ReactNode` |
+| `renderResolved` | `(answers) => ReactNode` |
+| `className` | `string` |
+
+Controls: `toggleOption`, `setOther`, `submit`, `skip`, `selected`, …

--- a/site/docs/chat-ui/api/runtime.md
+++ b/site/docs/chat-ui/api/runtime.md
@@ -1,0 +1,105 @@
+---
+title: Runtime API
+parent: API Reference
+nav_order: 2
+---
+
+# Runtime API
+
+```ts
+import {
+  createExternalStoreRuntime,
+  createMockRuntime,
+  RuntimeProvider,
+  normalizeState,
+} from 'jcode-ui'
+// or jcode-ui-core/runtime
+```
+
+## ChatRuntime
+
+```ts
+interface ChatRuntime {
+  getState: () => RuntimeState
+  subscribe: (listener: () => void) => () => void
+  readonly actions: RuntimeActions
+}
+```
+
+## RuntimeState
+
+| Field | Type | Default (normalize) |
+|-------|------|---------------------|
+| `items` | `ThreadItem[]` | `[]` |
+| `isRunning` | `boolean` | `false` |
+| `tokenSnapshot` | `TokenSnapshot \| null` | `null` |
+| `goal` | `Goal \| null` | `null` |
+| `todos` | `TodoItem[]` | `[]` |
+| `queued` | `QueuedMessage[]` | `[]` |
+
+## RuntimeActions
+
+| Action | Signature |
+|--------|-----------|
+| `sendMessage` | `(text: string, images?: ChatImage[]) => void` |
+| `enqueueMessage` | `(text: string, images?: ChatImage[]) => void` |
+| `removeQueuedMessage` | `(id: string) => void` |
+| `stop` | `() => void` |
+| `resolveApproval` | `(id: string, approved: boolean, approveAll?: boolean) => void` |
+| `submitAskUser` | `(id: string, answers: AskUserAnswer[]) => void` |
+| `editMessage` | `(id: string, newText: string) => void` |
+
+## createExternalStoreRuntime
+
+```ts
+function createExternalStoreRuntime<THostState>(
+  opts: ExternalStoreRuntimeOptions<THostState>,
+): ChatRuntime
+
+interface ExternalStoreRuntimeOptions<THostState> {
+  store: {
+    getState: () => THostState
+    subscribe: (listener: () => void) => () => void
+  }
+  select: (state: THostState) => PartialRuntimeState
+  actions: RuntimeActions
+}
+```
+
+Returns a runtime whose `getState()` is **referentially stable** between host dispatches.
+
+## createMockRuntime
+
+```ts
+function createMockRuntime(opts?: MockRuntimeOptions): ChatRuntime & {
+  setItems(items: ThreadItem[]): void
+  push(item: ThreadItem): void
+  setRunning(running: boolean): void
+  patchState(partial: PartialRuntimeState): void
+  appendText(delta: string): void
+  calls: { action: string; args: unknown[] }[]
+}
+
+interface MockRuntimeOptions {
+  items?: ThreadItem[]
+  isRunning?: boolean
+  state?: PartialRuntimeState
+  actions?: Partial<RuntimeActions>
+}
+```
+
+Default `resolveApproval` / `submitAskUser` update items so demos are interactive.
+
+## RuntimeProvider
+
+```tsx
+<RuntimeProvider runtime={runtime}>{children}</RuntimeProvider>
+```
+
+## normalizeState
+
+```ts
+function normalizeState(partial: PartialRuntimeState | undefined): RuntimeState
+```
+
+Fills missing slices with safe defaults.

--- a/site/docs/chat-ui/api/types.md
+++ b/site/docs/chat-ui/api/types.md
@@ -1,0 +1,207 @@
+---
+title: Types
+parent: API Reference
+nav_order: 1
+---
+
+# Types
+
+Core types from `jcode-ui-core` (re-exported from `jcode-ui` where noted).
+
+```ts
+import type {
+  Message,
+  ToolCall,
+  Approval,
+  ThreadItem,
+  TokenSnapshot,
+  TaskContextBreakdown,
+  Goal,
+  TodoItem,
+  Role,
+} from 'jcode-ui-core'
+// or from 'jcode-ui' (Message is exported as MessageData type alias)
+```
+
+## Message
+
+```ts
+type Role = 'user' | 'assistant' | 'system'
+type SystemLevel = 'error' | 'notice'
+
+interface ChatImage {
+  data: string       // base64, no data: prefix
+  media_type: string
+}
+
+interface MessageSource {
+  id: string
+  title: string
+  url?: string
+  snippet?: string
+}
+
+interface Message {
+  id: string
+  role: Role
+  content: string
+  timestamp: number
+  source?: string           // e.g. 'wechat'
+  images?: ChatImage[]
+  level?: SystemLevel       // system messages
+  detail?: string
+  durationMs?: number       // assistant turn elapsed
+  reasoning?: string        // chain-of-thought
+  sources?: MessageSource[]
+}
+```
+
+## ToolCall
+
+```ts
+type ToolStatus = 'running' | 'done' | 'error'
+
+interface ToolDisplayInfo {
+  title: string
+  subtitle?: string
+  icon?: string
+  category?: string         // 'context' | 'mutation' | 'execution' | …
+}
+
+interface ToolCall {
+  id: string
+  toolCallID?: string
+  name: string
+  args: string              // raw JSON string
+  output?: string
+  displayOutput?: string
+  error?: string
+  status: ToolStatus
+  timestamp: number
+  displayInfo?: ToolDisplayInfo
+  children?: ToolCall[]     // subagent nesting
+  askUserId?: string
+  askUserQuestions?: AskUserQuestion[]
+}
+```
+
+## Ask user
+
+```ts
+interface AskUserOption {
+  label: string
+  description?: string
+}
+
+interface AskUserQuestion {
+  question: string
+  header?: string
+  options?: AskUserOption[]
+  multi_select?: boolean
+}
+
+interface AskUserAnswer {
+  question_header: string
+  answer: string
+  selected?: string[]
+}
+```
+
+## Approval
+
+```ts
+interface Approval {
+  id: string
+  tool_name: string
+  tool_args: string
+  is_external: boolean
+  resolved?: boolean
+  approved?: boolean
+  resolving?: boolean
+}
+```
+
+## ThreadItem
+
+```ts
+type ThreadItem =
+  | { kind: 'message'; data: Message; seq: number }
+  | { kind: 'tool'; data: ToolCall; seq: number }
+  | { kind: 'approval'; data: Approval; seq: number }
+
+function isMessageItem(i: ThreadItem): boolean
+function isToolItem(i: ThreadItem): boolean
+function isApprovalItem(i: ThreadItem): boolean
+```
+
+`seq` is the stable React / virtualizer key across streaming updates.
+
+## Tokens & context
+
+```ts
+interface TokenSnapshot {
+  total_tokens: number
+  prompt_tokens: number
+  completion_tokens: number
+  cached_tokens?: number
+  reasoning_tokens?: number
+  cache_write_tokens?: number
+  call_count?: number
+  cache_hit_rate?: number
+  cache_supported?: boolean
+  model_context_limit: number
+}
+
+interface TaskContextBreakdown {
+  context_limit: number
+  system_prompt_tokens: number
+  system_tools_tokens: number
+  mcp_tools_tokens: number
+  skills_tokens: number
+  messages_tokens: number
+}
+```
+
+## Goal & todos
+
+```ts
+type GoalStatus = 'active' | 'complete' | 'blocked'
+
+interface Goal {
+  objective: string
+  status: GoalStatus
+  tokens_used?: number
+  created_at?: number
+  updated_at?: number
+}
+
+interface TodoItem {
+  id: number
+  title: string
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+}
+
+interface QueuedMessage {
+  id: string
+  text: string
+  images?: ChatImage[]
+}
+```
+
+## Tool renderer props
+
+```ts
+// jcode-ui-core/adapters
+interface ToolRendererProps {
+  name: string
+  args: string
+  output?: string
+  displayOutput?: string
+  error?: string
+  status: ToolStatus
+  displayInfo?: ToolDisplayInfo
+  children?: ToolCall[]
+}
+
+type ToolRenderer = ComponentType<ToolRendererProps>
+```

--- a/site/docs/chat-ui/components.md
+++ b/site/docs/chat-ui/components.md
@@ -1,284 +1,56 @@
 ---
 title: Components
-parent: jcode-ui
-nav_order: 5
+nav_order: 4
+has_children: true
 ---
 
 # Component reference
 
-Every styled component `jcode-ui` exports, with its props. This mirrors
-assistant-ui's component catalog — if you're migrating from assistant-ui, the
-table below maps their components to ours.
+Styled components exported by `jcode-ui`. Each page includes a **live preview** (real components, mock runtime) plus props tables.
+
+## Catalog
+
+| Component | Page | Role |
+|-----------|------|------|
+| `Thread` | [Thread](/chat-ui/docs/components/thread) | Virtualized conversation timeline |
+| `ChatInput` | [ChatInput](/chat-ui/docs/components/chat-input) | Composer (send / queue / stop) |
+| `Message` | [Message](/chat-ui/docs/components/message) | User / assistant / system bubble |
+| `ToolCallCard` | [ToolCallCard](/chat-ui/docs/components/tool-call-card) | Tool shell + renderer dispatch |
+| `ApprovalBanner` | [ApprovalBanner](/chat-ui/docs/components/approval-banner) | Human approval gate |
+| `AskUserCard` | [AskUserCard](/chat-ui/docs/components/ask-user-card) | Mid-run questions |
+| `Reasoning` | [Reasoning](/chat-ui/docs/components/reasoning) | Collapsible chain-of-thought |
+| `Sources` | [Sources](/chat-ui/docs/components/sources) | Citation chips |
+| `Attachment` | [Attachment](/chat-ui/docs/components/attachment) | Image thumbnails |
+| `ContextBar` | [ContextBar](/chat-ui/docs/components/context-bar) | Token / context ring |
+
+Providers: `RuntimeProvider`, `ToolRegistryProvider`, `ApiBaseProvider` — see [Runtime](/chat-ui/docs/runtime).
 
 ## assistant-ui → jcode-ui mapping
 
-Complete coverage of the assistant-ui component catalog. Every component has a
-jcode-ui equivalent (either a same-named component, a field-driven render inside
-an existing component, or a documented product-app equivalent).
-
 | assistant-ui | jcode-ui equivalent | Status | Notes |
 |--------------|---------------------|--------|-------|
-| `Thread` | `Thread` | ✅ same-named | Virtualized + auto-follow. |
-| `ThreadList` (conversation list) | `Sidebar` (product app) | 🟡 product | The conversation list is app chrome, not a library primitive — shipped in the product web app. |
-| `Composer` | `ChatInput` | ✅ same concept | Send/queue/stop, slash commands, attachments, context bar. |
-| `Attachment` | `Attachment` + `AttachmentList` | ✅ same-named | Standalone + embedded in ChatInput. |
-| `Markdown` | (built into `Message`) | ✅ field-driven | marked + highlight.js + DOMPurify. Render any markdown via `renderMarkdown()`. |
-| `Diff Viewer` | `DiffRenderer` | ✅ tool renderer | Renders edit/multi_edit tool calls (red/green line table). |
-| `Image` | (built into `Message` + `Attachment`) | ✅ field-driven | `message.images[]` renders inline; `Attachment` for the composer. |
-| `Context Display` | `ContextBar` | ✅ same concept | SVG ring + breakdown popover. |
-| `Message Timing` | (built into `Message`) | ✅ field-driven | `message.durationMs` renders a turn-elapsed label on the final assistant message. |
-| `Reasoning` | `Reasoning` | ✅ same-named | Collapsible model thinking. Driven by `message.reasoning`. |
-| `Sources` | `Sources` | ✅ same-named | Citation list. Driven by `message.sources`. |
-| `Tool Fallback` | `GenericRenderer` | ✅ same concept | The registry fallback for unknown tools. |
-| `Tool Group` | `ToolCallCard` (children recursion) | ✅ field-driven | Subagent nested calls render recursively via `tool.children`. |
-| `Assistant Modal` | (product app) | 🟡 product | A floating-chat pattern is app-level; jcode ships a full-screen product UI instead. Buildable on top of the primitives. |
-| `Assistant Sidebar` | `Sidebar` (product app) | 🟡 product | Same as ThreadList — app chrome. |
-| `Model Selector` | `ProjectHeader` (product) | 🟡 product | Model/mode switching is app-level; the library is model-agnostic. |
-| `makeAssistantToolUI` | `ToolRendererRegistry` | ✅ same concept | Plugin registry — register any tool renderer by name. |
-
-**Legend:** ✅ = same-named / equivalent component in the library · 🟡 = app-level
-(lives in the product app, not the library, because it's host-specific chrome) ·
-field-driven = rendered automatically from a `Message`/`ToolCall` field.
-
----
-
-## `<Thread />`
-
-The conversation container. Renders the timeline with virtualization + the
-"follow only when at bottom" streaming contract.
-
-```tsx
-import { Thread } from 'jcode-ui'
-
-<Thread
-  virtualize        // default true
-  overscanBottom={96}  // px, clears a sticky composer
-  emptyState={<EmptyState />}
-/>
-```
-
-| Prop | Type | Default | Notes |
-|------|------|---------|-------|
-| `virtualize` | `boolean` | `true` | TanStack Virtual. Disable for short/replay timelines. |
-| `overscanBottom` | `number` | — | Bottom padding (px) to clear a sticky composer. |
-| `emptyState` | `ReactNode` | — | Shown when no items + not running. |
-| `renderPending` | `() => ReactNode` | "Thinking…" | The trailing running indicator. |
-| `className` | `string` | — | Passthrough. |
-
----
-
-## `<ChatInput />`
-
-The composer: autosizing textarea, send/queue/stop, slash-command palette,
-image attachments, context bar.
-
-```tsx
-import { ChatInput } from 'jcode-ui'
-
-<ChatInput
-  slashCommands={[{ slash: '/goal', description: 'set the session goal' }]}
-  allowImages={modelSupportsVision}
-  showContextBar
-  onSent={() => timelineSnapToBottom()}
-/>
-```
-
-| Prop | Type | Default | Notes |
-|------|------|---------|-------|
-| `slashCommands` | `SlashCommand[]` | — | Drives the `/` menu. |
-| `allowImages` | `boolean` | `false` | Gate by model vision support. |
-| `placeholder` | `string` | `'Send a message…'` | |
-| `showContextBar` | `boolean` | `true` | The token ring suffix. |
-| `onSent` | `() => void` | — | Fires on send/queue (snap timeline to bottom). |
-
-When the runtime reports `isRunning`, the send button becomes a stop button and
-`send()` routes to `enqueueMessage` (type-ahead).
-
----
-
-## `<Message />`
-
-A single chat bubble. Usually rendered by `Thread`; use directly for custom layouts.
-
-```tsx
-import { Message } from 'jcode-ui'
-
-<Message message={msg} canEdit={msg.role === 'user' && !isRunning} />
-```
-
-| Prop | Type | Notes |
-|------|------|-------|
-| `message` | `Message` | The message data. |
-| `canEdit` | `boolean` | Shows the edit affordance (user messages, idle). |
-
-Markdown is rendered via marked + highlight.js + DOMPurify. Role styling:
-user = right-aligned primary fill, assistant = left surface, system = muted/error.
-
----
-
-## `<ToolCallCard />`
-
-The expand/collapse shell for a tool call. Dispatches the body to a registered
-renderer. Recurses into `children` for subagent calls.
-
-```tsx
-import { ToolCallCard } from 'jcode-ui'
-
-<ToolCallCard tool={toolCall} />
-```
-
-| Prop | Type | Notes |
-|------|------|-------|
-| `tool` | `ToolCall` | The tool call data. |
-| `registry` | `ToolRendererRegistry` | Override (defaults to context). |
-
-The header shows a status glyph (◈ running / ✓ done / ✗ error), title, subtitle,
-and a diff counter (+N/-M) for edit/multi_edit. The shimmer animation plays while
-running.
-
----
-
-## `<ApprovalBanner />`
-
-The approval gate. 3-tier decision (allow once / allow all [armed] / deny).
-
-```tsx
-import { ApprovalBanner } from 'jcode-ui'
-
-<ApprovalBanner approval={ap} />
-```
-
-Pending: a warning-tinted card with the tool identity, primary target, an
-external-path chip, collapsible full args, and the button ramp. Resolved:
-collapses to a borderless inline note (✓ allowed / ✗ denied).
-
----
-
-## `<AskUserCard />`
-
-Interactive question block. Single + multi-select, free-text "Other", digit-key
-shortcuts (1-9).
-
-```tsx
-import { AskUserCard } from 'jcode-ui'
-
-<AskUserCard tool={toolWithAskUser} />
-```
-
----
-
-## `<Reasoning />`
-
-Collapsible model thinking / chain-of-thought. Mirrors assistant-ui's Reasoning.
-Renders an assistant message's `reasoning` field in a collapsed disclosure
-("Thought for Ns") with markdown support.
-
-```tsx
-import { Reasoning } from 'jcode-ui'
-
-// Usually rendered automatically by <Message> when message.reasoning is set,
-// but usable standalone:
-<Reasoning reasoning={msg.reasoning} durationMs={msg.durationMs} defaultExpanded={false} />
-```
-
-| Prop | Type | Notes |
-|------|------|-------|
-| `reasoning` | `string` | Markdown text of the model's thinking. |
-| `defaultExpanded` | `boolean` | Default `false` (collapsed). |
-| `durationMs` | `number?` | Shows "Thought for Ns" label. |
-
----
-
-## `<Sources />`
-
-Citation list for a message. Mirrors assistant-ui's Sources. Renders a row of
-clickable source chips; clicking opens a snippet popover.
-
-```tsx
-import { Sources } from 'jcode-ui'
-
-// Usually rendered automatically by <Message> when message.sources is set:
-<Sources sources={msg.sources} />
-```
-
-| Prop | Type | Notes |
-|------|------|-------|
-| `sources` | `MessageSource[]` | `{ id, title, url?, snippet? }`. |
-
----
-
-## `<Attachment />` + `<AttachmentList />`
-
-Image-attachment thumbnails. Mirrors assistant-ui's Attachment. Embedded in
-`ChatInput`; also exported standalone for composing custom attachment UIs
-(drag-drop zones, file pickers).
-
-```tsx
-import { Attachment, AttachmentList } from 'jcode-ui'
-
-<Attachment image={img} size={64} onRemove={() => removeImage(i)} />
-<AttachmentList images={images} onRemove={removeImage} />
-```
-
-| Prop | Type | Notes |
-|------|------|-------|
-| `image` | `ChatImage` | `{ data: base64, media_type }`. |
-| `onRemove` | `() => void` | Renders the × button when provided. |
-| `size` | `number` | Thumbnail px. Default 64. |
-
----
-
-## `<ContextBar />`
-
-The token/context indicator. SVG ring showing context-window occupancy (red at
-≥90%) + a hover popover with the bucket breakdown.
-
-```tsx
-import { ContextBar } from 'jcode-ui'
-
-<ContextBar size={20} breakdown={taskContextBreakdown} />
-```
-
-| Prop | Type | Notes |
-|------|------|-------|
-| `breakdown` | `TaskContextBreakdown` | Host-provided per-task stats. |
-| `size` | `number` | Ring diameter (px). Default 20. |
-| `dangerThreshold` | `number` | 0-1, turns red above. Default 0.9. |
-
----
-
-## Providers
-
-### `<RuntimeProvider>`
-
-Provides the `ChatRuntime` to a subtree.
-
-```tsx
-<RuntimeProvider runtime={runtime}>
-  <Thread />
-  <ChatInput />
-</RuntimeProvider>
-```
-
-### `<ToolRegistryProvider>`
-
-Provides the `ToolRendererRegistry` (defaults to `createDefaultToolRegistry()`).
-
-```tsx
-const registry = createDefaultToolRegistry()
-registry.register('my_tool', MyRenderer)
-
-<ToolRegistryProvider registry={registry}>
-  <Thread />
-</ToolRegistryProvider>
-```
-
-### `<ApiBaseProvider>`
-
-Provides the API base URL so `browser_screenshot` can resolve image refs.
-
-```tsx
-<ApiBaseProvider apiBase={apiBase}>
-  <Thread />
-</ApiBaseProvider>
-```
+| `Thread` | `Thread` | ✅ | Virtualized + auto-follow |
+| `ThreadList` | product `Sidebar` | 🟡 product | App chrome, not a library primitive |
+| `Composer` | `ChatInput` | ✅ | Send/queue/stop, slash, attachments |
+| `Attachment` | `Attachment` + `AttachmentList` | ✅ | Image-focused |
+| `Markdown` | built into `Message` | ✅ | marked + highlight.js + DOMPurify |
+| `Diff Viewer` | `DiffRenderer` | ✅ tool renderer | edit / multi_edit |
+| `Image` | `Message` + `Attachment` | ✅ | |
+| `Context Display` | `ContextBar` | ✅ | SVG ring + popover |
+| `Message Timing` | `message.durationMs` | ✅ field | Footer on assistant messages |
+| `Reasoning` | `Reasoning` | ✅ | |
+| `Sources` | `Sources` | ✅ | |
+| `Tool Fallback` | `GenericRenderer` | ✅ | Registry fallback |
+| `Tool Group` | `tool.children` recursion | ✅ | Subagent nesting |
+| `ActionBar` (copy/edit) | built into `Message` | ✅ | Hover actions |
+| `Assistant Modal` | product app | 🟡 product | Build with primitives |
+| `Model Selector` | product header | 🟡 product | Host-specific |
+| Voice / Dictation | — | ❌ skipped | Not in scope |
+| Branch Picker | — | ❌ | Not yet |
+| `makeAssistantToolUI` | `ToolRendererRegistry` | ✅ | |
+
+**Legend:** ✅ library · 🟡 product app · field-driven = automatic from data.
+
+## Full thread preview
+
+<div data-jcode-demo="thread" data-height="420"></div>

--- a/site/docs/chat-ui/components/approval-banner.md
+++ b/site/docs/chat-ui/components/approval-banner.md
@@ -1,0 +1,56 @@
+---
+title: ApprovalBanner
+parent: Components
+nav_order: 5
+---
+
+# ApprovalBanner
+
+Human-in-the-loop approval gate. Three-tier decision: **allow once** / **allow all** (armed two-step) / **deny**.
+
+<div data-jcode-demo="approval"></div>
+
+## Usage
+
+```tsx
+import { ApprovalBanner } from 'jcode-ui'
+
+<ApprovalBanner approval={ap} />
+```
+
+## Props
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `approval` | `Approval` | Gate data from the timeline. |
+
+```ts
+interface Approval {
+  id: string
+  tool_name: string
+  tool_args: string
+  is_external: boolean   // outside workspace — UI flags prominently
+  resolved?: boolean
+  approved?: boolean
+  resolving?: boolean    // in-flight; disables controls
+}
+```
+
+## States
+
+| State | UI |
+|-------|-----|
+| Pending | Warning-tinted card: tool identity, primary target, optional external chip, collapsible args, button ramp |
+| Allow all (first click) | Arms confirm (two-step — prevents accidents) |
+| Resolved approved | Borderless inline note with ✓ |
+| Resolved denied | Borderless inline note with ✗ |
+
+Actions call `runtime.actions.resolveApproval(id, approved, approveAll?)`.
+
+## Headless
+
+`ApprovalBlock` from `jcode-ui-core/primitives` with `renderPending` / `renderResolved` slots.
+
+## Guide
+
+[Approvals guide](/chat-ui/docs/guides/approvals) — when to require approval in the host agent.

--- a/site/docs/chat-ui/components/ask-user-card.md
+++ b/site/docs/chat-ui/components/ask-user-card.md
@@ -1,0 +1,50 @@
+---
+title: AskUserCard
+parent: Components
+nav_order: 6
+---
+
+# AskUserCard
+
+Interactive question block for mid-run agent questions. Single + multi-select, free-text "Other", digit-key shortcuts (1–9).
+
+<div data-jcode-demo="ask-user"></div>
+
+## Usage
+
+```tsx
+import { AskUserCard } from 'jcode-ui'
+
+// Usually rendered from ToolCallCard when tool.askUserQuestions is set:
+<AskUserCard tool={toolWithAskUser} />
+```
+
+## Props
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `tool` | `ToolCall` | Must include `askUserQuestions` / `askUserId` while pending. |
+
+## Question shape
+
+```ts
+interface AskUserQuestion {
+  question: string
+  header?: string
+  options?: { label: string; description?: string }[]
+  multi_select?: boolean
+}
+```
+
+On submit, calls `actions.submitAskUser(askUserId, answers[])`.
+
+## Keyboard
+
+| Key | Action |
+|-----|--------|
+| `1`–`9` | Toggle option by index |
+| Enter | Submit (when valid) |
+
+## Headless
+
+`AskUserBlock` with `renderPending(questions, controls)` — controls expose `toggleOption`, `setOther`, `submit`, `skip`.

--- a/site/docs/chat-ui/components/attachment.md
+++ b/site/docs/chat-ui/components/attachment.md
@@ -1,0 +1,108 @@
+---
+title: Attachment
+parent: Components
+nav_order: 9
+---
+
+# Attachment
+
+Image attachment tiles for the composer and user messages — thumbnails, remove control, and click-to-preview. Inspired by [assistant-ui Attachments](https://www.assistant-ui.com/docs/guides/attachments), scoped to **vision images** (`ChatImage`) that jcode agents already send to the model.
+
+<div data-jcode-demo="attachment"></div>
+
+## Overview
+
+| Piece | Role |
+|-------|------|
+| `Attachment` | One image tile (+ optional × + lightbox) |
+| `AttachmentList` | Flex row of tiles |
+| `ChatInput` + `allowImages` | Paste + paperclip picker + strip above the input |
+| `Message` | Renders `message.images` with the same tiles |
+
+**Not included (by design):** PDF / arbitrary file adapters, upload progress, cloud storage. Those stay host concerns — attach your own chips next to the composer if needed. Most agent models only accept images today.
+
+## Usage
+
+```tsx
+import { Attachment, AttachmentList, ChatInput } from 'jcode-ui'
+import type { ChatImage } from 'jcode-ui-core'
+
+// Standalone tiles
+<Attachment image={img} size={56} onRemove={() => remove(i)} />
+<AttachmentList images={images} onRemove={remove} />
+
+// In the composer (preferred — handles paste + file picker)
+<ChatInput allowImages placeholder="Send a message…" />
+```
+
+`ChatImage` shape (shared with the jcode product):
+
+```ts
+interface ChatImage {
+  data: string        // base64, no data: prefix
+  media_type: string  // e.g. image/png
+  name?: string       // filename for tooltip / a11y
+}
+```
+
+## Props
+
+### Attachment
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `image` | `ChatImage` | Required. |
+| `onRemove` | `() => void` | Shows the × button when set (composer). |
+| `size` | `number` | Thumbnail px. Default `56`. |
+| `preview` | `boolean` | Click-to-lightbox. Default `true`. |
+
+### AttachmentList
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `images` | `ChatImage[]` | |
+| `onRemove` | `(index: number) => void` | |
+| `size` | `number` | Passthrough. |
+| `preview` | `boolean` | Passthrough. |
+| `className` | `string` | |
+
+### ChatInput attachment-related
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `allowImages` | `boolean` | Enables paste, paperclip, and the attachment strip. Gate on model vision. |
+| `acceptImages` | `string` | File input `accept`. Default `image/*`. |
+
+## How it wires (runtime)
+
+1. **Composer** (`jcode-ui-core`) owns pending images, paste handling, hidden file input, and size limits (`maxImageBytes`, default 10MB).
+2. **ChatInput** supplies the styled paperclip (`ComposerAddAttachment` equivalent) and `AttachmentList` strip (`ComposerAttachments`).
+3. On send, images go out via `actions.sendMessage(text, images)` / `enqueueMessage`.
+4. **Message** renders `message.images` with the same tiles (no remove).
+
+This keeps **library demos**, **docs**, and the **jcode product** (`web/src/components/ChatInput.tsx` uses `AttachmentList`) on one visual path.
+
+## Product (jcode web / desktop)
+
+- Attach entry: **+ menu → Image** (and paste into the textarea).
+- Capability gate: model `image_support` / settings “Allow image attachments”.
+- Thumbnails: shared `AttachmentList` (preview + remove).
+- Backend contract remains base64 `ChatImage[]` on the user message.
+
+## Compared to assistant-ui
+
+| assistant-ui | jcode-ui |
+|--------------|----------|
+| `AttachmentAdapter` (image / text / PDF / composite) | Image-only `ChatImage` pipeline |
+| Pending / uploading / error status | Immediate base64 decode (sync UX) |
+| `ComposerAddAttachment` primitive | `renderAddAttachment` + paperclip in `ChatInput` |
+| `UserMessageAttachments` | `Message` → `AttachmentList` |
+| External URL attachments | Host-owned if needed |
+
+If you need PDF-as-text or remote upload later, extend the host (product) and keep rendering custom chips beside `ChatInput` — don’t fork the image tile path.
+
+## Related
+
+- [ChatInput](/chat-ui/docs/components/chat-input)
+- [Message](/chat-ui/docs/components/message)
+- [assistant-ui Attachments guide](https://www.assistant-ui.com/docs/guides/attachments)

--- a/site/docs/chat-ui/components/chat-input.md
+++ b/site/docs/chat-ui/components/chat-input.md
@@ -1,0 +1,70 @@
+---
+title: ChatInput
+parent: Components
+nav_order: 2
+---
+
+# ChatInput
+
+The composer: autosizing textarea, send / queue / stop, slash-command palette, image attachments, and optional context ring.
+
+<div data-jcode-demo="chat-input" data-height="140"></div>
+
+## Usage
+
+```tsx
+import { ChatInput } from 'jcode-ui'
+
+<ChatInput
+  slashCommands={[{ slash: '/goal', description: 'set the session goal' }]}
+  allowImages={modelSupportsVision}
+  showContextBar
+  onSent={() => timelineSnapToBottom()}
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `slashCommands` | `SlashCommand[]` | — | Drives the `/` menu. |
+| `allowImages` | `boolean` | `false` | Gate by model vision support. Enables paste + paperclip + attachment strip. |
+| `acceptImages` | `string` | `'image/*'` | File picker `accept`. |
+| `placeholder` | `string` | `'Send a message…'` | |
+| `showContextBar` | `boolean` | `true` | Token ring suffix (`ContextBar`). |
+| `onSent` | `() => void` | — | Fires on send/queue (snap timeline). |
+
+```ts
+interface SlashCommand {
+  slash: string        // e.g. '/goal'
+  description?: string
+}
+```
+
+## Behavior
+
+| Runtime state | Composer behavior |
+|---------------|-------------------|
+| `isRunning === false` | Send → `actions.sendMessage` |
+| `isRunning === true` | Send → `actions.enqueueMessage` (type-ahead); button becomes **Stop** → `actions.stop` |
+| Queued messages | Chips rendered above the textarea |
+| Slash `/` | Filters `slashCommands` and inserts on select |
+| `allowImages` | Paperclip opens file picker; paste images into the textarea; strip uses `AttachmentList` |
+
+See [Attachment](/chat-ui/docs/components/attachment) for the shared tile API (library + product).
+
+Keyboard: Enter sends (Shift+Enter newline). IME composition is respected.
+
+## App chrome vs library
+
+`ChatInput` intentionally **excludes** model/mode/workspace pickers — those stay in the host product (see jcode web `ProjectHeader`). Compose them above or beside `ChatInput`.
+
+## Headless alternative
+
+`Composer` from `jcode-ui-core/primitives` exposes render slots (`renderSubmitButton`, `renderSlashMenu`, `renderAttachments`, …).
+
+## Related
+
+- [ContextBar](/chat-ui/docs/components/context-bar)  
+- [Attachment](/chat-ui/docs/components/attachment)  
+- [Slash commands guide](/chat-ui/docs/guides/slash-commands)  

--- a/site/docs/chat-ui/components/context-bar.md
+++ b/site/docs/chat-ui/components/context-bar.md
@@ -1,0 +1,49 @@
+---
+title: ContextBar
+parent: Components
+nav_order: 10
+---
+
+# ContextBar
+
+Token / context-window indicator. SVG ring showing occupancy (turns red at ≥90%) plus an optional hover popover with the bucket breakdown.
+
+<div data-jcode-demo="context-bar"></div>
+
+## Usage
+
+```tsx
+import { ContextBar } from 'jcode-ui'
+
+// Reads tokenSnapshot from the runtime automatically:
+<ContextBar size={20} breakdown={taskContextBreakdown} />
+```
+
+Embedded in `ChatInput` when `showContextBar` is true.
+
+## Props
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `breakdown` | `TaskContextBreakdown \| null` | — | Host-provided per-task stats for the popover. |
+| `size` | `number` | `20` | Ring diameter (px). |
+| `dangerThreshold` | `number` | `0.9` | 0–1; ring turns red above. |
+| `showPopover` | `boolean` | `true` | Hover breakdown. |
+
+## Data sources
+
+| Source | Field |
+|--------|-------|
+| Runtime | `tokenSnapshot.total_tokens` / `model_context_limit` |
+| Host (optional) | `TaskContextBreakdown` for system/tools/mcp/skills/messages |
+
+```ts
+interface TaskContextBreakdown {
+  context_limit: number
+  system_prompt_tokens: number
+  system_tools_tokens: number
+  mcp_tools_tokens: number
+  skills_tokens: number
+  messages_tokens: number
+}
+```

--- a/site/docs/chat-ui/components/message.md
+++ b/site/docs/chat-ui/components/message.md
@@ -1,0 +1,64 @@
+---
+title: Message
+parent: Components
+nav_order: 3
+---
+
+# Message
+
+A single chat turn — flat layout (avatar + role label + markdown body), not a chat bubble card. Usually rendered by `Thread`; use directly for custom layouts.
+
+<div data-jcode-demo="message"></div>
+
+## Usage
+
+```tsx
+import { Message } from 'jcode-ui'
+
+<Message message={msg} canEdit={msg.role === 'user' && !isRunning} />
+```
+
+## Props
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `message` | `Message` | See [types](/chat-ui/docs/api/types). |
+| `canEdit` | `boolean` | Shows edit affordance (typically user + idle). |
+
+## Message fields that drive UI
+
+| Field | Renders |
+|-------|---------|
+| `role` | Avatar glyph + label (You / JCODE / System / WeChat) |
+| `content` | Markdown via `renderMarkdown()` (marked + highlight.js + DOMPurify) |
+| `images[]` | Inline previews |
+| `reasoning` | Collapsible [Reasoning](/chat-ui/docs/components/reasoning) |
+| `sources[]` | [Sources](/chat-ui/docs/components/sources) chips |
+| `durationMs` | Turn elapsed label on assistant messages |
+| `level` / `detail` | System severity + expandable detail |
+| `source` | e.g. `'wechat'` tint |
+
+## Action bar (built-in)
+
+On hover / focus:
+
+- **Copy** — clipboard write of `content`
+- **Edit** — when `canEdit`; Enter saves via `actions.editMessage`, Esc cancels
+
+This is the jcode-ui equivalent of assistant-ui's ActionBar (copy/edit). Reload / speak / feedback are host concerns.
+
+## Markdown
+
+```ts
+import { renderMarkdown } from 'jcode-ui'
+
+const html = renderMarkdown('# Hello')
+```
+
+Same pipeline the component uses. No separate `<Markdown />` component is required.
+
+## Related
+
+- [Reasoning](/chat-ui/docs/components/reasoning)  
+- [Sources](/chat-ui/docs/components/sources)  
+- [Thread](/chat-ui/docs/components/thread)  

--- a/site/docs/chat-ui/components/reasoning.md
+++ b/site/docs/chat-ui/components/reasoning.md
@@ -1,0 +1,35 @@
+---
+title: Reasoning
+parent: Components
+nav_order: 7
+---
+
+# Reasoning
+
+Collapsible model thinking / chain-of-thought. Usually auto-rendered by `Message` when `message.reasoning` is set.
+
+<div data-jcode-demo="reasoning"></div>
+
+## Usage
+
+```tsx
+import { Reasoning } from 'jcode-ui'
+
+<Reasoning
+  reasoning={msg.reasoning}
+  durationMs={msg.durationMs}
+  defaultExpanded={false}
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `reasoning` | `string` | — | Markdown text of the model's thinking. |
+| `defaultExpanded` | `boolean` | `false` | Start open. |
+| `durationMs` | `number?` | — | Shows "Thought for Ns". |
+
+## Wiring from the host
+
+Set `reasoning` on assistant `Message` objects as the model streams thinking tokens (or after the turn completes). No separate message-part protocol is required — jcode-ui is field-driven.

--- a/site/docs/chat-ui/components/sources.md
+++ b/site/docs/chat-ui/components/sources.md
@@ -1,0 +1,36 @@
+---
+title: Sources
+parent: Components
+nav_order: 8
+---
+
+# Sources
+
+Citation list for a message. Auto-rendered by `Message` when `message.sources` is set.
+
+<div data-jcode-demo="sources"></div>
+
+## Usage
+
+```tsx
+import { Sources } from 'jcode-ui'
+
+<Sources sources={msg.sources} />
+```
+
+## Props
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `sources` | `MessageSource[]` | |
+
+```ts
+interface MessageSource {
+  id: string
+  title: string
+  url?: string
+  snippet?: string
+}
+```
+
+Click a chip to open the snippet popover; URL titles link out in a new tab.

--- a/site/docs/chat-ui/components/thread.md
+++ b/site/docs/chat-ui/components/thread.md
@@ -1,0 +1,74 @@
+---
+title: Thread
+parent: Components
+nav_order: 1
+---
+
+# Thread
+
+The conversation container. Renders the timeline with virtualization and the "follow only when at bottom" streaming contract.
+
+<div data-jcode-demo="thread" data-height="420"></div>
+
+## Usage
+
+```tsx
+import { Thread } from 'jcode-ui'
+
+<Thread
+  virtualize
+  overscanBottom={96}
+  emptyState={<EmptyState />}
+/>
+```
+
+Requires a parent `<RuntimeProvider>`. Tool cards need `<ToolRegistryProvider>` (or the default registry if you pass one higher up).
+
+## Props
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `virtualize` | `boolean` | `true` | TanStack Virtual. Disable for short/replay timelines. |
+| `overscanBottom` | `number` | `24` | Bottom padding (px) to clear a sticky composer. |
+| `emptyState` | `ReactNode` | — | Shown when no items + not running. |
+| `renderPending` | `() => ReactNode` | "Thinking…" | Trailing running indicator. |
+| `className` | `string` | — | Passthrough on the scroll container. |
+
+## What it renders
+
+Timeline items are a discriminated union:
+
+| `item.kind` | Component |
+|-------------|-----------|
+| `message` | `Message` (edit enabled for user messages while idle) |
+| `tool` | `ToolCallCard` (indented) |
+| `approval` | `ApprovalBanner` (indented) |
+
+While `isRunning`, a pending row appears at the bottom.
+
+## Empty state + suggestions
+
+Pass your own welcome UI via `emptyState`. Suggestion chips are host-owned — wire them to `actions.sendMessage`:
+
+```tsx
+const empty = (
+  <div className="p-8 text-center">
+    <h2>How can I help?</h2>
+    <button type="button" onClick={() => actions.sendMessage('Summarize this repo')}>
+      Summarize this repo
+    </button>
+  </div>
+)
+
+<Thread emptyState={empty} />
+```
+
+## Headless alternative
+
+For full control over item chrome, use `Thread` from `jcode-ui-core/primitives` with `renderItem`. See [Primitives](/chat-ui/docs/primitives).
+
+## Related
+
+- [ChatInput](/chat-ui/docs/components/chat-input)  
+- [Message](/chat-ui/docs/components/message)  
+- [Virtualization guide](/chat-ui/docs/guides/virtualization)  

--- a/site/docs/chat-ui/components/tool-call-card.md
+++ b/site/docs/chat-ui/components/tool-call-card.md
@@ -1,0 +1,65 @@
+---
+title: ToolCallCard
+parent: Components
+nav_order: 4
+---
+
+# ToolCallCard
+
+Expand/collapse shell for a tool invocation. Dispatches the body to a registered renderer. Recurses into `children` for subagent calls.
+
+<div data-jcode-demo="tool-call"></div>
+
+## Usage
+
+```tsx
+import { ToolCallCard } from 'jcode-ui'
+
+<ToolCallCard tool={toolCall} />
+```
+
+## Props
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `tool` | `ToolCall` | Tool call data. |
+| `registry` | `ToolRendererRegistry` | Optional override (defaults to context). |
+| `className` | `string` | Passthrough. |
+
+## Header chrome
+
+- Status glyph: running / done / error  
+- Title + subtitle from `displayInfo` (or extracted from args)  
+- Diff counter (+N/-M) for edit tools  
+- Shimmer while `status === 'running'`
+
+## Renderer dispatch
+
+```
+tool.name  →  ToolRendererRegistry.get(name)  →  fallback GenericRenderer
+```
+
+Default registry (via `createDefaultToolRegistry()`):
+
+| Tools | Renderer |
+|-------|----------|
+| `execute` | terminal |
+| `read`, `write` | file-viewer |
+| `edit`, `multi_edit` | diff |
+| `grep` | search |
+| `todowrite`, `todoread` | todo |
+| `load_skill` | skill |
+| team_* | team |
+| `browser_screenshot` | browser-shot |
+| * | generic |
+
+See [Tool renderers](/chat-ui/docs/tool-renderers) and the [custom renderer guide](/chat-ui/docs/guides/custom-tool-renderer).
+
+## Nested tools
+
+When `tool.children` is set (subagent), cards nest recursively — the assistant-ui "Tool Group" pattern.
+
+## Related
+
+- [AskUserCard](/chat-ui/docs/components/ask-user-card) (rendered inside tools with `askUserQuestions`)  
+- [ApprovalBanner](/chat-ui/docs/components/approval-banner)  

--- a/site/docs/chat-ui/examples.md
+++ b/site/docs/chat-ui/examples.md
@@ -1,0 +1,39 @@
+---
+title: Examples
+nav_order: 9
+---
+
+# Examples
+
+Runnable starters in the monorepo under `examples/`.
+
+| Example | Pattern | Path |
+|---------|---------|------|
+| **minimal** | `createMockRuntime` — no backend | [`examples/jcode-ui-minimal`](https://github.com/cnjack/jcode/tree/main/examples/jcode-ui-minimal) |
+| **zustand** | `createExternalStoreRuntime` + Zustand | [`examples/jcode-ui-zustand`](https://github.com/cnjack/jcode/tree/main/examples/jcode-ui-zustand) |
+
+## Quick start (minimal)
+
+```bash
+# from repo root — build packages once
+cd packages/jcode-ui-core && pnpm build
+cd ../jcode-ui && pnpm build
+
+cd ../../examples/jcode-ui-minimal
+pnpm install
+pnpm dev   # http://localhost:5177
+```
+
+## External store (Zustand)
+
+```bash
+cd examples/jcode-ui-zustand
+pnpm install
+pnpm dev   # http://localhost:5178
+```
+
+This is the production path: host store owns `ThreadItem[]`, the runtime only projects + binds actions. See the [external store guide](/chat-ui/docs/guides/external-store).
+
+## Live docs previews
+
+Every component page embeds a **Preview | Code** panel with the same components. Start at [Components](/chat-ui/docs/components) or the [marketing playground](/chat-ui).

--- a/site/docs/chat-ui/guides.md
+++ b/site/docs/chat-ui/guides.md
@@ -1,0 +1,17 @@
+---
+title: Guides
+nav_order: 8
+has_children: true
+---
+
+# Guides
+
+Practical recipes for integrating `jcode-ui` into an agent product. Skip multimodal/voice — focus on store wiring, tools, approvals, and streaming UX.
+
+| Guide | When to read |
+|-------|----------------|
+| [External store](/chat-ui/docs/guides/external-store) | Wiring Redux / Zustand / custom state |
+| [Custom tool renderer](/chat-ui/docs/guides/custom-tool-renderer) | Your agent emits tools jcode doesn't ship |
+| [Slash commands](/chat-ui/docs/guides/slash-commands) | `/goal`, `/compact`, host commands |
+| [Approvals](/chat-ui/docs/guides/approvals) | Human-in-the-loop gates |
+| [Virtualization](/chat-ui/docs/guides/virtualization) | Long threads, scroll contract |

--- a/site/docs/chat-ui/guides/approvals.md
+++ b/site/docs/chat-ui/guides/approvals.md
@@ -1,0 +1,53 @@
+---
+title: Approvals
+parent: Guides
+nav_order: 4
+---
+
+# Approvals
+
+Agent coding UIs need human gates before destructive tools. jcode-ui treats approvals as first-class timeline items.
+
+<div data-jcode-demo="approval"></div>
+
+## Host responsibilities
+
+1. When the agent requests confirmation, append:
+
+```ts
+{
+  kind: 'approval',
+  seq: ++seq,
+  data: {
+    id: 'ap_123',
+    tool_name: 'execute',
+    tool_args: JSON.stringify({ command: 'rm -rf build' }),
+    is_external: false,
+  },
+}
+```
+
+2. Implement `resolveApproval`:
+
+```ts
+resolveApproval: async (id, approved, approveAll) => {
+  await api.post('/approvals/resolve', { id, approved, approve_all: approveAll })
+  // mark item resolved in the timeline
+}
+```
+
+3. Optionally set `resolving: true` while the request is in flight.
+
+## UX details
+
+| Control | Behavior |
+|---------|----------|
+| Allow once | `approved=true`, `approveAll` unset |
+| Allow all | Two-step arm → confirm; then `approveAll=true` |
+| Deny | `approved=false` |
+
+External paths (`is_external`) get a stronger chip — use when the tool target escapes the workspace root.
+
+## Pair with tools
+
+Approvals sit **alongside** tool cards, not inside them. Typical order: assistant text → approval → tool (running) → tool (done).

--- a/site/docs/chat-ui/guides/custom-tool-renderer.md
+++ b/site/docs/chat-ui/guides/custom-tool-renderer.md
@@ -1,0 +1,70 @@
+---
+title: Custom tool renderer
+parent: Guides
+nav_order: 2
+---
+
+# Custom tool renderer
+
+`ToolCallCard` looks up a React component by `tool.name`. Ship your own for agent-specific tools.
+
+## 1. Write a renderer
+
+```tsx
+import type { ToolRenderer } from 'jcode-ui-core/adapters'
+
+const DeployRenderer: ToolRenderer = ({ name, args, output, status, error }) => {
+  const parsed = safeJson(args)
+  return (
+    <div className="p-3 text-sm">
+      <div className="font-mono text-xs opacity-70">{name} · {status}</div>
+      <div>env: {parsed?.env}</div>
+      {error && <pre className="text-red-500">{error}</pre>}
+      {output && <pre>{output}</pre>}
+    </div>
+  )
+}
+
+function safeJson(s: string) {
+  try { return JSON.parse(s) } catch { return null }
+}
+```
+
+## 2. Register
+
+```ts
+import { createDefaultToolRegistry } from 'jcode-ui'
+// or start empty:
+// import { createToolRendererRegistry } from 'jcode-ui-core/adapters'
+// import { GenericRenderer } from 'jcode-ui/tool-renderers'
+
+const registry = createDefaultToolRegistry()
+registry.register('custom_deploy', DeployRenderer)
+registry.register(['ship', 'deploy_prod'], DeployRenderer) // aliases
+```
+
+## 3. Provide
+
+```tsx
+<ToolRegistryProvider registry={registry}>
+  <Thread />
+</ToolRegistryProvider>
+```
+
+## Props contract
+
+| Prop | Notes |
+|------|-------|
+| `name` | Logical tool name |
+| `args` | Raw JSON string — parse what you need |
+| `output` / `displayOutput` | May be absent while running |
+| `error` | Failure string |
+| `status` | `'running' \| 'done' \| 'error'` |
+| `displayInfo` | Optional title/subtitle/icon from host |
+| `children` | Nested subagent tools — recurse with `ToolCallCard` if useful |
+
+Renderers should be **pure** — no store access, no side effects.
+
+## Gallery of defaults
+
+<div data-jcode-demo="tool-gallery"></div>

--- a/site/docs/chat-ui/guides/external-store.md
+++ b/site/docs/chat-ui/guides/external-store.md
@@ -1,0 +1,94 @@
+---
+title: External store
+parent: Guides
+nav_order: 1
+---
+
+# External store
+
+jcode-ui is **bring-your-own-state**. The host owns the conversation; the library only needs a `ChatRuntime`.
+
+## Pattern
+
+1. Keep timeline + flags in your store (RTK, Zustand, Valtio, …).  
+2. Project → `PartialRuntimeState` with `select`.  
+3. Bind UI actions to dispatches / API calls.  
+4. Wrap with `createExternalStoreRuntime` + `RuntimeProvider`.
+
+```tsx
+import { createExternalStoreRuntime, RuntimeProvider, Thread, ChatInput } from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const runtime = createExternalStoreRuntime({
+  store,
+  select: (s) => ({
+    items: s.chat.timeline,
+    isRunning: s.chat.isRunning,
+    tokenSnapshot: s.chat.tokenInfo,
+    goal: s.chat.goal,
+    todos: s.chat.todos,
+    queued: s.chat.queued,
+  }),
+  actions: {
+    sendMessage: (text, images) => {
+      // 1) optimistic user message into timeline
+      // 2) POST / stream agent events → append assistant / tools / approvals
+    },
+    enqueueMessage: (text, images) => { /* type-ahead queue */ },
+    removeQueuedMessage: (id) => { /* … */ },
+    stop: () => { /* abort controller / cancel run */ },
+    resolveApproval: (id, approved, approveAll) => { /* POST decision */ },
+    submitAskUser: (id, answers) => { /* POST answers */ },
+    editMessage: (id, newText) => { /* truncate timeline + resend */ },
+  },
+})
+
+export function Chat() {
+  return (
+    <RuntimeProvider runtime={runtime}>
+      <Thread />
+      <ChatInput />
+    </RuntimeProvider>
+  )
+}
+```
+
+## Timeline shape
+
+Your `items` array must be `ThreadItem[]` — interleaved messages, tools, and approvals with monotonic `seq` keys:
+
+```ts
+let seq = 0
+function pushMessage(msg: Message): ThreadItem {
+  return { kind: 'message', data: msg, seq: ++seq }
+}
+```
+
+Streaming: mutate the last assistant message's `content` (or replace the item immutably) and let the runtime notify subscribers. Do **not** reassign `seq` on the same logical row.
+
+## Zustand example
+
+```ts
+import { create } from 'zustand'
+import { createExternalStoreRuntime } from 'jcode-ui'
+
+const useChat = create((set, get) => ({
+  items: [] as ThreadItem[],
+  isRunning: false,
+  // …
+}))
+
+// Zustand's API is getState/subscribe compatible:
+const runtime = createExternalStoreRuntime({
+  store: useChat,
+  select: (s) => ({ items: s.items, isRunning: s.isRunning }),
+  actions: { /* … */ },
+})
+```
+
+## Checklist
+
+- [ ] `actions` object identity is stable (module-level or `useMemo`)  
+- [ ] `seq` never recycled for an in-place update  
+- [ ] `isRunning` true for the whole agent turn (drives stop button + pending row)  
+- [ ] Approvals and ask_user update the matching timeline item when resolved  

--- a/site/docs/chat-ui/guides/slash-commands.md
+++ b/site/docs/chat-ui/guides/slash-commands.md
@@ -1,0 +1,50 @@
+---
+title: Slash commands
+parent: Guides
+nav_order: 3
+---
+
+# Slash commands
+
+`ChatInput` / headless `Composer` filter a host-provided command list when the user types `/`.
+
+<div data-jcode-demo="chat-input" data-height="140"></div>
+
+## Provide commands
+
+```tsx
+const slashCommands = [
+  { slash: '/goal', description: 'Set or update the session goal' },
+  { slash: '/compact', description: 'Compact conversation context' },
+  { slash: '/clear', description: 'Clear the timeline' },
+]
+
+<ChatInput slashCommands={slashCommands} />
+```
+
+Selecting a row inserts the `slash` text at the caret (the host can still intercept on send).
+
+## Handle on send
+
+Slash menus only insert text. Interpretation happens in `sendMessage`:
+
+```ts
+actions: {
+  sendMessage: (text, images) => {
+    if (text.startsWith('/goal ')) {
+      dispatch(setGoal(text.slice(6)))
+      return
+    }
+    if (text.trim() === '/clear') {
+      dispatch(clearTimeline())
+      return
+    }
+    dispatch(sendToAgent({ text, images }))
+  },
+  // …
+}
+```
+
+## Headless customization
+
+Use `Composer` + `renderSlashMenu` for a design-system listbox, keyboard highlight, or remote-filtered results.

--- a/site/docs/chat-ui/guides/virtualization.md
+++ b/site/docs/chat-ui/guides/virtualization.md
@@ -1,0 +1,41 @@
+---
+title: Virtualization
+parent: Guides
+nav_order: 5
+---
+
+# Virtualization & stream follow
+
+Long agent sessions can produce thousands of timeline rows. `Thread` uses TanStack Virtual by default.
+
+## Defaults
+
+| Prop | Default | Meaning |
+|------|---------|---------|
+| `virtualize` | `true` | Window the DOM |
+| `overscanBottom` | `24` (styled) | Padding for sticky composer |
+| scroll threshold | `80` px (primitive) | "At bottom" hysteresis |
+
+## Follow-only-when-at-bottom
+
+While the user is near the bottom, new / streaming content auto-scrolls into view. If they scroll up to read earlier tools, the viewport **must not** yank down on every token.
+
+This contract is implemented in the headless `Thread` + `useAutoScroll` / `useStreamFollow` hooks.
+
+## When to disable virtualization
+
+```tsx
+<Thread virtualize={false} />
+```
+
+Use for:
+
+- Short session replays  
+- Screenshot / visual tests  
+- SSR first paint (hydrate, then enable)
+
+## Performance tips
+
+- Keep `seq` stable; don't remount the whole list on each token  
+- Prefer updating the last message's `content` over pushing new message items per chunk  
+- Avoid huge uncontrolled markdown in a single cell without collapse (tool cards already collapse)  

--- a/site/docs/chat-ui/index.md
+++ b/site/docs/chat-ui/index.md
@@ -1,7 +1,6 @@
 ---
-title: jcode-ui
+title: Overview
 nav_order: 0
-has_children: true
 ---
 
 # jcode-ui — React AI Chat Components
@@ -10,6 +9,8 @@ has_children: true
 messages, tool calls, approvals, and ask-user interactions. It powers jcode's own Web + Desktop UIs
 and is published as a standalone package so you can drop the same components into any agent or
 copilot.
+
+<div data-jcode-demo="thread" data-height="420"></div>
 
 ## Two packages
 
@@ -27,6 +28,8 @@ Use `jcode-ui` for the full styled experience, or reach for `jcode-ui-core` if y
 pnpm add jcode-ui jcode-ui-core
 # or: npm install jcode-ui jcode-ui-core
 ```
+
+See the full [Installation](/chat-ui/docs/installation) guide for Vite/Next setup, CSS, and a 5-minute mock runtime walkthrough.
 
 ## Quick start
 
@@ -69,10 +72,20 @@ mock, a replayed session, or a different state manager without touching the UI.
 On top of that, `ChatInput` is the composer (autosizing textarea, send/queue/stop, slash commands,
 image attachments, context bar).
 
-## Next
+## Docs map
 
-- [Runtime](/chat-ui/docs/runtime) — the `ChatRuntime` contract and `ExternalStoreRuntime`.
-- [Primitives](/chat-ui/docs/primitives) — the headless components under the styled layer.
-- [Tool renderers](/chat-ui/docs/tool-renderers) — the registry + writing your own.
-- [Theming](/chat-ui/docs/theming) — CSS custom properties and dark mode.
-- [Components](/chat-ui/docs/components) — props + examples for every styled component.
+| Section | Contents |
+|---------|----------|
+| [Installation](/chat-ui/docs/installation) | Package install, CSS, Vite/Next, mock runtime |
+| [Runtime](/chat-ui/docs/runtime) | `ChatRuntime`, external store, mock runtime |
+| [Primitives](/chat-ui/docs/primitives) | Headless building blocks |
+| [Components](/chat-ui/docs/components) | Styled components + live previews |
+| [Tool renderers](/chat-ui/docs/tool-renderers) | Registry + 9 defaults + gallery |
+| [Theming](/chat-ui/docs/theming) | CSS tokens, light/dark |
+| [API Reference](/chat-ui/docs/api) | Types, hooks, runtime, primitives |
+| [Guides](/chat-ui/docs/guides) | Recipes (store wiring, tools, approvals, …) |
+| [Examples](/chat-ui/docs/examples) | Cloneable Vite apps (mock + Zustand) |
+
+## Live playground
+
+The [chat-ui marketing page](/chat-ui) runs a full scripted conversation with the real components — no backend required.

--- a/site/docs/chat-ui/installation.md
+++ b/site/docs/chat-ui/installation.md
@@ -1,0 +1,192 @@
+---
+title: Installation
+nav_order: 1
+---
+
+# Installation
+
+Get `jcode-ui` rendering a live chat thread in about five minutes. No backend required for the first pass — use `createMockRuntime` for local demos, then swap in your store.
+
+## Requirements
+
+| Dependency | Version |
+|------------|---------|
+| React | `^18` or `^19` |
+| React DOM | `^18` or `^19` |
+| Bundler | Vite, Next.js, or any ESM-capable bundler |
+
+`jcode-ui` ships prebuilt CSS (Tailwind utilities are compiled in). You do **not** need to configure Tailwind in the host app unless you want to extend tokens.
+
+## 1. Install packages
+
+```bash
+pnpm add jcode-ui jcode-ui-core
+# npm install jcode-ui jcode-ui-core
+# yarn add jcode-ui jcode-ui-core
+```
+
+Both packages are required for the styled surface (`jcode-ui` depends on `jcode-ui-core`). Tree-shakeable subpaths:
+
+| Import | Purpose |
+|--------|---------|
+| `jcode-ui` | Styled components + runtime re-exports |
+| `jcode-ui/styles.css` | Required stylesheet |
+| `jcode-ui/tool-renderers` | Individual tool renderers |
+| `jcode-ui-core` | Types + everything |
+| `jcode-ui-core/runtime` | Runtime only |
+| `jcode-ui-core/primitives` | Headless primitives |
+| `jcode-ui-core/adapters` | Tool registry |
+| `jcode-ui-core/hooks` | Behavioral hooks |
+
+## 2. Import styles
+
+```tsx
+import 'jcode-ui/styles.css'
+```
+
+Put this once at your app root (or the route that mounts the chat UI). The file includes:
+
+1. Compiled Tailwind utilities used by components  
+2. Base design tokens (`:root` light + `.dark` dark)  
+3. Animations (tool shimmer)  
+4. Component-local styles (code blocks, diff tables)
+
+### Dark mode
+
+Add the `.dark` class on `<html>` (or a wrapping ancestor):
+
+```ts
+document.documentElement.classList.toggle('dark')
+```
+
+## 3. Minimal app (mock runtime)
+
+```tsx
+import {
+  RuntimeProvider,
+  ToolRegistryProvider,
+  createDefaultToolRegistry,
+  createMockRuntime,
+  Thread,
+  ChatInput,
+} from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const runtime = createMockRuntime()
+const registry = createDefaultToolRegistry()
+
+// Seed a couple of items so the thread isn't empty:
+runtime.push({
+  kind: 'message',
+  seq: 1,
+  data: {
+    id: 'm1',
+    role: 'user',
+    content: 'Hello jcode-ui',
+    timestamp: Date.now(),
+  },
+})
+runtime.push({
+  kind: 'message',
+  seq: 2,
+  data: {
+    id: 'm2',
+    role: 'assistant',
+    content: 'Hi — components are live.',
+    timestamp: Date.now(),
+  },
+})
+
+export function App() {
+  return (
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <RuntimeProvider runtime={runtime}>
+        <ToolRegistryProvider registry={registry}>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <Thread />
+          </div>
+          <ChatInput />
+        </ToolRegistryProvider>
+      </RuntimeProvider>
+    </div>
+  )
+}
+```
+
+<div data-jcode-demo="thread" data-height="360"></div>
+
+## 4. Wire your own store (production path)
+
+jcode-ui never owns the conversation. Wrap any Redux-shaped store:
+
+```tsx
+import { createExternalStoreRuntime, RuntimeProvider, Thread, ChatInput } from 'jcode-ui'
+
+const runtime = createExternalStoreRuntime({
+  store, // { getState, subscribe }
+  select: (s) => ({
+    items: s.chat.timeline,
+    isRunning: s.chat.isRunning,
+    tokenSnapshot: s.chat.tokenInfo,
+    goal: s.chat.goal,
+    todos: s.chat.todos,
+    queued: s.chat.queued,
+  }),
+  actions: {
+    sendMessage: (text, images) => dispatch(sendMessage({ text, images })),
+    enqueueMessage: (text, images) => dispatch(enqueue({ text, images })),
+    removeQueuedMessage: (id) => dispatch(removeQueued(id)),
+    stop: () => dispatch(stopAgent()),
+    resolveApproval: (id, approved, approveAll) =>
+      dispatch(resolveApproval({ id, approved, approveAll })),
+    submitAskUser: (id, answers) => dispatch(submitAskUser({ id, answers })),
+    editMessage: (id, text) => dispatch(editAndResend({ id, text })),
+  },
+})
+```
+
+Full recipe: [External store guide](/chat-ui/docs/guides/external-store).
+
+## Framework notes
+
+### Vite
+
+```tsx
+// main.tsx
+import 'jcode-ui/styles.css'
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+
+createRoot(document.getElementById('root')!).render(<App />)
+```
+
+No extra Vite plugins required.
+
+### Next.js (App Router)
+
+Import styles in the root layout and render chat UI in a **client** component:
+
+```tsx
+// app/layout.tsx
+import 'jcode-ui/styles.css'
+
+// app/chat/page.tsx
+'use client'
+import { Chat } from './Chat'
+export default function Page() {
+  return <Chat />
+}
+```
+
+If you see hydration warnings around virtualization, disable it for SSR-first paints (`<Thread virtualize={false} />`) or only mount the thread after `useEffect`.
+
+## TypeScript
+
+Types ship with the packages (`"types"` export). No `@types/*` package is needed beyond React.
+
+## Next steps
+
+- [Runtime](/chat-ui/docs/runtime) — state contract in depth  
+- [Components](/chat-ui/docs/components) — every styled component with live previews  
+- [Custom tool renderers](/chat-ui/docs/guides/custom-tool-renderer) — render your agent tools  
+- [API Reference](/chat-ui/docs/api) — full type surface  

--- a/site/docs/chat-ui/primitives.md
+++ b/site/docs/chat-ui/primitives.md
@@ -1,7 +1,6 @@
 ---
 title: Primitives
-parent: jcode-ui
-nav_order: 2
+nav_order: 3
 ---
 
 # Headless primitives
@@ -9,6 +8,12 @@ nav_order: 2
 Under every styled `jcode-ui` component is a headless primitive in `jcode-ui-core` — behavior with
 no styling. Use these directly when you want the logic (streaming, virtualization, keyboard
 handling) but your own visual language.
+
+```ts
+import { Thread, MessageView, Composer, ToolCallView, ApprovalBlock, AskUserBlock } from 'jcode-ui-core/primitives'
+```
+
+Full prop tables: [API → Primitives](/chat-ui/docs/api/primitives).
 
 ## Thread
 
@@ -36,10 +41,8 @@ Key behaviors:
 - **Virtualization** via TanStack Virtual — handles 10k-message threads. Set `virtualize={false}` for
   short replay timelines where DOM simplicity matters.
 - **Auto-follow**: when the user is within `scrollThreshold` px of the bottom, new/streaming content
-  scrolls into view. Scroll up to read and the view won't yank back down — the core streaming-UX
-  contract.
-- **`seq` keying**: each `ThreadItem` carries a `seq` counter used as the React key, keeping DOM
-  identity stable across streaming updates.
+  scrolls into view. Scroll up to read and the view won't yank back down.
+- **`seq` keying**: each `ThreadItem` carries a `seq` counter used as the React key.
 
 ## MessageView
 
@@ -68,12 +71,14 @@ import { Composer } from 'jcode-ui-core/primitives'
   slashCommands={[{ slash: '/goal', description: 'set the session goal' }]}
   allowImages={modelSupportsVision}
   onSent={() => timelineSnapToBottom()}
-  renderSubmitButton={(mode, disabled) => <MyButton ... />}
+  renderSubmitButton={(mode, disabled, onActivate) => (
+    <MyButton disabled={disabled} onClick={onActivate} />
+  )}
 />
 ```
 
 When the runtime reports `isRunning`, `send()` routes to `enqueueMessage` (type-ahead) and the
-button slot receives `mode: 'stop'`.
+button slot receives `mode: 'stop'`. Always wire `onActivate` on the submit control.
 
 ## ToolCallView
 
@@ -128,3 +133,26 @@ import { AskUserBlock } from 'jcode-ui-core/primitives'
 
 The `controls` object exposes `toggleOption`, `setOther`, `submit`, `skip` — so a styled consumer
 needs no local state.
+
+## Behavioral hooks
+
+```ts
+import { useAutoScroll, useStreamFollow, useFocusOnIdle, useQueuedMessages } from 'jcode-ui-core/hooks'
+```
+
+| Hook | Purpose |
+|------|---------|
+| `useAutoScroll(threshold?)` | Track "at bottom" + `scrollToBottom` |
+| `useStreamFollow(autoScroll, dep)` | Follow stream only when at bottom |
+| `useFocusOnIdle(isRunning)` | Refocus composer when turn ends |
+| `useQueuedMessages()` | Read type-ahead queue |
+
+See [API → Hooks](/chat-ui/docs/api/hooks).
+
+## Styled vs headless
+
+| Need | Use |
+|------|-----|
+| Drop-in jcode look | `jcode-ui` (`Thread`, `ChatInput`, …) |
+| Own design system | `jcode-ui-core/primitives` + your CSS |
+| Mix | Styled `Thread` + custom `Composer` slots, etc. |

--- a/site/docs/chat-ui/runtime.md
+++ b/site/docs/chat-ui/runtime.md
@@ -1,7 +1,6 @@
 ---
 title: Runtime
-parent: jcode-ui
-nav_order: 1
+nav_order: 2
 ---
 
 # ChatRuntime
@@ -19,7 +18,7 @@ interface ChatRuntime {
 }
 ```
 
-`RuntimeState` is the read side:
+### RuntimeState (read side)
 
 ```ts
 interface RuntimeState {
@@ -32,7 +31,7 @@ interface RuntimeState {
 }
 ```
 
-`RuntimeActions` is the write side — callbacks the UI dispatches:
+### RuntimeActions (write side)
 
 ```ts
 interface RuntimeActions {
@@ -46,6 +45,8 @@ interface RuntimeActions {
 }
 ```
 
+Full field reference: [API → Runtime](/chat-ui/docs/api/runtime) · [API → Types](/chat-ui/docs/api/types).
+
 ## Wrapping an external store
 
 `createExternalStoreRuntime` adapts any Redux-shaped store. You provide a `select` function that
@@ -53,10 +54,7 @@ projects your full app state down to a (possibly partial) `RuntimeState` — mis
 to safe empties.
 
 ```ts
-import { configureStore } from '@reduxjs/toolkit'
 import { createExternalStoreRuntime } from 'jcode-ui'
-
-const store = configureStore({ /* your reducers */ })
 
 const runtime = createExternalStoreRuntime({
   store,
@@ -81,30 +79,75 @@ const runtime = createExternalStoreRuntime({
 })
 ```
 
-The action bag's identity should be stable (memoize it) — the components don't depend on it changing.
+**Options**
+
+| Option | Type | Notes |
+|--------|------|-------|
+| `store` | `{ getState, subscribe }` | Redux / Zustand / custom |
+| `select` | `(state) => PartialRuntimeState` | Project host → runtime |
+| `actions` | `RuntimeActions` | Keep identity stable (memoize) |
+
+Snapshot caching: `getState()` returns a **stable reference** between host dispatches so
+`useSyncExternalStore` does not loop.
 
 ## Subscribing in components
 
 Under a `<RuntimeProvider>`, three hooks read state:
 
 ```ts
-const items      = useRuntimeSelector((s) => s.items)       // granular; re-renders only on items change
-const state      = useRuntimeState()                        // full state; re-renders on any change
-const actions    = useRuntimeActions()                      // stable action bag
+const items   = useRuntimeSelector((s) => s.items)  // granular re-renders
+const state   = useRuntimeState()                     // full state
+const actions = useRuntimeActions()                   // stable action bag
 ```
 
-`useRuntimeSelector` is the preferred read — it memoizes via a ref cache so a stable selector
-returning a primitive won't trigger spurious re-renders.
+Prefer `useRuntimeSelector` for hot paths (timeline length, `isRunning`).
 
 ## Mock runtime
 
 For docs, tests, and demos, `createMockRuntime` gives you a scriptable runtime with no backend:
 
 ```ts
-const rt = createMockRuntime()
+const rt = createMockRuntime({
+  items: [],
+  state: { tokenSnapshot: { total_tokens: 1000, prompt_tokens: 800, completion_tokens: 200, model_context_limit: 128000 } },
+})
+
 rt.push({ kind: 'message', seq: 1, data: { id: 'm1', role: 'user', content: 'hi', timestamp: 0 } })
 rt.appendText('Hello!')   // streams into the last assistant message
 rt.setRunning(true)
+rt.patchState({ goal: { objective: 'Ship the UI', status: 'active' } })
 ```
 
-This is exactly what powers the [live demo on the chat-ui page](/chat-ui).
+### Mutators
+
+| Method | Purpose |
+|--------|---------|
+| `setItems(items)` | Replace timeline |
+| `push(item)` | Append one item |
+| `setRunning(bool)` | Toggle agent-running |
+| `appendText(delta)` | Stream into last assistant message |
+| `patchState(partial)` | Merge token/goal/todos/queued/… |
+| `calls` | Recorded action invocations (tests) |
+
+Default `resolveApproval` / `submitAskUser` handlers update items in-place so interactive demos work without a backend.
+
+This powers the [live demo](/chat-ui) and every docs preview on this site.
+
+## Providers
+
+```tsx
+<RuntimeProvider runtime={runtime}>
+  <ToolRegistryProvider registry={createDefaultToolRegistry()}>
+    <Thread />
+    <ChatInput />
+  </ToolRegistryProvider>
+</RuntimeProvider>
+```
+
+Optional: `<ApiBaseProvider apiBase={…}>` so `browser_screenshot` can resolve image URLs.
+
+## Related
+
+- [External store guide](/chat-ui/docs/guides/external-store)  
+- [API → Runtime](/chat-ui/docs/api/runtime)  
+- [API → Hooks](/chat-ui/docs/api/hooks)  

--- a/site/docs/chat-ui/theming.md
+++ b/site/docs/chat-ui/theming.md
@@ -1,14 +1,14 @@
 ---
 title: Theming
-parent: jcode-ui
-nav_order: 4
+nav_order: 6
 ---
 
 # Theming
 
 Every color, radius, shadow, and transition in jcode-ui is a CSS custom property. There are no
-hardcoded hex values in the components — so you can retheme the entire UI by overriding tokens,
-with zero component edits.
+hardcoded hex values in the components — retheme by overriding tokens, with zero component edits.
+
+<div data-jcode-demo="theming"></div>
 
 ## Importing the base theme
 
@@ -18,20 +18,18 @@ import 'jcode-ui/styles.css'
 
 This brings in:
 
-1. Tailwind CSS 4 utilities.
-2. The base design tokens (`:root` light + `.dark` dark).
-3. Animations (shimmer for running tools).
-4. Component-local styles (code blocks, diff tables).
+1. Tailwind CSS 4 utilities used by components  
+2. Base design tokens (`:root` light + `.dark` dark)  
+3. Animations (shimmer for running tools)  
+4. Component-local styles (code blocks, diff tables)
 
 ## Light / dark mode
 
-Dark mode is toggled by a `.dark` class on `<html>`:
+Dark mode is toggled by a `.dark` class on `<html>` (or a wrapping ancestor):
 
 ```html
 <html class="dark"> ... </html>
 ```
-
-Toggle it at runtime:
 
 ```ts
 document.documentElement.classList.toggle('dark')
@@ -39,11 +37,9 @@ document.documentElement.classList.toggle('dark')
 
 ## Overriding tokens
 
-Override any token in your own CSS, scoped to `:root` and/or `.dark`:
-
 ```css
 :root {
-  --color-primary: #6366f1;       /* rebrand the accent */
+  --color-primary: #6366f1;
   --color-background: #fafaf9;
   --radius-lg: 10px;
 }
@@ -53,32 +49,25 @@ Override any token in your own CSS, scoped to `:root` and/or `.dark`:
 }
 ```
 
-Every component picks up the change — buttons, the send icon, selection highlights, focus rings.
-
-## The token reference
-
-These are the tokens jcode-ui components read (defined in `tokens.css`):
+## Token reference
 
 **Colors** — `--color-primary`, `--color-background`, `--color-surface`, `--color-foreground`,
 `--color-muted-foreground`, `--color-border`, `--color-muted`, `--color-secondary`,
-`--color-success`/`-bg`/`-fg`, `--color-error`/`-bg`/`-fg`, `--color-warning`/`-bg`/`-fg`,
-`--color-info`/`-bg`/`-fg`, `--color-destructive`, `--color-on-primary`, `--color-on-destructive`.
+`--color-success` / `-bg` / `-fg`, `--color-error` / `-bg` / `-fg`, `--color-warning` / `-bg` / `-fg`,
+`--color-info` / `-bg` / `-fg`, `--color-destructive`, `--color-on-primary`, `--color-on-destructive`.
 
 **Code** — `--code-bg`, `--code-border`, plus the full `--hljs-*` syntax-highlight palette.
 
-**Accent washes** (derived from `--color-primary` via `color-mix`) — `--accent-wash-soft`,
-`--accent-wash`, `--accent-wash-strong`, `--accent-border`, `--accent-fill`, `--accent-selection`.
+**Accent washes** (from `--color-primary` via `color-mix`) — `--accent-wash-soft`, `--accent-wash`,
+`--accent-wash-strong`, `--accent-border`, `--accent-fill`, `--accent-selection`.
 
 **Radii** — `--radius-xs` / `sm` / `md` / `lg` / `xl` / `2xl` / `pill`.
 
 **Shadows** — `--shadow-sm` / `md` / `lg` / `xl`, `--backdrop`.
 
-**Motion** — `--ease-out`, `--ease-in`, `--ease-spring`, `--duration-fast` / `normal` / `slow` /
-`slower`.
+**Motion** — `--ease-out`, `--ease-in`, `--ease-spring`, `--duration-fast` / `normal` / `slow` / `slower`.
 
-## Generated themes
+## Generated themes (jcode product)
 
-jcode itself ships generated themes (dracula, nord, solarized, …) produced by a Go generator from a
-single palette. Those live outside this package — they're emitted as
-`html[data-theme="<id>"] { --color-…: … }` blocks and loaded by the host app. jcode-ui's components
-work with any of them because they only read tokens.
+jcode ships generated themes (dracula, nord, solarized, …) from a Go palette generator as
+`html[data-theme="<id>"] { --color-… }` blocks. jcode-ui only reads tokens, so those themes work as long as the host sets the same custom properties.

--- a/site/docs/chat-ui/tool-renderers.md
+++ b/site/docs/chat-ui/tool-renderers.md
@@ -1,33 +1,33 @@
 ---
 title: Tool renderers
-parent: jcode-ui
-nav_order: 3
+nav_order: 5
 ---
 
 # Tool renderers
 
 `ToolCallCard` doesn't know how to render any specific tool. It looks up a renderer by `tool.name`
 in a `ToolRendererRegistry`. jcode-ui ships default renderers; you can override or extend with your
-own. This is what makes the component reusable across agents with completely different tool
-surfaces.
+own.
 
-## The default registry
+## Live gallery
 
-`createDefaultToolRegistry()` registers renderers for the common jcode tools:
+<div data-jcode-demo="tool-gallery"></div>
+
+## Default registry
+
+`createDefaultToolRegistry()` registers renderers for common jcode tools:
 
 | Tool name(s) | Renderer | Shows |
 |--------------|----------|-------|
 | `execute` | terminal | `$ command` + stdout/stderr |
-| `read`, `write` | file-viewer | line-numbered table (`   N│content`) |
+| `read`, `write` | file-viewer | line-numbered table |
 | `edit`, `multi_edit` | diff | red/green line table |
 | `grep` | search | `file:line:content` matches |
 | `todowrite`, `todoread` | todo | status-icon task list |
 | `load_skill` | skill | name + description card |
-| `team_list` / `team_send_message` / `team_create` | team | member tables / message cards |
+| `team_list` / `team_send_message` / `team_create` / `team_spawn` | team | members / messages |
 | `browser_screenshot` | browser-shot | inline screenshot image |
-| *(fallback)* | generic | args + output + error columns |
-
-Provide it once at the app root via `<ToolRegistryProvider>`:
+| *(fallback)* | generic | args + output + error |
 
 ```tsx
 import { ToolRegistryProvider, createDefaultToolRegistry } from 'jcode-ui'
@@ -41,13 +41,10 @@ const registry = createDefaultToolRegistry()
 
 ## Writing a custom renderer
 
-A renderer is a React component receiving `ToolRendererProps`:
-
 ```tsx
 import type { ToolRenderer } from 'jcode-ui-core/adapters'
 
 const MyRenderer: ToolRenderer = ({ name, args, output, status }) => {
-  const data = JSON.parse(args)
   return (
     <div>
       <h4>{name}</h4>
@@ -57,27 +54,23 @@ const MyRenderer: ToolRenderer = ({ name, args, output, status }) => {
 }
 ```
 
-Register it:
-
 ```ts
 import { createToolRendererRegistry } from 'jcode-ui-core/adapters'
 import { GenericRenderer } from 'jcode-ui/tool-renderers'
 
 const registry = createToolRendererRegistry()
 registry.register('my_custom_tool', MyRenderer)
-registry.setFallback(GenericRenderer)   // for tools without a specific renderer
+registry.setFallback(GenericRenderer)
 ```
 
-You can also register against multiple names at once:
+Or extend the defaults:
 
 ```ts
-registry.register(['tool_a', 'tool_b'], SharedRenderer)
+const registry = createDefaultToolRegistry()
+registry.register('my_custom_tool', MyRenderer)
 ```
 
 ## Importing individual renderers
-
-Each default renderer is individually importable so you can tree-shake or compose your own
-registry:
 
 ```ts
 import { TerminalRenderer, DiffRenderer, GenericRenderer } from 'jcode-ui/tool-renderers'
@@ -85,17 +78,19 @@ import { TerminalRenderer, DiffRenderer, GenericRenderer } from 'jcode-ui/tool-r
 
 ## Render prop contract
 
-Every renderer receives:
-
 | Prop | Type | Notes |
 |------|------|-------|
 | `name` | `string` | logical tool name |
-| `args` | `string` | raw args JSON — parse what you need |
+| `args` | `string` | raw args JSON |
 | `output` | `string?` | raw output (omitted while running) |
-| `displayOutput` | `string?` | clean output (metadata stripped) |
-| `error` | `string?` | error string on failure |
-| `status` | `'running' \| 'done' \| 'error'` | drives shimmer / error tinting |
+| `displayOutput` | `string?` | clean output |
+| `error` | `string?` | on failure |
+| `status` | `'running' \| 'done' \| 'error'` | |
 | `displayInfo` | `ToolDisplayInfo?` | pre-extracted title/subtitle/icon |
-| `children` | `ToolCall[]?` | nested subagent calls — recurse if relevant |
+| `children` | `ToolCall[]?` | nested subagent calls |
 
 Renderers are pure functions of these props — no store access, no side effects.
+
+## Guide
+
+Step-by-step: [Custom tool renderer](/chat-ui/docs/guides/custom-tool-renderer).

--- a/site/package.json
+++ b/site/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "generate:api-docs": "node ../script/generate_jcode_ui_api_docs.mjs"
   },
   "dependencies": {
     "@remotion/player": "4.0.410",
     "github-slugger": "^2.0.0",
+    "highlight.js": "^11.11.1",
     "jcode-ui": "file:../packages/jcode-ui",
     "jcode-ui-core": "file:../packages/jcode-ui-core",
     "react": "^18.3.1",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       jcode-ui:
         specifier: file:../packages/jcode-ui
         version: file:../packages/jcode-ui(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,0 +1,60 @@
+# jcode-ui
+
+> React components for AI chat interfaces — streaming messages, tool calls, approvals, and ask-user interactions. Backend-agnostic, token-driven. Powers jcode Web + Desktop.
+
+Packages: `jcode-ui` (styled) · `jcode-ui-core` (types, runtime, headless primitives)
+
+## Docs
+
+- [Overview](https://www.j-code.net/chat-ui/docs): Library intro + quick start
+- [Installation](https://www.j-code.net/chat-ui/docs/installation): Install, CSS, Vite/Next, mock runtime
+- [Runtime](https://www.j-code.net/chat-ui/docs/runtime): ChatRuntime, external store, mock runtime
+- [Primitives](https://www.j-code.net/chat-ui/docs/primitives): Headless Thread / Composer / ApprovalBlock / …
+- [Components](https://www.j-code.net/chat-ui/docs/components): Styled component catalog
+- [Thread](https://www.j-code.net/chat-ui/docs/components/thread)
+- [ChatInput](https://www.j-code.net/chat-ui/docs/components/chat-input)
+- [Message](https://www.j-code.net/chat-ui/docs/components/message)
+- [ToolCallCard](https://www.j-code.net/chat-ui/docs/components/tool-call-card)
+- [ApprovalBanner](https://www.j-code.net/chat-ui/docs/components/approval-banner)
+- [AskUserCard](https://www.j-code.net/chat-ui/docs/components/ask-user-card)
+- [Reasoning](https://www.j-code.net/chat-ui/docs/components/reasoning)
+- [Sources](https://www.j-code.net/chat-ui/docs/components/sources)
+- [Attachment](https://www.j-code.net/chat-ui/docs/components/attachment)
+- [ContextBar](https://www.j-code.net/chat-ui/docs/components/context-bar)
+- [Tool renderers](https://www.j-code.net/chat-ui/docs/tool-renderers): Registry + defaults + gallery
+- [Theming](https://www.j-code.net/chat-ui/docs/theming): CSS tokens
+- [API Reference](https://www.j-code.net/chat-ui/docs/api)
+- [Types](https://www.j-code.net/chat-ui/docs/api/types)
+- [Runtime API](https://www.j-code.net/chat-ui/docs/api/runtime)
+- [Hooks](https://www.j-code.net/chat-ui/docs/api/hooks)
+- [Primitives API](https://www.j-code.net/chat-ui/docs/api/primitives)
+- [Components API](https://www.j-code.net/chat-ui/docs/api/components)
+- [Guides](https://www.j-code.net/chat-ui/docs/guides)
+- [External store](https://www.j-code.net/chat-ui/docs/guides/external-store)
+- [Custom tool renderer](https://www.j-code.net/chat-ui/docs/guides/custom-tool-renderer)
+- [Slash commands](https://www.j-code.net/chat-ui/docs/guides/slash-commands)
+- [Approvals](https://www.j-code.net/chat-ui/docs/guides/approvals)
+- [Virtualization](https://www.j-code.net/chat-ui/docs/guides/virtualization)
+- [Live playground](https://www.j-code.net/chat-ui)
+- [Examples](https://www.j-code.net/chat-ui/docs/examples): cloneable Vite starters
+- [Generated API](https://www.j-code.net/chat-ui/docs/api/generated): full symbol dump from sources
+
+## Examples (repo)
+
+- https://github.com/cnjack/jcode/tree/main/examples/jcode-ui-minimal
+- https://github.com/cnjack/jcode/tree/main/examples/jcode-ui-zustand
+
+## Install
+
+```bash
+pnpm add jcode-ui jcode-ui-core
+```
+
+```tsx
+import { RuntimeProvider, createMockRuntime, Thread, ChatInput } from 'jcode-ui'
+import 'jcode-ui/styles.css'
+```
+
+## Out of scope (for now)
+
+Voice / dictation, branch picker, assistant-ui Cloud, audio multimodal widgets.

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -73,6 +73,11 @@ export default function App() {
               <Route index element={<ChatUiDocsIndex />} />
               <Route path="*" element={<ChatUiDocPage />} />
             </Route>
+            {/* Legacy product-docs path used in older links / README */}
+            <Route path="/docs/chat-ui" element={<ChatUiDocsLayout />}>
+              <Route index element={<ChatUiDocsIndex />} />
+              <Route path="*" element={<ChatUiDocPage />} />
+            </Route>
             <Route path="/showcase" element={<ShowcasePage />} />
             <Route path="/privacy" element={<PrivacyPage />} />
             <Route path="/docs" element={<DocsLayout />}>

--- a/site/src/lib/chatUiDocs.ts
+++ b/site/src/lib/chatUiDocs.ts
@@ -3,13 +3,13 @@
  *
  * The jcode-ui component library is an independent, npm-published product, so
  * its documentation lives in its own nav tree and route (/chat-ui/docs/*), NOT
- * mixed into the jcode product docs (/docs/*). This file mirrors docs.ts but
- * loads only site/docs/chat-ui/*.md and builds an independent nav.
+ * mixed into the jcode product docs (/docs/*). Supports nested sections:
+ * components/, api/, guides/.
  */
 
 import GithubSlugger from 'github-slugger'
 
-const rawDocs = import.meta.glob('../../docs/chat-ui/*.md', {
+const rawDocs = import.meta.glob('../../docs/chat-ui/**/*.md', {
   query: '?raw',
   import: 'default',
   eager: true,
@@ -28,7 +28,6 @@ export interface ChatUiDocEntry {
 
 export interface ChatUiNavNode {
   entry: ChatUiDocEntry
-  /** Child docs (single level — chat-ui docs don't nest deeper). */
   children: ChatUiDocEntry[]
 }
 
@@ -41,32 +40,57 @@ function parseFrontmatter(raw: string): { fm: Record<string, string | number | b
     if (!mm) continue
     const [, k, v] = mm
     const clean = (v || '').replace(/["']/g, '').trim()
-    fm[k] = clean === 'true' ? true : clean === 'false' ? false : /^\d+$/.test(clean) ? Number(clean) : clean
+    fm[k] =
+      clean === 'true' ? true : clean === 'false' ? false : /^\d+$/.test(clean) ? Number(clean) : clean
   }
   return { fm, body: m[2] || '' }
 }
 
-function transformMarkdown(body: string): { html: string; headings: { id: string; text: string; level: number }[] } {
-  // Minimal transform: the DocPage renders markdown via react-markdown, so we
-  // only need to extract headings for the in-page ToC. The body is passed
-  // through as-is.
+function transformBody(body: string): string {
+  // Leading blank lines after `---` are common — trim before stripping the H1.
+  let out = body.replace(/^\s+/, '')
+  // Strip leading h1 that duplicates front-matter title (page renders its own <h1>).
+  out = out.replace(/^#\s+.+\n+/, '')
+  // Normalize internal links that still point at product-docs style paths.
+  out = out.replace(/\]\(\/docs\/chat-ui\/?/g, '](/chat-ui/docs/')
+  out = out.replace(/\]\(\/chat-ui\/docs\/docs\//g, '](/chat-ui/docs/')
+  return out
+}
+
+function extractHeadings(body: string): { id: string; text: string; level: number }[] {
   const headings: { id: string; text: string; level: number }[] = []
   const slugger = new GithubSlugger()
+  let inFence = false
   for (const line of body.split('\n')) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
     const m = line.match(/^(#{2,4})\s+(.*)$/)
     if (m) {
       const level = m[1].length
-      const text = m[2].replace(/[`*_]/g, '').trim()
+      const text = m[2].replace(/[`*_]/g, '').replace(/\[([^\]]*)\]\([^)]*\)/g, '$1').trim()
       headings.push({ id: slugger.slug(text), text, level })
     }
   }
-  return { html: body, headings }
+  return headings
+}
+
+function toPlain(md: string): string {
+  return md
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#>*_`|[\]()!-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
 }
 
 const DOCS: ChatUiDocEntry[] = Object.entries(rawDocs).map(([path, raw]) => {
-  const slug = path.replace('../../docs/chat-ui/', '').replace(/\.md$/, '')
-  const { fm, body } = parseFrontmatter(raw)
-  const { headings } = transformMarkdown(body)
+  // path like ../../docs/chat-ui/components/thread.md → components/thread
+  const slug = path.replace(/^.*\/docs\/chat-ui\//, '').replace(/\.md$/, '')
+  const { fm, body: rawBody } = parseFrontmatter(raw)
+  const body = transformBody(rawBody)
   return {
     slug,
     title: String(fm.title ?? slug),
@@ -74,23 +98,71 @@ const DOCS: ChatUiDocEntry[] = Object.entries(rawDocs).map(([path, raw]) => {
     parent: fm.parent ? String(fm.parent) : undefined,
     hasChildren: Boolean(fm.has_children),
     body,
-    plain: body.toLowerCase(),
-    headings,
+    plain: toPlain(body),
+    headings: extractHeadings(body),
   }
 })
 
-DOCS.sort((a, b) => a.navOrder - b.navOrder)
+DOCS.sort((a, b) => a.navOrder - b.navOrder || a.title.localeCompare(b.title))
 
 export const CHAT_UI_DOCS: ChatUiDocEntry[] = DOCS
 
-export const CHAT_UI_NAV_TREE: ChatUiNavNode[] = DOCS.filter((d) => !d.parent || d.hasChildren).map(
-  (entry) => ({
-    entry,
-    children: DOCS.filter((d) => d.parent === entry.title),
-  }),
-)
+/** Top-level nav: docs without a parent. Section pages list their children. */
+export const CHAT_UI_NAV_TREE: ChatUiNavNode[] = DOCS.filter((d) => !d.parent).map((entry) => ({
+  entry,
+  children: DOCS.filter((d) => d.parent === entry.title).sort(
+    (a, b) => a.navOrder - b.navOrder || a.title.localeCompare(b.title),
+  ),
+}))
 
-/** Resolve a slug (e.g. 'runtime') to a doc entry, or undefined. */
+/** Depth-first flatten for prev/next pagination. */
+export const CHAT_UI_FLAT_NAV: ChatUiDocEntry[] = CHAT_UI_NAV_TREE.flatMap((n) => [
+  n.entry,
+  ...n.children,
+])
+
+/** Resolve a slug (e.g. 'runtime' or 'components/thread') to a doc entry. */
 export function getChatUiDoc(slug: string): ChatUiDocEntry | undefined {
-  return DOCS.find((d) => d.slug === slug || d.slug === slug.replace(/\.md$/, ''))
+  const clean = slug.replace(/\.md$/, '').replace(/^\/+/, '')
+  return DOCS.find((d) => d.slug === clean || d.slug === clean.replace(/\/index$/, ''))
+}
+
+export interface ChatUiSearchHit {
+  doc: ChatUiDocEntry
+  snippet: string
+  heading?: { id: string; text: string }
+}
+
+/** Lightweight search across jcode-ui docs. */
+export function searchChatUiDocs(query: string, limit = 8): ChatUiSearchHit[] {
+  const q = query.trim().toLowerCase()
+  if (q.length < 2) return []
+  const hits: (ChatUiSearchHit & { score: number })[] = []
+  for (const doc of DOCS) {
+    let score = 0
+    let heading: ChatUiSearchHit['heading']
+    if (doc.title.toLowerCase().includes(q)) score += 100
+    if (doc.slug.toLowerCase().includes(q)) score += 60
+    for (const h of doc.headings) {
+      if (h.text.toLowerCase().includes(q)) {
+        score += 40
+        heading = heading ?? { id: h.id, text: h.text }
+      }
+    }
+    const idx = doc.plain.indexOf(q)
+    if (idx >= 0) {
+      score += 10
+      const start = Math.max(0, idx - 40)
+      const raw = doc.plain.slice(start, idx + q.length + 60).trim()
+      hits.push({
+        doc,
+        snippet: (start > 0 ? '…' : '') + raw + '…',
+        heading,
+        score,
+      })
+    } else if (score > 0) {
+      hits.push({ doc, snippet: doc.plain.slice(0, 90) + '…', heading, score })
+    }
+  }
+  return hits.sort((a, b) => b.score - a.score).slice(0, limit)
 }

--- a/site/src/lib/docs.ts
+++ b/site/src/lib/docs.ts
@@ -65,7 +65,9 @@ function transformBody(body: string, slug: string): string {
   // asset image paths → /docs-asset/
   out = out.replace(/\]\((?:\.\.\/)*asset\//g, '](/docs-asset/')
 
-  // strip a leading h1 that duplicates the front-matter title (we render our own)
+  // strip a leading h1 that duplicates the front-matter title (we render our own).
+  // Trim leading blanks after `---` so `^#` still matches.
+  out = out.replace(/^\s+/, '')
   out = out.replace(/^#\s+.+\n+/, '')
 
   void slug

--- a/site/src/main.tsx
+++ b/site/src/main.tsx
@@ -6,7 +6,7 @@ import './styles/global.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <App />
     </BrowserRouter>
   </StrictMode>,

--- a/site/src/pages/ChatUIPage.tsx
+++ b/site/src/pages/ChatUIPage.tsx
@@ -6,13 +6,38 @@
  * but showcases the reusable React library rather than the product.
  */
 
+import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import Reveal from '../components/Reveal'
 import CopyButton from '../components/CopyButton'
 import { ChatDemo } from '../playground/ChatDemo'
+import { highlightDemoCode } from '../playground/highlightDemoCode'
 import './chatui.css'
 
 const INSTALL = 'pnpm add jcode-ui jcode-ui-core'
+
+const QUICK_START = `import { RuntimeProvider, createExternalStoreRuntime, Thread, ChatInput } from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const runtime = createExternalStoreRuntime({
+  store,                       // your Redux/Zustand store
+  select: (s) => ({            // project to RuntimeState
+    items: s.chat.timeline,
+    isRunning: s.chat.isRunning,
+    tokenSnapshot: s.chat.tokenInfo,
+    // …
+  }),
+  actions: { sendMessage, stop, resolveApproval, /* … */ },
+})
+
+export function App() {
+  return (
+    <RuntimeProvider runtime={runtime}>
+      <Thread />
+      <ChatInput />
+    </RuntimeProvider>
+  )
+}`
 
 const FEATURES = [
   {
@@ -48,6 +73,8 @@ const FEATURES = [
 ]
 
 export default function ChatUIPage() {
+  const quickStartHtml = useMemo(() => highlightDemoCode(QUICK_START, 'tsx'), [])
+
   return (
     <div className="chatui-page">
       {/* Hero */}
@@ -66,7 +93,7 @@ export default function ChatUIPage() {
               <code>{INSTALL}</code>
               <CopyButton text={INSTALL} />
             </div>
-            <Link className="chatui-docs-link" to="/docs/chat-ui">
+            <Link className="chatui-docs-link" to="/chat-ui/docs">
               Read the docs →
             </Link>
           </div>
@@ -109,28 +136,15 @@ export default function ChatUIPage() {
       <section className="chatui-quickstart">
         <Reveal>
           <h2 className="chatui-section-title">Quick start</h2>
-          <pre className="chatui-codeblock">{`import { RuntimeProvider, createExternalStoreRuntime, Thread, ChatInput } from 'jcode-ui'
-import 'jcode-ui/styles.css'
-
-const runtime = createExternalStoreRuntime({
-  store,                       // your Redux/Zustand store
-  select: (s) => ({            // project to RuntimeState
-    items: s.chat.timeline,
-    isRunning: s.chat.isRunning,
-    tokenSnapshot: s.chat.tokenInfo,
-    // …
-  }),
-  actions: { sendMessage, stop, resolveApproval, /* … */ },
-})
-
-export function App() {
-  return (
-    <RuntimeProvider runtime={runtime}>
-      <Thread />
-      <ChatInput />
-    </RuntimeProvider>
-  )
-}`}</pre>
+          <div className="chatui-codeblock-wrap">
+            <CopyButton text={QUICK_START} />
+            <pre className="chatui-codeblock">
+              <code
+                className="hljs language-tsx"
+                dangerouslySetInnerHTML={{ __html: quickStartHtml }}
+              />
+            </pre>
+          </div>
         </Reveal>
       </section>
     </div>

--- a/site/src/pages/chatui.css
+++ b/site/src/pages/chatui.css
@@ -35,7 +35,14 @@
 
 /* Demo */
 .chatui-demo-section { margin-bottom: 5rem; }
-.chatui-demo-frame { max-width: 760px; margin: 0 auto; }
+/* Wider than the default marketing column so the chat UI can breathe. */
+.chatui-demo-frame {
+  max-width: 920px;
+  margin: 0 auto;
+}
+.chatui-demo-frame .jcode-live-demo {
+  width: 100%;
+}
 
 /* Features */
 .chatui-features { margin-bottom: 5rem; }
@@ -54,13 +61,72 @@
 .chatui-feature h3 { font-size: 1.05rem; margin: 0.5rem 0 0.5rem; }
 .chatui-feature p { font-size: 0.9rem; line-height: 1.55; color: var(--muted, #888); margin: 0; }
 
-/* Quick start code */
+/* Quick start code — dark pane + hljs (same palette as demo Code tabs) */
 .chatui-quickstart { margin-bottom: 2rem; }
-.chatui-codeblock {
-  background: #0d0d0d; border: 1px solid #2e2e2e; border-radius: 12px;
-  padding: 1.5rem; overflow-x: auto; font-family: 'JetBrains Mono', monospace;
-  font-size: 0.82rem; line-height: 1.6; color: #e4e4e7; margin: 1.5rem 0 0;
+.chatui-codeblock-wrap {
+  position: relative;
+  margin: 1.5rem 0 0;
 }
+.chatui-codeblock-wrap .copy-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 1;
+}
+.chatui-codeblock {
+  background: #121218;
+  border: 1px solid #2e2e2e;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  overflow-x: hidden;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: pre-wrap;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: #e8e8ec;
+  margin: 0;
+  max-width: 100%;
+  box-sizing: border-box;
+  tab-size: 2;
+}
+.chatui-codeblock code,
+.chatui-codeblock .hljs {
+  display: block;
+  background: transparent !important;
+  color: #e8e8ec !important;
+  padding: 0 !important;
+  border: 0 !important;
+  font: inherit;
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
+}
+.chatui-codeblock .hljs-comment,
+.chatui-codeblock .hljs-quote { color: #8b8b96; font-style: italic; }
+.chatui-codeblock .hljs-keyword,
+.chatui-codeblock .hljs-selector-tag,
+.chatui-codeblock .hljs-meta,
+.chatui-codeblock .hljs-built_in { color: #7dd3fc; }
+.chatui-codeblock .hljs-string,
+.chatui-codeblock .hljs-attr,
+.chatui-codeblock .hljs-template-tag { color: #86efac; }
+.chatui-codeblock .hljs-number,
+.chatui-codeblock .hljs-literal { color: #fcd34d; }
+.chatui-codeblock .hljs-title,
+.chatui-codeblock .hljs-section,
+.chatui-codeblock .hljs-name,
+.chatui-codeblock .hljs-title.class_ { color: #d8b4fe; }
+.chatui-codeblock .hljs-type { color: #fca5a5; }
+.chatui-codeblock .hljs-params { color: #f0abfc; }
+.chatui-codeblock .hljs-variable,
+.chatui-codeblock .hljs-template-variable { color: #fde68a; }
+.chatui-codeblock .hljs-function,
+.chatui-codeblock .hljs-title.function_ { color: #c4b5fd; }
+.chatui-codeblock .hljs-property { color: #93c5fd; }
+.chatui-codeblock .hljs-punctuation,
+.chatui-codeblock .hljs-tag { color: #a1a1aa; }
 
 @media (max-width: 640px) {
   .chatui-page { padding: 2rem 1rem 4rem; }

--- a/site/src/pages/chatui/ChatUiDocPage.tsx
+++ b/site/src/pages/chatui/ChatUiDocPage.tsx
@@ -1,15 +1,82 @@
 /**
  * ChatUiDocPage — renders a single jcode-ui doc page from CHAT_UI_DOCS.
- * Mirrors DocPage but reads from the chat-ui doc set + uses /chat-ui/docs links.
+ * Live previews are lazy-loaded so non-demo docs stay light.
  */
 
+import { lazy, Suspense, isValidElement, useMemo, type HTMLAttributes, type ReactNode } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import rehypeSlug from 'rehype-slug'
 import rehypeHighlight from 'rehype-highlight'
-import { CHAT_UI_DOCS, getChatUiDoc } from '../../lib/chatUiDocs'
+import CopyButton from '../../components/CopyButton'
+import { CHAT_UI_FLAT_NAV, getChatUiDoc } from '../../lib/chatUiDocs'
+import '../../playground/component-demo.css'
+
+function textOf(node: ReactNode): string {
+  if (node == null) return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(textOf).join('')
+  if (isValidElement(node)) return textOf((node.props as { children?: ReactNode }).children)
+  return ''
+}
+
+/** Drop a leading ATX H1 that duplicates frontmatter `title` (page already renders <h1>). */
+function stripDuplicateLeadingH1(body: string, title: string): string {
+  const escaped = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return body.replace(new RegExp(`^#\\s+${escaped}\\s*\\n+`, 'i'), '')
+}
+
+// Heavy: jcode-ui + demos. Only fetched when a page embeds data-jcode-demo.
+const ComponentDemo = lazy(() =>
+  import('../../playground/ComponentDemo').then((m) => ({ default: m.ComponentDemo })),
+)
+
+function rewriteInternalHref(href: string): string {
+  if (/^https?:/.test(href) || href.startsWith('#') || href.startsWith('mailto:')) return href
+  if (href.startsWith('/docs/chat-ui')) {
+    return href.replace('/docs/chat-ui', '/chat-ui/docs')
+  }
+  if (href.startsWith('/chat-ui/docs/')) return href
+  if (href.startsWith('/chat-ui')) return href
+  if (!href.startsWith('/')) {
+    const clean = href.replace(/^\.\//, '').replace(/\.md$/, '')
+    return `/chat-ui/docs/${clean}`
+  }
+  return href
+}
+
+function DemoSlot({ id, height, showCode }: { id: string; height?: number; showCode: boolean }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="jcode-demo jcode-demo-placeholder" style={{ minHeight: height ?? 160 }}>
+          <div className="jcode-demo-chrome">
+            <span className="jcode-demo-dot red" />
+            <span className="jcode-demo-dot yellow" />
+            <span className="jcode-demo-dot green" />
+            <span className="jcode-demo-label">loading preview…</span>
+          </div>
+          <div className="jcode-demo-placeholder-body" />
+        </div>
+      }
+    >
+      <ComponentDemo id={id} height={height} showCode={showCode} />
+    </Suspense>
+  )
+}
+
+function readDataAttr(
+  props: Record<string, unknown>,
+  kebab: string,
+  camel: string,
+): string | undefined {
+  const nodeProps = (props.node as { properties?: Record<string, unknown> } | undefined)?.properties
+  const v = props[kebab] ?? props[camel] ?? nodeProps?.[kebab] ?? nodeProps?.[camel]
+  if (v == null || v === '') return undefined
+  return String(v)
+}
 
 export default function ChatUiDocPage() {
   const { '*': splat = '' } = useParams()
@@ -22,18 +89,17 @@ export default function ChatUiDocPage() {
         <article className="doc-article">
           <h1>Doc not found</h1>
           <p>
-            No jcode-ui doc at <code>{slug}</code>. See the{' '}
-            <Link to="/chat-ui/docs">jcode-ui docs index</Link>.
+            No jcode-ui doc at <code>{slug}</code>. See the <Link to="/chat-ui/docs">jcode-ui docs index</Link>.
           </p>
         </article>
       </div>
     )
   }
 
-  // prev/next within the chat-ui doc set (flat nav order).
-  const idx = CHAT_UI_DOCS.findIndex((d) => d.slug === doc.slug)
-  const prev = idx > 0 ? CHAT_UI_DOCS[idx - 1] : undefined
-  const next = idx >= 0 && idx < CHAT_UI_DOCS.length - 1 ? CHAT_UI_DOCS[idx + 1] : undefined
+  const idx = CHAT_UI_FLAT_NAV.findIndex((d) => d.slug === doc.slug)
+  const prev = idx > 0 ? CHAT_UI_FLAT_NAV[idx - 1] : undefined
+  const next = idx >= 0 && idx < CHAT_UI_FLAT_NAV.length - 1 ? CHAT_UI_FLAT_NAV[idx + 1] : undefined
+  const body = useMemo(() => stripDuplicateLeadingH1(doc.body, doc.title), [doc.body, doc.title])
 
   return (
     <div className="doc-main">
@@ -42,6 +108,12 @@ export default function ChatUiDocPage() {
           <Link to="/chat-ui">chat-ui</Link>
           <span className="crumb-sep">/</span>
           <Link to="/chat-ui/docs">docs</Link>
+          {doc.parent && (
+            <>
+              <span className="crumb-sep">/</span>
+              <span>{doc.parent}</span>
+            </>
+          )}
           <span className="crumb-sep">/</span>
           <b>{doc.title}</b>
         </nav>
@@ -51,18 +123,51 @@ export default function ChatUiDocPage() {
           rehypePlugins={[rehypeRaw, rehypeSlug, rehypeHighlight]}
           components={{
             a({ href = '', children }) {
-              if (/^https?:/.test(href)) {
+              const to = rewriteInternalHref(href)
+              if (/^https?:/.test(to)) {
                 return (
-                  <a href={href} target="_blank" rel="noreferrer">
+                  <a href={to} target="_blank" rel="noreferrer">
                     {children}
                   </a>
                 )
               }
-              return <a href={href}>{children}</a>
+              if (to.startsWith('/')) {
+                return <Link to={to}>{children}</Link>
+              }
+              return <a href={to}>{children}</a>
+            },
+            // Navy code card + copy button (same pattern as product DocPage).
+            pre({ children }) {
+              const code = textOf(children).replace(/\n$/, '')
+              return (
+                <div className="doc-codeblock">
+                  <CopyButton text={code} />
+                  <pre>{children}</pre>
+                </div>
+              )
+            },
+            div(props) {
+              const raw = props as Record<string, unknown>
+              const demoId = readDataAttr(raw, 'data-jcode-demo', 'dataJcodeDemo')
+              if (demoId) {
+                const hRaw = readDataAttr(raw, 'data-height', 'dataHeight')
+                const height = hRaw != null ? Number(hRaw) : undefined
+                const codeAttr = readDataAttr(raw, 'data-code', 'dataCode') ?? 'true'
+                const showCode = codeAttr !== 'false' && codeAttr !== '0'
+                return (
+                  <DemoSlot
+                    id={demoId}
+                    height={Number.isFinite(height) ? height : undefined}
+                    showCode={showCode}
+                  />
+                )
+              }
+              const { node: _node, ...rest } = raw
+              return <div {...(rest as HTMLAttributes<HTMLDivElement>)} />
             },
           }}
         >
-          {doc.body}
+          {body}
         </ReactMarkdown>
         <nav className="doc-pager">
           {prev ? (

--- a/site/src/pages/chatui/ChatUiDocsIndex.tsx
+++ b/site/src/pages/chatui/ChatUiDocsIndex.tsx
@@ -1,51 +1,50 @@
 /**
- * ChatUiDocsIndex — the landing page for /chat-ui/docs. Lists every jcode-ui
- * doc as cards (like the jcode docs home, but only the chat-ui set).
+ * ChatUiDocsIndex — landing page for /chat-ui/docs.
  */
 
 import { Link } from 'react-router-dom'
-import { CHAT_UI_DOCS } from '../../lib/chatUiDocs'
+import { CHAT_UI_NAV_TREE } from '../../lib/chatUiDocs'
 
 export default function ChatUiDocsIndex() {
   return (
     <div className="doc-main">
       <article className="doc-article">
-        <nav className="doc-crumbs">
+        <nav className="doc-crumbs" aria-label="Breadcrumb">
           <Link to="/chat-ui">chat-ui</Link>
           <span className="crumb-sep">/</span>
           <b>docs</b>
         </nav>
         <h1>jcode-ui documentation</h1>
-        <p className="doc-lede">
-          React components for AI chat interfaces — streaming, tool calls, approvals, ask-user flows.
-          Backend-agnostic, token-driven, tree-shakeable.
+        <p>
+          React components for AI chat interfaces — streaming messages, tool calls, approvals, and
+          ask-user interactions. Backend-agnostic, token-driven, and published as{' '}
+          <code>jcode-ui</code> + <code>jcode-ui-core</code>.
         </p>
-        <div className="doc-home-grid">
-          {CHAT_UI_DOCS.filter((d) => d.slug !== 'index').map((d) => (
-            <Link key={d.slug} to={`/chat-ui/docs/${d.slug}`} className="doc-home-card">
-              <h3>{d.title}</h3>
-              <p>{blurb(d.slug)}</p>
-            </Link>
+        <p>
+          Prefer a guided start? Jump to <Link to="/chat-ui/docs/installation">Installation</Link>{' '}
+          or the <Link to="/chat-ui">live playground</Link>.
+        </p>
+
+        <div className="doc-home-grid" style={{ marginTop: '2rem' }}>
+          {CHAT_UI_NAV_TREE.map((node) => (
+            <div key={node.entry.slug} className="doc-home-section">
+              <Link to={`/chat-ui/docs/${node.entry.slug}`} className="doc-home-card">
+                <b>{node.entry.title}</b>
+                <span className="doc-home-meta">{node.entry.slug}</span>
+              </Link>
+              {node.children.length > 0 && (
+                <ul className="doc-home-children">
+                  {node.children.map((c) => (
+                    <li key={c.slug}>
+                      <Link to={`/chat-ui/docs/${c.slug}`}>{c.title}</Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
           ))}
         </div>
       </article>
     </div>
   )
-}
-
-function blurb(slug: string): string {
-  switch (slug) {
-    case 'runtime':
-      return 'The ChatRuntime contract + ExternalStoreRuntime — connect any Redux-shaped store.'
-    case 'primitives':
-      return 'Headless components: Thread, MessageView, Composer, ToolCallView, ApprovalBlock, AskUserBlock.'
-    case 'tool-renderers':
-      return 'The tool-call plugin registry. 9 default renderers + writing your own.'
-    case 'theming':
-      return 'CSS custom properties for every color/radius/shadow. Light, dark, generated themes.'
-    case 'components':
-      return 'Component reference: props, slots, and examples for every styled component.'
-    default:
-      return ''
-  }
 }

--- a/site/src/pages/chatui/ChatUiDocsLayout.tsx
+++ b/site/src/pages/chatui/ChatUiDocsLayout.tsx
@@ -1,16 +1,69 @@
 /**
- * ChatUiDocsLayout — the sidebar shell for jcode-ui component docs.
- *
- * SEPARATE from the jcode product docs (DocsLayout). The jcode-ui library is
- * an independent product, so its docs have their own nav tree (CHAT_UI_NAV_TREE)
- * and route prefix (/chat-ui/docs/*). The sidebar links back to the chat-ui
- * landing page and the npm/github, not to the jcode product docs.
+ * ChatUiDocsLayout — sidebar shell for jcode-ui component docs.
+ * Separate from product DocsLayout; includes search over chat-ui docs only.
  */
 
-import { useEffect, useState } from 'react'
-import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
-import { CHAT_UI_NAV_TREE } from '../../lib/chatUiDocs'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link, NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { CHAT_UI_NAV_TREE, searchChatUiDocs, type ChatUiSearchHit } from '../../lib/chatUiDocs'
 import '../docs/docs.css'
+
+function SearchBox() {
+  const [q, setQ] = useState('')
+  const [open, setOpen] = useState(false)
+  const nav = useNavigate()
+  const boxRef = useRef<HTMLDivElement>(null)
+  const hits = useMemo(() => searchChatUiDocs(q), [q])
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (!boxRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [])
+
+  const go = (h: ChatUiSearchHit) => {
+    setOpen(false)
+    setQ('')
+    nav(`/chat-ui/docs/${h.doc.slug}${h.heading ? `#${h.heading.id}` : ''}`)
+  }
+
+  return (
+    <div className="docs-search" ref={boxRef}>
+      <span className="docs-search-icon" aria-hidden>
+        ⌕
+      </span>
+      <input
+        value={q}
+        placeholder="Search jcode-ui docs…"
+        onChange={(e) => {
+          setQ(e.target.value)
+          setOpen(true)
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && hits[0]) go(hits[0])
+          if (e.key === 'Escape') setOpen(false)
+        }}
+      />
+      {open && q.trim().length >= 2 && (
+        <div className="docs-search-pop">
+          {hits.length === 0 && <div className="dsp-empty">No results for “{q}”</div>}
+          {hits.map((h, i) => (
+            <button key={i} className="dsp-hit" type="button" onClick={() => go(h)}>
+              <span className="dsp-title">
+                {h.doc.title}
+                {h.heading ? ` › ${h.heading.text}` : ''}
+              </span>
+              <span className="dsp-snippet">{h.snippet}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
 
 export default function ChatUiDocsLayout() {
   const { pathname } = useLocation()
@@ -20,10 +73,11 @@ export default function ChatUiDocsLayout() {
 
   return (
     <div className="docs-shell container">
-      <button className="docs-menu-toggle" onClick={() => setMenuOpen((v) => !v)}>
+      <button className="docs-menu-toggle" type="button" onClick={() => setMenuOpen((v) => !v)}>
         {menuOpen ? '✕ Close' : '☰ Docs menu'}
       </button>
       <aside className={`docs-side${menuOpen ? ' open' : ''}`}>
+        <SearchBox />
         <nav className="docs-nav">
           <NavLink to="/chat-ui/docs" end className="docs-nav-item docs-nav-top">
             jcode-ui docs

--- a/site/src/pages/docs/docs.css
+++ b/site/src/pages/docs/docs.css
@@ -147,6 +147,16 @@
   font-size: 15.5px;
   line-height: 1.75;
 }
+/* Live component previews need the full article width (not a nested 56rem). */
+.doc-article .jcode-demo {
+  max-width: none;
+  width: 100%;
+}
+/* Chat-ui docs (live demos + long code samples) get a wider reading column. */
+.docs-shell:has(.jcode-demo) .doc-article,
+.docs-shell:has(.doc-codeblock) .doc-article {
+  max-width: min(960px, 100%);
+}
 .doc-article h1 {
   font-size: clamp(30px, 4vw, 40px);
   margin: 10px 0 18px;
@@ -167,7 +177,8 @@
 .doc-article li { color: var(--ink); margin: 0.25em 0; }
 .doc-article ul, .doc-article ol { padding-left: 26px; }
 .doc-article hr { border: none; border-top: 1px solid var(--line); margin: 2em 0; }
-.doc-article code {
+/* Inline chips only — never paint `pre > code` (breaks jcode-ui demos). */
+.doc-article :not(pre) > code {
   background: var(--paper-2);
   border: 1px solid var(--line);
   padding: 0.1em 0.38em;
@@ -228,26 +239,35 @@ kbd {
 .callout-important { background: var(--accent-soft); border-color: #f0c2a0; }
 .callout-new { background: #edf7ee; border-color: #cbe5cd; }
 
-/* code blocks */
+/* code blocks — wrap long lines, no horizontal scrollbar */
 .doc-codeblock {
   position: relative;
   margin: 1.2em 0;
+  max-width: 100%;
 }
 .doc-codeblock pre {
   background: var(--navy-2);
   color: var(--navy-ink);
   border-radius: var(--r-md);
   padding: 16px 74px 16px 18px;
-  overflow-x: auto;
+  overflow-x: hidden;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: pre-wrap;
   font-size: 13px;
   line-height: 1.65;
   margin: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 .doc-codeblock code {
   background: none;
   border: none;
   padding: 0;
   font-size: inherit;
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
 }
 
 /* hljs — warm-navy syntax palette */
@@ -365,6 +385,62 @@ kbd {
 }
 .doc-home-card h3 { font-size: 18px; margin: 0 0 6px; color: var(--ink); }
 .doc-home-card p { font-size: 13.5px; color: var(--ink-soft); margin: 0; }
+/* Section card: parent link + child links share one bordered surface. */
+.doc-home-section {
+  display: flex;
+  flex-direction: column;
+  align-content: start;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--card);
+  overflow: hidden;
+  transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
+}
+.doc-home-section:hover {
+  border-color: var(--line-strong);
+  box-shadow: var(--shadow-soft);
+}
+.doc-home-section > .doc-home-card {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  transform: none;
+}
+.doc-home-section > .doc-home-card:hover {
+  transform: none;
+  box-shadow: none;
+  background: color-mix(in srgb, var(--accent, #ff8400) 6%, transparent);
+}
+.doc-home-section:has(.doc-home-children) > .doc-home-card {
+  border-bottom: 1px solid var(--line);
+}
+.doc-home-meta {
+  display: block;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+}
+.doc-home-children {
+  margin: 0;
+  padding: 8px 10px 12px;
+  list-style: none;
+  display: grid;
+  gap: 2px;
+}
+.doc-home-children a {
+  display: block;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 13.5px;
+  color: var(--ink-soft);
+  text-decoration: none;
+}
+.doc-home-children a:hover {
+  color: var(--accent-ink, var(--accent));
+  background: color-mix(in srgb, var(--accent, #ff8400) 8%, transparent);
+}
 
 /* ---------- responsive ---------- */
 @media (max-width: 1120px) {

--- a/site/src/playground/ChatDemo.tsx
+++ b/site/src/playground/ChatDemo.tsx
@@ -1,10 +1,10 @@
 /**
- * ChatDemo — the website "footprint" component.
+ * ChatDemo — marketing-page footprint: scripted Thread + ChatInput.
  *
- * Renders a live, scripted jcode-ui Thread + ChatInput inside a framed window.
- * No backend: a MockRuntime plays the canned demo script on a loop. This is the
- * most concrete demonstration that the component library is self-contained and
- * reusable — the marketing site embeds it with zero wiring beyond a runtime.
+ * Layout is pure CSS (see component-demo.css / chatui.css). Do NOT rely on
+ * Tailwind utilities from jcode-ui/styles.css here — that file only ships
+ * classes used inside packages/jcode-ui, so host-side utilities are missing
+ * and layout collapses (e.g. missing .flex-col → chrome bar ends up vertical).
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -17,23 +17,19 @@ import {
   ChatInput,
 } from 'jcode-ui'
 import 'jcode-ui/styles.css'
+import './component-demo.css'
 import { buildDemoScript, runScript } from './mockScript'
 
 export interface ChatDemoProps {
-  /** Loop the script after it finishes. Default true. */
   loop?: boolean
-  /** Pause between loops (ms). Default 3000. */
   loopPause?: number
-  /** Fixed height of the demo window. Default 480. */
   height?: number
-  /** Show the framed chrome (titlebar dots). Default true. */
   chrome?: boolean
 }
 
 export function ChatDemo({ loop = true, loopPause = 3000, height = 480, chrome = true }: ChatDemoProps) {
-  // NOTE: the default loops for the marketing page; tests can pass loop={false}.
-  // Allow ?noloop=1 to disable looping for screenshot/tests.
-  const shouldLoop = loop && !new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '').has('noloop')
+  const shouldLoop =
+    loop && !new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '').has('noloop')
   const registry = useMemo(() => createDefaultToolRegistry(), [])
   const [runtime, setRuntime] = useState(() => createMockRuntime())
   const cancelRef = useRef<(() => void) | null>(null)
@@ -69,26 +65,23 @@ export function ChatDemo({ loop = true, loopPause = 3000, height = 480, chrome =
   }, [shouldLoop, loopPause])
 
   return (
-    <div
-      className="flex flex-col overflow-hidden rounded-xl border border-[var(--color-border,#2E2E2E)] bg-[var(--color-surface,#1A1A1A)] shadow-2xl"
-      style={{ height }}
-    >
+    <div className="jcode-live-demo dark" style={{ height }}>
       {chrome && (
-        <div className="flex shrink-0 items-center gap-1.5 border-b border-[var(--color-border,#2E2E2E)] bg-[var(--color-muted,#2E2E2E)] px-3 py-2">
-          <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
-          <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]" />
-          <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]" />
-          <span className="ml-2 text-[0.7rem] text-[#888]">jcode · chat-ui demo</span>
+        <div className="jcode-live-demo__chrome">
+          <span className="jcode-live-demo__dot jcode-live-demo__dot--red" />
+          <span className="jcode-live-demo__dot jcode-live-demo__dot--yellow" />
+          <span className="jcode-live-demo__dot jcode-live-demo__dot--green" />
+          <span className="jcode-live-demo__title">jcode · chat-ui demo</span>
         </div>
       )}
       {runtime && (
         <RuntimeProvider runtime={runtime}>
           <ToolRegistryProvider registry={registry}>
-            <div className="flex min-h-0 flex-1 flex-col">
-              <div className="min-h-0 flex-1 overflow-hidden">
-                <Thread overscanBottom={8} />
+            <div className="jcode-live-demo__body">
+              <div className="jcode-live-demo__thread">
+                <Thread virtualize overscanBottom={8} />
               </div>
-              <div className="shrink-0 border-t border-[var(--color-border,#2E2E2E)] p-2">
+              <div className="jcode-live-demo__composer">
                 <ChatInput placeholder="This demo plays automatically…" showContextBar={false} />
               </div>
             </div>

--- a/site/src/playground/ComponentDemo.tsx
+++ b/site/src/playground/ComponentDemo.tsx
@@ -1,0 +1,620 @@
+/**
+ * ComponentDemo — embeddable live previews for jcode-ui docs.
+ *
+ * Markdown: <div data-jcode-demo="message" data-height="320"></div>
+ *
+ * Performance:
+ *  - Mount only when scrolled near viewport (IntersectionObserver)
+ *  - Styles imported once (side-effect of this module; host should also
+ *    import in docs layout so first paint has tokens)
+ *  - Thread demos always use virtualize={false} + explicit pixel height
+ */
+
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import {
+  RuntimeProvider,
+  ToolRegistryProvider,
+  createDefaultToolRegistry,
+  createMockRuntime,
+  Thread,
+  ChatInput,
+  Message,
+  ToolCallCard,
+  ApprovalBanner,
+  AskUserCard,
+  Reasoning,
+  Sources,
+  AttachmentList,
+  ContextBar,
+} from 'jcode-ui'
+import type {
+  Message as MessageData,
+  ToolCall,
+  Approval,
+  ThreadItem,
+  TokenSnapshot,
+  TaskContextBreakdown,
+} from 'jcode-ui-core'
+import 'jcode-ui/styles.css'
+import './component-demo.css'
+import { DEMO_SOURCES } from './demoSources'
+import { highlightDemoCode } from './highlightDemoCode'
+
+export type DemoId =
+  | 'thread'
+  | 'message'
+  | 'chat-input'
+  | 'tool-call'
+  | 'tool-gallery'
+  | 'approval'
+  | 'ask-user'
+  | 'reasoning'
+  | 'sources'
+  | 'attachment'
+  | 'context-bar'
+  | 'theming'
+
+export interface ComponentDemoProps {
+  id: DemoId | string
+  height?: number
+  /** Show Preview | Code tabs (default true when a source snippet exists). */
+  showCode?: boolean
+}
+
+const ts = 1_700_000_000_000 // stable across HMR so React keys stay quiet
+
+const sampleUser: MessageData = {
+  id: 'demo-u1',
+  role: 'user',
+  content: 'Fix the race condition in `server.go` and run the tests.',
+  timestamp: ts,
+}
+
+const sampleAssistant: MessageData = {
+  id: 'demo-a1',
+  role: 'assistant',
+  content:
+    "I found an unguarded map write. Here's the fix:\n\n```go\nmu.Lock()\ndefer mu.Unlock()\nm[key] = val\n```\n\nTests are green.",
+  timestamp: ts + 1,
+  durationMs: 4200,
+  reasoning:
+    'The panic stack points at concurrent map writes. The handler spawns a goroutine without synchronizing access to the shared map.',
+  sources: [
+    {
+      id: 's1',
+      title: 'Go memory model',
+      url: 'https://go.dev/ref/mem',
+      snippet: 'Happens-before rules for channel operations and mutexes.',
+    },
+    {
+      id: 's2',
+      title: 'server.go:48',
+      snippet: 'go process(req) // no lock around m[key]',
+    },
+  ],
+}
+
+const toolTerminal: ToolCall = {
+  id: 'demo-t1',
+  name: 'execute',
+  args: JSON.stringify({ command: 'go test ./...' }),
+  status: 'done',
+  timestamp: ts,
+  output: 'ok  \tgithub.com/acme/server\t0.412s\nPASS',
+  displayInfo: { title: 'execute', subtitle: 'go test ./...', icon: 'terminal', category: 'execution' },
+}
+
+const toolRead: ToolCall = {
+  id: 'demo-t2',
+  name: 'read',
+  args: JSON.stringify({ path: 'server.go' }),
+  status: 'done',
+  timestamp: ts,
+  output: '   1│package main\n   2│\n   3│func handle(r *Request) {\n   4│  go process(r)\n   5│}',
+  displayInfo: { title: 'read', subtitle: 'server.go', icon: 'file', category: 'context' },
+}
+
+const toolDiff: ToolCall = {
+  id: 'demo-t3',
+  name: 'edit',
+  args: JSON.stringify({
+    path: 'server.go',
+    old_string: 'go process(r)',
+    new_string: 'mu.Lock()\ndefer mu.Unlock()\ngo process(r)',
+  }),
+  status: 'done',
+  timestamp: ts,
+  output:
+    '@@ -3,3 +3,5 @@\n func handle(r *Request) {\n-  go process(r)\n+  mu.Lock()\n+  defer mu.Unlock()\n+  go process(r)\n }',
+  displayInfo: { title: 'edit', subtitle: 'server.go', icon: 'diff', category: 'mutation' },
+}
+
+const toolGrep: ToolCall = {
+  id: 'demo-t4',
+  name: 'grep',
+  args: JSON.stringify({ pattern: 'go process', path: '.' }),
+  status: 'done',
+  timestamp: ts,
+  output: 'server.go:4:  go process(r)\nhandler.go:12:  go process(job)',
+  displayInfo: { title: 'grep', subtitle: 'go process', icon: 'search', category: 'context' },
+}
+
+const toolTodo: ToolCall = {
+  id: 'demo-t5',
+  name: 'todowrite',
+  args: JSON.stringify({
+    todos: [
+      { id: 1, title: 'Find race', status: 'completed' },
+      { id: 2, title: 'Add mutex', status: 'completed' },
+      { id: 3, title: 'Run tests', status: 'in_progress' },
+    ],
+  }),
+  status: 'done',
+  timestamp: ts,
+  displayInfo: { title: 'todowrite', subtitle: '3 tasks', icon: 'todo', category: 'context' },
+}
+
+const toolSkill: ToolCall = {
+  id: 'demo-t6',
+  name: 'load_skill',
+  args: JSON.stringify({ name: 'go-concurrency', description: 'Mutex and channel patterns' }),
+  status: 'done',
+  timestamp: ts,
+  output: 'Skill loaded: go-concurrency',
+  displayInfo: { title: 'load_skill', subtitle: 'go-concurrency', icon: 'skill', category: 'context' },
+}
+
+const toolTeam: ToolCall = {
+  id: 'demo-t7',
+  name: 'team_list',
+  args: '{}',
+  status: 'done',
+  timestamp: ts,
+  output: 'Team: ship-it (2 members)\n@lead status=idle type=coordinator\n@tester status=busy type=worker',
+  displayInfo: { title: 'team_list', subtitle: '2 members', icon: 'team', category: 'context' },
+}
+
+const toolGeneric: ToolCall = {
+  id: 'demo-t8',
+  name: 'custom_deploy',
+  args: JSON.stringify({ env: 'staging', region: 'us-east-1' }),
+  status: 'done',
+  timestamp: ts,
+  output: '{"ok":true,"url":"https://staging.example.com"}',
+  displayInfo: { title: 'custom_deploy', subtitle: 'staging', category: 'execution' },
+}
+
+const sampleApproval: Approval = {
+  id: 'demo-ap1',
+  tool_name: 'execute',
+  tool_args: JSON.stringify({ command: 'rm -rf ./build' }),
+  is_external: false,
+}
+
+const sampleAskTool: ToolCall = {
+  id: 'demo-ask1',
+  name: 'ask_user',
+  args: '{}',
+  status: 'running',
+  timestamp: ts,
+  askUserId: 'demo-ask1',
+  askUserQuestions: [
+    {
+      question: 'Which test strategy should I use?',
+      header: 'test strategy',
+      options: [
+        { label: 'Unit only', description: 'Fast, package-local' },
+        { label: 'Integration', description: 'Hit the real DB' },
+        { label: 'Both', description: 'Unit then integration' },
+      ],
+    },
+  ],
+  displayInfo: { title: 'ask_user', subtitle: '1 question', category: 'context' },
+}
+
+const tokenSnapshot: TokenSnapshot = {
+  total_tokens: 98000,
+  model_context_limit: 128000,
+  prompt_tokens: 92000,
+  completion_tokens: 6000,
+}
+
+const contextBreakdown: TaskContextBreakdown = {
+  context_limit: 128000,
+  system_prompt_tokens: 1200,
+  system_tools_tokens: 8400,
+  mcp_tools_tokens: 2100,
+  skills_tokens: 900,
+  messages_tokens: 85400,
+}
+
+function msgItem(data: MessageData, seq: number): ThreadItem {
+  return { kind: 'message', data, seq }
+}
+function toolItem(data: ToolCall, seq: number): ThreadItem {
+  return { kind: 'tool', data, seq }
+}
+
+/** Shared registry — building default renderers once is much cheaper. */
+let sharedRegistry: ReturnType<typeof createDefaultToolRegistry> | null = null
+function getSharedRegistry() {
+  if (!sharedRegistry) sharedRegistry = createDefaultToolRegistry()
+  return sharedRegistry
+}
+
+function useVisible(rootMargin = '200px'): [React.RefCallback<HTMLDivElement>, boolean] {
+  const nodeRef = useRef<HTMLDivElement | null>(null)
+  const [visible, setVisible] = useState(false)
+  const setRef = useMemo(
+    () => (el: HTMLDivElement | null) => {
+      nodeRef.current = el
+    },
+    [],
+  )
+  useEffect(() => {
+    const el = nodeRef.current
+    if (!el || visible) return
+    if (typeof IntersectionObserver === 'undefined') {
+      setVisible(true)
+      return
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setVisible(true)
+          io.disconnect()
+        }
+      },
+      { rootMargin, threshold: 0.01 },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [visible, rootMargin])
+  return [setRef, visible]
+}
+
+function DemoChrome({
+  id,
+  height,
+  showCode,
+  children,
+}: {
+  id: string
+  height?: number
+  showCode: boolean
+  children: ReactNode
+}) {
+  const code = DEMO_SOURCES[id]
+  const canCode = showCode && Boolean(code)
+  const [tab, setTab] = useState<'preview' | 'code'>('preview')
+  const [copied, setCopied] = useState(false)
+  const previewH = height ?? (id === 'thread' ? 420 : id === 'chat-input' ? 160 : undefined)
+
+  const highlighted = useMemo(
+    () => (code ? highlightDemoCode(code, 'tsx') : ''),
+    [code],
+  )
+
+  const copy = () => {
+    if (!code) return
+    void navigator.clipboard?.writeText(code).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1600)
+    })
+  }
+
+  return (
+    <div
+      className="jcode-demo jcode-demo-shell"
+      style={previewH && tab === 'preview' ? { height: previewH + (canCode ? 40 : 0) } : undefined}
+    >
+      {canCode && (
+        <div className="jcode-demo-tabbar">
+          <div className="jcode-demo-tabs">
+            <button
+              type="button"
+              className={tab === 'preview' ? 'active' : ''}
+              onClick={() => setTab('preview')}
+            >
+              Preview
+            </button>
+            <button type="button" className={tab === 'code' ? 'active' : ''} onClick={() => setTab('code')}>
+              Code
+            </button>
+          </div>
+          <div className="jcode-demo-tab-actions">
+            {tab === 'code' && (
+              <button type="button" className="jcode-demo-copy" onClick={copy}>
+                {copied ? 'Copied ✓' : 'Copy'}
+              </button>
+            )}
+            <span className="jcode-demo-label">{id}</span>
+          </div>
+        </div>
+      )}
+      {!canCode && (
+        <div className="jcode-demo-chrome">
+          <span className="jcode-demo-dot red" />
+          <span className="jcode-demo-dot yellow" />
+          <span className="jcode-demo-dot green" />
+          <span className="jcode-demo-label">live preview · {id}</span>
+        </div>
+      )}
+      {tab === 'preview' ? (
+        <div
+          className="jcode-demo-preview-slot dark"
+          style={{
+            height: previewH,
+            minHeight: previewH ?? 80,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          }}
+        >
+          {children}
+        </div>
+      ) : (
+        <pre className="jcode-demo-code">
+          <code
+            className="hljs language-tsx"
+            dangerouslySetInnerHTML={{ __html: highlighted }}
+          />
+        </pre>
+      )}
+    </div>
+  )
+}
+
+function WithRuntime({
+  children,
+  items = [],
+  token,
+  style,
+  className,
+}: {
+  children: ReactNode
+  items?: ThreadItem[]
+  token?: TokenSnapshot | null
+  style?: CSSProperties
+  className?: string
+}) {
+  const registry = useMemo(() => getSharedRegistry(), [])
+  const runtime = useMemo(
+    () =>
+      createMockRuntime({
+        items,
+        state: token ? { tokenSnapshot: token } : undefined,
+      }),
+    // fixtures are static per demo mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
+  return (
+    <div className={className} style={style}>
+      <RuntimeProvider runtime={runtime}>
+        <ToolRegistryProvider registry={registry}>{children}</ToolRegistryProvider>
+      </RuntimeProvider>
+    </div>
+  )
+}
+
+function DemoBody({ id }: { id: string }): ReactNode {
+  switch (id) {
+    case 'thread':
+      return (
+        <WithRuntime
+          className="jcode-live-demo__body"
+          style={{ flex: 1, minHeight: 0, height: '100%' }}
+          items={[
+            msgItem(sampleUser, 1),
+            toolItem(toolRead, 2),
+            toolItem(toolDiff, 3),
+            msgItem(sampleAssistant, 4),
+          ]}
+          token={tokenSnapshot}
+        >
+          <div className="jcode-live-demo__thread">
+            <Thread virtualize={false} overscanBottom={12} />
+          </div>
+          <div className="jcode-live-demo__composer">
+            <ChatInput placeholder="Type to try the composer…" showContextBar />
+          </div>
+        </WithRuntime>
+      )
+
+    case 'message':
+      return (
+        <WithRuntime className="jcode-demo-pad" style={{ overflow: 'auto', flex: 1 }}>
+          <Message message={sampleUser} canEdit />
+          <Message message={sampleAssistant} />
+        </WithRuntime>
+      )
+
+    case 'chat-input':
+      return (
+        <WithRuntime className="jcode-demo-pad" style={{ flex: 1 }} token={tokenSnapshot}>
+          <ChatInput
+            slashCommands={[
+              { slash: '/goal', description: 'Set the session goal' },
+              { slash: '/compact', description: 'Compact conversation context' },
+            ]}
+            allowImages
+            showContextBar
+            placeholder="Send a message… try / for slash commands"
+          />
+        </WithRuntime>
+      )
+
+    case 'tool-call':
+      return (
+        <WithRuntime className="jcode-demo-pad" style={{ overflow: 'auto', flex: 1 }}>
+          <ToolCallCard tool={toolTerminal} />
+          <div style={{ height: 8 }} />
+          <ToolCallCard tool={toolDiff} />
+        </WithRuntime>
+      )
+
+    case 'tool-gallery':
+      return (
+        <WithRuntime className="jcode-demo-pad" style={{ overflow: 'auto', flex: 1 }}>
+          <div className="jcode-demo-gallery">
+            {[toolTerminal, toolRead, toolDiff, toolGrep, toolTodo, toolSkill, toolTeam, toolGeneric].map(
+              (t) => (
+                <div key={t.id} className="jcode-demo-gallery-item">
+                  <div className="jcode-demo-gallery-label">{t.name}</div>
+                  <ToolCallCard tool={t} />
+                </div>
+              ),
+            )}
+          </div>
+        </WithRuntime>
+      )
+
+    case 'approval':
+      return (
+        <WithRuntime className="jcode-demo-pad" style={{ overflow: 'auto', flex: 1 }}>
+          <ApprovalBanner approval={sampleApproval} />
+          <div style={{ height: 12 }} />
+          <ApprovalBanner
+            approval={{
+              ...sampleApproval,
+              id: 'demo-ap2',
+              resolved: true,
+              approved: true,
+            }}
+          />
+        </WithRuntime>
+      )
+
+    case 'ask-user':
+      return (
+        <WithRuntime className="jcode-demo-pad" style={{ overflow: 'auto', flex: 1 }}>
+          <AskUserCard tool={sampleAskTool} />
+        </WithRuntime>
+      )
+
+    case 'reasoning':
+      return (
+        <div className="jcode-demo-pad" style={{ overflow: 'auto', flex: 1 }}>
+          <Reasoning reasoning={sampleAssistant.reasoning!} durationMs={3200} defaultExpanded />
+        </div>
+      )
+
+    case 'sources':
+      return (
+        <div className="jcode-demo-pad" style={{ overflow: 'auto', flex: 1 }}>
+          <Sources sources={sampleAssistant.sources!} />
+        </div>
+      )
+
+    case 'attachment': {
+      // Readable SVG tiles (not 1×1 PNGs that look broken when stretched).
+      const svgB64 = (fill: string, label: string) =>
+        typeof btoa === 'function'
+          ? btoa(
+              `<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">` +
+                `<rect width="128" height="128" rx="16" fill="${fill}"/>` +
+                `<text x="64" y="72" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="28" font-weight="600" fill="white">${label}</text>` +
+                `</svg>`,
+            )
+          : ''
+      return (
+        <div className="jcode-demo-pad" style={{ overflow: 'auto', flex: 1 }}>
+          <p className="jcode-demo-hint" style={{ marginBottom: 10 }}>
+            Composer strip — click tile to preview, × to remove.
+          </p>
+          <AttachmentList
+            images={[
+              {
+                data: svgB64('#0ea5e9', 'A'),
+                media_type: 'image/svg+xml',
+                name: 'shot-a.svg',
+              },
+              {
+                data: svgB64('#f97316', 'B'),
+                media_type: 'image/svg+xml',
+                name: 'shot-b.svg',
+              },
+            ]}
+            onRemove={() => undefined}
+            size={64}
+          />
+          <p className="jcode-demo-hint" style={{ marginTop: 14 }}>
+            Enable in ChatInput with <code>allowImages</code> (paste + paperclip).
+          </p>
+        </div>
+      )
+    }
+
+    case 'context-bar':
+      return (
+        <WithRuntime className="jcode-demo-pad" style={{ flex: 1 }} token={tokenSnapshot}>
+          <div className="jcode-demo-row">
+            <span className="jcode-demo-hint">Token ring (hover for breakdown):</span>
+            <ContextBar size={28} breakdown={contextBreakdown} />
+            <span className="jcode-demo-hint mono">98k / 128k · 76%</span>
+          </div>
+        </WithRuntime>
+      )
+
+    case 'theming':
+      return (
+        <div className="jcode-demo-pad" style={{ overflow: 'auto', flex: 1 }}>
+          <div className="jcode-demo-swatches">
+            {[
+              ['--color-primary', 'Primary'],
+              ['--color-background', 'Background'],
+              ['--color-surface', 'Surface'],
+              ['--color-foreground', 'Foreground'],
+              ['--color-border', 'Border'],
+              ['--color-success-fg', 'Success'],
+              ['--color-error-fg', 'Error'],
+              ['--color-warning-fg', 'Warning'],
+            ].map(([token, label]) => (
+              <div key={token} className="jcode-demo-swatch">
+                <div className="jcode-demo-swatch-chip" style={{ background: `var(${token})` }} />
+                <code>{token}</code>
+                <span>{label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    default:
+      return (
+        <div className="jcode-demo-missing" style={{ padding: 16 }}>
+          Unknown demo: <code>{id}</code>
+        </div>
+      )
+  }
+}
+
+export function ComponentDemo({ id, height, showCode = true }: ComponentDemoProps) {
+  const [hostRef, visible] = useVisible('240px')
+  const placeholderH = height ?? (id === 'thread' ? 420 : id === 'chat-input' ? 160 : 120)
+
+  return (
+    <div ref={hostRef}>
+      {!visible ? (
+        <div
+          className="jcode-demo jcode-demo-placeholder"
+          style={{ minHeight: placeholderH }}
+          aria-hidden
+        >
+          <div className="jcode-demo-chrome">
+            <span className="jcode-demo-dot red" />
+            <span className="jcode-demo-dot yellow" />
+            <span className="jcode-demo-dot green" />
+            <span className="jcode-demo-label">loading preview…</span>
+          </div>
+          <div className="jcode-demo-placeholder-body" />
+        </div>
+      ) : (
+        <DemoChrome id={id} height={height} showCode={showCode}>
+          <DemoBody id={id} />
+        </DemoChrome>
+      )}
+    </div>
+  )
+}

--- a/site/src/playground/component-demo.css
+++ b/site/src/playground/component-demo.css
@@ -1,0 +1,573 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Live demo shell — PURE CSS (no Tailwind). Host pages must not depend on
+ * utilities from jcode-ui/styles.css (those are tree-shaken to package source).
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+.jcode-live-demo {
+  --jcode-col-max: 100%;
+  --jcode-col-pad-x: 1rem;
+  --jcode-gutter: 2.25rem;
+
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid var(--color-border, #2e2e2e);
+  background: var(--color-background, #111111);
+  color: var(--color-foreground, #e4e4e7);
+  box-shadow: 0 12px 40px -12px rgba(0, 0, 0, 0.45);
+  color-scheme: dark;
+  font-family: var(--font-sans, system-ui, sans-serif);
+}
+
+.jcode-live-demo__chrome {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border, #2e2e2e);
+  background: var(--color-muted, #2e2e2e);
+}
+
+.jcode-live-demo__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.jcode-live-demo__dot--red { background: #ff5f57; }
+.jcode-live-demo__dot--yellow { background: #febc2e; }
+.jcode-live-demo__dot--green { background: #28c840; }
+
+.jcode-live-demo__title {
+  margin-left: 8px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: #888;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  writing-mode: horizontal-tb; /* never vertical */
+}
+
+.jcode-live-demo__body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  background: var(--color-background, #111111);
+}
+
+.jcode-live-demo__thread {
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.jcode-live-demo__composer {
+  flex-shrink: 0;
+  width: 100%;
+  border-top: 1px solid var(--color-border, #2e2e2e);
+  padding: 8px 10px 10px;
+  background: var(--color-surface, #1a1a1a);
+  box-sizing: border-box;
+}
+
+.jcode-live-demo__composer .jcode-chat-input {
+  max-width: 100%;
+  margin: 0;
+  box-shadow: none;
+}
+
+/* Docs embed frames */
+.jcode-demo {
+  /* Fill the host frame — don't inherit product-app 56rem reading column. */
+  --jcode-col-max: 100%;
+  --jcode-col-pad-x: 0.75rem;
+  --jcode-gutter: 2rem;
+
+  margin: 1.25rem 0 1.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--line-strong, #2e2e2e);
+  overflow: hidden;
+  background: var(--color-background, #111);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+  /* Isolate from host .doc-article typography (code/pre/p styles). */
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--color-foreground, #e4e4e7);
+  color-scheme: dark;
+}
+
+/*
+ * Host isolation: docs use `.doc-article code { background: paper; }` for
+ * inline chips. That selector also hits `pre > code` inside demos and paints a
+ * light paper strip under light syntax colors → unreadable "blank" code cards.
+ *
+ * 1) Pin elevated dark code tokens on demo roots (don't inherit host paper).
+ * 2) Reset every `code` under demos, then re-apply inline/pre surfaces.
+ */
+.jcode-demo-preview-slot.dark,
+.jcode-live-demo.dark,
+.jcode-demo-body.dark,
+.chatui-demo-frame.dark {
+  --code-bg: #222228;
+  --code-border: #3f3f48;
+  --code-fg: #f0f0f4;
+  --code-inline-bg: #2c2c34;
+  --hljs-fg: #f0f0f4;
+  --hljs-keyword: #7dd3fc;
+  --hljs-string: #86efac;
+  --hljs-comment: #8b8b96;
+  --hljs-number: #fcd34d;
+  --hljs-title: #d8b4fe;
+  --hljs-type: #fca5a5;
+  --hljs-params: #f0abfc;
+  --hljs-variable: #fde68a;
+  --hljs-function: #c4b5fd;
+  --hljs-meta: #a1a1aa;
+  --hljs-property: #93c5fd;
+  --hljs-punctuation: #a1a1aa;
+}
+
+/* Strip host paper chip from ALL code nodes inside demos (incl. pre > code). */
+.doc-article .jcode-demo code,
+.doc-article .jcode-live-demo code,
+.chatui-demo-frame code {
+  background: transparent !important;
+  background-color: transparent !important;
+  border: 0 !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  color: inherit !important;
+  font-size: inherit !important;
+  box-shadow: none !important;
+}
+
+.doc-article .jcode-demo .jcode-prose pre,
+.chatui-demo-frame .jcode-prose pre,
+.jcode-live-demo .jcode-prose pre {
+  background: var(--code-bg, #222228) !important;
+  color: var(--code-fg, #f0f0f4) !important;
+  border: 1px solid var(--code-border, #3f3f48) !important;
+  padding: 0.85rem 1rem !important;
+  border-radius: 8px !important;
+}
+.doc-article .jcode-demo .jcode-prose pre code,
+.doc-article .jcode-demo .jcode-prose pre .hljs,
+.chatui-demo-frame .jcode-prose pre code,
+.jcode-live-demo .jcode-prose pre code {
+  background: transparent !important;
+  background-color: transparent !important;
+  color: inherit !important;
+  border: 0 !important;
+  padding: 0 !important;
+}
+.doc-article .jcode-demo .jcode-prose :not(pre) > code,
+.chatui-demo-frame .jcode-prose :not(pre) > code,
+.jcode-live-demo .jcode-prose :not(pre) > code {
+  background: var(--code-inline-bg, #2c2c34) !important;
+  color: var(--code-fg, #f0f0f4) !important;
+  border: 1px solid var(--code-border, #3f3f48) !important;
+  padding: 0.12em 0.45em !important;
+  border-radius: 4px !important;
+  font-family: var(--font-mono, ui-monospace, monospace) !important;
+  font-size: 0.86em !important;
+}
+.doc-article .jcode-demo .jcode-terminal,
+.doc-article .jcode-demo .jcode-file-viewer,
+.doc-article .jcode-demo .jcode-diff,
+.jcode-live-demo .jcode-terminal,
+.jcode-live-demo .jcode-file-viewer,
+.jcode-live-demo .jcode-diff {
+  background: var(--code-bg, #222228) !important;
+  color: var(--code-fg, #f0f0f4) !important;
+}
+
+/* Preview | Code shell */
+.jcode-demo-shell {
+  display: flex;
+  flex-direction: column;
+}
+
+.jcode-demo-tabbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 10px;
+  background: #161616;
+  border-bottom: 1px solid #2e2e2e;
+  min-height: 40px;
+}
+
+.jcode-demo-tabs {
+  display: flex;
+  gap: 2px;
+}
+
+.jcode-demo-tabs button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: #999;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.jcode-demo-tabs button:hover {
+  color: #ddd;
+}
+
+.jcode-demo-tabs button.active {
+  color: #fff;
+  border-bottom-color: var(--accent, #ff8400);
+}
+
+.jcode-demo-tab-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.jcode-demo-copy {
+  appearance: none;
+  border: 1px solid #333;
+  background: #222;
+  color: #ccc;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.jcode-demo-copy:hover {
+  border-color: #555;
+  color: #fff;
+}
+
+.jcode-demo-preview-slot {
+  min-height: 0;
+  flex: 1;
+  background: var(--color-background, #0d0d0d);
+  color: var(--color-foreground, #e4e4e7);
+  color-scheme: dark;
+}
+
+.jcode-demo-placeholder-body {
+  flex: 1;
+  min-height: 72px;
+  background:
+    linear-gradient(90deg, #1a1a1a 25%, #222 37%, #1a1a1a 63%);
+  background-size: 400% 100%;
+  animation: jcode-demo-shimmer 1.2s ease infinite;
+}
+
+@keyframes jcode-demo-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jcode-demo-placeholder-body {
+    animation: none;
+  }
+}
+
+/* Code tab — dark elevated pane + hljs tokens (readable on #121218). */
+.jcode-demo-code {
+  margin: 0;
+  padding: 16px 18px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 480px;
+  max-width: 100%;
+  background: #121218 !important;
+  color: #e8e8ec !important;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12.5px;
+  line-height: 1.55;
+  tab-size: 2;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  box-sizing: border-box;
+}
+
+.jcode-demo-code code,
+.jcode-demo-code .hljs {
+  display: block;
+  font-family: inherit;
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
+  background: transparent !important;
+  color: #e8e8ec !important;
+  padding: 0 !important;
+  border: 0 !important;
+  font-size: inherit !important;
+  line-height: inherit;
+}
+
+/* Syntax colors scoped to demo Code tab (not docs navy article blocks). */
+.jcode-demo-code .hljs-comment,
+.jcode-demo-code .hljs-quote {
+  color: #8b8b96;
+  font-style: italic;
+}
+.jcode-demo-code .hljs-keyword,
+.jcode-demo-code .hljs-selector-tag,
+.jcode-demo-code .hljs-meta,
+.jcode-demo-code .hljs-built_in {
+  color: #7dd3fc;
+}
+.jcode-demo-code .hljs-string,
+.jcode-demo-code .hljs-attr,
+.jcode-demo-code .hljs-template-tag {
+  color: #86efac;
+}
+.jcode-demo-code .hljs-number,
+.jcode-demo-code .hljs-literal {
+  color: #fcd34d;
+}
+.jcode-demo-code .hljs-title,
+.jcode-demo-code .hljs-section,
+.jcode-demo-code .hljs-name {
+  color: #d8b4fe;
+}
+.jcode-demo-code .hljs-type,
+.jcode-demo-code .hljs-class .hljs-title {
+  color: #fca5a5;
+}
+.jcode-demo-code .hljs-params {
+  color: #f0abfc;
+}
+.jcode-demo-code .hljs-variable,
+.jcode-demo-code .hljs-template-variable {
+  color: #fde68a;
+}
+.jcode-demo-code .hljs-function,
+.jcode-demo-code .hljs-title.function_ {
+  color: #c4b5fd;
+}
+.jcode-demo-code .hljs-property {
+  color: #93c5fd;
+}
+.jcode-demo-code .hljs-punctuation,
+.jcode-demo-code .hljs-tag {
+  color: #a1a1aa;
+}
+.jcode-demo-code .hljs-tag .hljs-name {
+  color: #f9a8d4;
+}
+.jcode-demo-code .hljs-tag .hljs-attr {
+  color: #93c5fd;
+}
+.jcode-demo-code .hljs-tag .hljs-string {
+  color: #86efac;
+}
+
+.jcode-demo-chrome {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: #1a1a1a;
+  border-bottom: 1px solid #2e2e2e;
+}
+
+.jcode-demo-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.jcode-demo-dot.red { background: #ff5f57; }
+.jcode-demo-dot.yellow { background: #febc2e; }
+.jcode-demo-dot.green { background: #28c840; }
+
+.jcode-demo-label {
+  margin-left: 8px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.jcode-demo-body {
+  background: var(--color-background, #0d0d0d);
+  color: var(--color-foreground, #e4e4e7);
+  min-height: 64px;
+}
+
+.jcode-demo-body.dark {
+  /* Ensure jcode-ui dark tokens apply even if the marketing site is light */
+  color-scheme: dark;
+}
+
+.jcode-demo-pad {
+  padding: 12px 14px 16px;
+}
+
+/* Composer fills the demo frame width (inherits --jcode-col-max: 100%). */
+.jcode-demo .jcode-chat-input {
+  border-radius: var(--radius-xl, 12px);
+  box-shadow: none;
+}
+
+.jcode-demo-input {
+  flex-shrink: 0;
+  border-top: 1px solid var(--color-border, #2e2e2e);
+  padding: 8px;
+}
+
+.jcode-demo-thread-wrap {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+  width: 100%;
+}
+
+.jcode-demo-hint {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: #a1a1aa;
+  line-height: 1.45;
+}
+.jcode-demo-hint code {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.92em;
+  color: #e4e4e7;
+  background: #25252b;
+  border: 1px solid #3a3a40;
+  border-radius: 4px;
+  padding: 0.05em 0.35em;
+}
+
+.jcode-demo-hint.mono {
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+/* Attachment demos: don't let host button/img rules blow up tiles. */
+.jcode-demo .jcode-attachment-list,
+.jcode-live-demo .jcode-attachment-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+.jcode-demo .jcode-attachment__thumb,
+.jcode-live-demo .jcode-attachment__thumb {
+  padding: 0 !important;
+  border-radius: 8px !important;
+}
+.jcode-demo .jcode-attachment__thumb img,
+.jcode-live-demo .jcode-attachment__thumb img {
+  margin: 0 !important;
+  max-width: none !important;
+}
+
+.jcode-demo-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  min-height: 48px;
+}
+
+.jcode-demo-gallery {
+  display: grid;
+  gap: 4px;
+}
+
+.jcode-demo-gallery-label {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  color: #777;
+  margin: 6px 0 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.jcode-demo-gallery-item:first-child .jcode-demo-gallery-label {
+  margin-top: 0;
+}
+
+.jcode-demo-gallery-item {
+  padding: 0;
+  border-bottom: none;
+}
+/* Keep tool headers compact in the gallery strip. */
+.jcode-demo-gallery .jcode-toolcall {
+  margin: 0;
+}
+.jcode-demo-gallery .jcode-toolcall > button {
+  padding-top: 0.2rem;
+  padding-bottom: 0.2rem;
+}
+
+.jcode-demo-swatches {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.jcode-demo-swatch {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.jcode-demo-swatch-chip {
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid #333;
+}
+
+.jcode-demo-swatch code {
+  font-size: 10px;
+  color: #aaa;
+  word-break: break-all;
+}
+
+.jcode-demo-swatch span {
+  color: #ccc;
+}
+
+.jcode-demo-missing {
+  padding: 16px;
+  color: #f87171;
+  font-size: 13px;
+}
+
+/* Callouts inside chat-ui docs */
+.doc-article .jcode-callout {
+  margin: 1rem 0 1.25rem;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--line, #e5e5e5);
+  background: var(--paper-2, #fafafa);
+  font-size: 14px;
+  line-height: 1.5;
+}
+.doc-article .jcode-callout.tip {
+  border-color: color-mix(in srgb, var(--accent, #ff8400) 35%, transparent);
+  background: color-mix(in srgb, var(--accent, #ff8400) 8%, transparent);
+}
+.doc-article .jcode-callout.warn {
+  border-color: #f59e0b55;
+  background: #f59e0b12;
+}

--- a/site/src/playground/demoSources.ts
+++ b/site/src/playground/demoSources.ts
@@ -1,0 +1,349 @@
+/**
+ * Source snippets shown in the Code tab of ComponentDemo.
+ * Keep these short and copy-pasteable — they mirror the live fixtures, not the
+ * full demo harness.
+ */
+
+export const DEMO_SOURCES: Record<string, string> = {
+  thread: `import {
+  RuntimeProvider,
+  ToolRegistryProvider,
+  createDefaultToolRegistry,
+  createMockRuntime,
+  Thread,
+  ChatInput,
+} from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const runtime = createMockRuntime({
+  items: [
+    {
+      kind: 'message',
+      seq: 1,
+      data: {
+        id: 'u1',
+        role: 'user',
+        content: 'Fix the race in server.go',
+        timestamp: Date.now(),
+      },
+    },
+    {
+      kind: 'message',
+      seq: 2,
+      data: {
+        id: 'a1',
+        role: 'assistant',
+        content: 'Done — tests are green.',
+        timestamp: Date.now(),
+        durationMs: 4200,
+      },
+    },
+  ],
+})
+
+export function App() {
+  return (
+    <RuntimeProvider runtime={runtime}>
+      <ToolRegistryProvider registry={createDefaultToolRegistry()}>
+        <div style={{ height: 420, display: 'flex', flexDirection: 'column' }}>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <Thread virtualize={false} />
+          </div>
+          <ChatInput showContextBar />
+        </div>
+      </ToolRegistryProvider>
+    </RuntimeProvider>
+  )
+}`,
+
+  message: `import { RuntimeProvider, createMockRuntime, Message } from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const runtime = createMockRuntime()
+
+const user = {
+  id: 'u1',
+  role: 'user' as const,
+  content: 'Fix the race condition in \`server.go\`.',
+  timestamp: Date.now(),
+}
+
+const assistant = {
+  id: 'a1',
+  role: 'assistant' as const,
+  content: "Here's the fix with a mutex around the map write.",
+  timestamp: Date.now(),
+  durationMs: 4200,
+  reasoning: 'Concurrent map writes without synchronization…',
+  sources: [
+    { id: 's1', title: 'Go memory model', url: 'https://go.dev/ref/mem' },
+  ],
+}
+
+export function Demo() {
+  return (
+    <RuntimeProvider runtime={runtime}>
+      <Message message={user} canEdit />
+      <Message message={assistant} />
+    </RuntimeProvider>
+  )
+}`,
+
+  'chat-input': `import {
+  RuntimeProvider,
+  createMockRuntime,
+  ChatInput,
+} from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const runtime = createMockRuntime({
+  state: {
+    tokenSnapshot: {
+      total_tokens: 98000,
+      prompt_tokens: 92000,
+      completion_tokens: 6000,
+      model_context_limit: 128000,
+    },
+  },
+})
+
+export function Demo() {
+  return (
+    <RuntimeProvider runtime={runtime}>
+      <ChatInput
+        slashCommands={[
+          { slash: '/goal', description: 'Set the session goal' },
+          { slash: '/compact', description: 'Compact context' },
+        ]}
+        allowImages
+        showContextBar
+        placeholder="Send a message… try /"
+      />
+    </RuntimeProvider>
+  )
+}`,
+
+  'tool-call': `import {
+  RuntimeProvider,
+  ToolRegistryProvider,
+  createDefaultToolRegistry,
+  createMockRuntime,
+  ToolCallCard,
+} from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const tool = {
+  id: 't1',
+  name: 'execute',
+  args: JSON.stringify({ command: 'go test ./...' }),
+  status: 'done' as const,
+  timestamp: Date.now(),
+  output: 'ok\\tgithub.com/acme/server\\t0.412s\\nPASS',
+  displayInfo: { title: 'execute', subtitle: 'go test ./...' },
+}
+
+export function Demo() {
+  return (
+    <RuntimeProvider runtime={createMockRuntime()}>
+      <ToolRegistryProvider registry={createDefaultToolRegistry()}>
+        <ToolCallCard tool={tool} />
+      </ToolRegistryProvider>
+    </RuntimeProvider>
+  )
+}`,
+
+  'tool-gallery': `import {
+  RuntimeProvider,
+  ToolRegistryProvider,
+  createDefaultToolRegistry,
+  createMockRuntime,
+  ToolCallCard,
+} from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+// Each tool.name maps to a default renderer:
+// execute → terminal | read → file-viewer | edit → diff | grep → search
+// todowrite → todo | load_skill → skill | team_list → team | * → generic
+
+const tools = [
+  { id: '1', name: 'execute', args: '{"command":"go test"}', status: 'done', timestamp: 0, output: 'PASS' },
+  { id: '2', name: 'edit', args: '{"path":"server.go"}', status: 'done', timestamp: 0, output: '- old\\n+ new' },
+]
+
+export function Demo() {
+  const registry = createDefaultToolRegistry()
+  return (
+    <RuntimeProvider runtime={createMockRuntime()}>
+      <ToolRegistryProvider registry={registry}>
+        {tools.map((t) => (
+          <ToolCallCard key={t.id} tool={t as never} />
+        ))}
+      </ToolRegistryProvider>
+    </RuntimeProvider>
+  )
+}`,
+
+  approval: `import {
+  RuntimeProvider,
+  createMockRuntime,
+  ApprovalBanner,
+} from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const pending = {
+  id: 'ap1',
+  tool_name: 'execute',
+  tool_args: JSON.stringify({ command: 'rm -rf ./build' }),
+  is_external: false,
+}
+
+const resolved = { ...pending, id: 'ap2', resolved: true, approved: true }
+
+export function Demo() {
+  // MockRuntime default resolveApproval updates items for interactive demos.
+  return (
+    <RuntimeProvider runtime={createMockRuntime()}>
+      <ApprovalBanner approval={pending} />
+      <ApprovalBanner approval={resolved} />
+    </RuntimeProvider>
+  )
+}`,
+
+  'ask-user': `import {
+  RuntimeProvider,
+  createMockRuntime,
+  AskUserCard,
+} from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const tool = {
+  id: 'ask1',
+  name: 'ask_user',
+  args: '{}',
+  status: 'running' as const,
+  timestamp: Date.now(),
+  askUserId: 'ask1',
+  askUserQuestions: [
+    {
+      question: 'Which test strategy should I use?',
+      header: 'test strategy',
+      options: [
+        { label: 'Unit only', description: 'Fast' },
+        { label: 'Integration', description: 'Real DB' },
+        { label: 'Both' },
+      ],
+    },
+  ],
+}
+
+export function Demo() {
+  return (
+    <RuntimeProvider runtime={createMockRuntime()}>
+      <AskUserCard tool={tool} />
+    </RuntimeProvider>
+  )
+}`,
+
+  reasoning: `import { Reasoning } from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+export function Demo() {
+  return (
+    <Reasoning
+      reasoning="The panic stack points at concurrent map writes…"
+      durationMs={3200}
+      defaultExpanded
+    />
+  )
+}`,
+
+  sources: `import { Sources } from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+export function Demo() {
+  return (
+    <Sources
+      sources={[
+        {
+          id: 's1',
+          title: 'Go memory model',
+          url: 'https://go.dev/ref/mem',
+          snippet: 'Happens-before rules for mutexes.',
+        },
+        { id: 's2', title: 'server.go:48', snippet: 'go process(req)' },
+      ]}
+    />
+  )
+}`,
+
+  attachment: `import { AttachmentList, ChatInput } from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+// Standalone tiles (composer / custom UIs)
+export function Tiles() {
+  return (
+    <AttachmentList
+      images={[{ data: '<base64…>', media_type: 'image/png', name: 'shot.png' }]}
+      onRemove={(i) => console.log('remove', i)}
+      size={56}
+    />
+  )
+}
+
+// Preferred: ChatInput owns paste + paperclip + strip
+export function Composer() {
+  return <ChatInput allowImages placeholder="Paste or attach an image…" />
+}`,
+
+  'context-bar': `import {
+  RuntimeProvider,
+  createMockRuntime,
+  ContextBar,
+} from 'jcode-ui'
+import 'jcode-ui/styles.css'
+
+const runtime = createMockRuntime({
+  state: {
+    tokenSnapshot: {
+      total_tokens: 98000,
+      prompt_tokens: 92000,
+      completion_tokens: 6000,
+      model_context_limit: 128000,
+    },
+  },
+})
+
+export function Demo() {
+  return (
+    <RuntimeProvider runtime={runtime}>
+      <ContextBar
+        size={28}
+        breakdown={{
+          context_limit: 128000,
+          system_prompt_tokens: 1200,
+          system_tools_tokens: 8400,
+          mcp_tools_tokens: 2100,
+          skills_tokens: 900,
+          messages_tokens: 85400,
+        }}
+      />
+    </RuntimeProvider>
+  )
+}`,
+
+  theming: `/* Override jcode-ui tokens in your global CSS */
+
+:root {
+  --color-primary: #6366f1;
+  --color-background: #fafaf9;
+  --radius-lg: 10px;
+}
+
+.dark {
+  --color-primary: #818cf8;
+  --color-background: #0a0a0a;
+}
+
+/* Toggle dark mode */
+// document.documentElement.classList.toggle('dark')`,
+}

--- a/site/src/playground/highlightDemoCode.ts
+++ b/site/src/playground/highlightDemoCode.ts
@@ -1,0 +1,41 @@
+/**
+ * Syntax-highlight demo source snippets (TSX) for the Preview | Code tab.
+ * Uses highlight.js core + only the languages we need to keep the chunk small.
+ */
+
+import hljs from 'highlight.js/lib/core'
+import typescript from 'highlight.js/lib/languages/typescript'
+import xml from 'highlight.js/lib/languages/xml'
+import javascript from 'highlight.js/lib/languages/javascript'
+
+let registered = false
+
+function ensureRegistered() {
+  if (registered) return
+  // TSX = TypeScript + XML (JSX tags). Order matters: register deps first.
+  hljs.registerLanguage('xml', xml)
+  hljs.registerLanguage('javascript', javascript)
+  hljs.registerLanguage('typescript', typescript)
+  registered = true
+}
+
+/** Escape then highlight; falls back to escaped plain text on failure. */
+export function highlightDemoCode(source: string, language: 'tsx' | 'typescript' | 'javascript' = 'tsx'): string {
+  ensureRegistered()
+  const lang = language === 'tsx' ? 'typescript' : language
+  try {
+    // highlight.js treats JSX as typescript when xml is registered (tsx mode via sublanguage).
+    // Prefer explicit 'typescript' which covers most demo sources (imports + JSX).
+    return hljs.highlight(source, { language: lang, ignoreIllegals: true }).value
+  } catch {
+    return escapeHtml(source)
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,9 +1,48 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const root = path.dirname(fileURLToPath(import.meta.url))
+
+// jcode-ui is linked via file: and ships its own nested react (devDependency of
+// the package). Without dedupe/alias, Vite serves two React copies →
+// "Invalid hook call" / useState of null in the browser.
+const reactPath = path.resolve(root, 'node_modules/react')
+const reactDomPath = path.resolve(root, 'node_modules/react-dom')
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
+    alias: {
+      react: reactPath,
+      'react-dom': reactDomPath,
+      'react/jsx-runtime': path.resolve(reactPath, 'jsx-runtime.js'),
+      'react/jsx-dev-runtime': path.resolve(reactPath, 'jsx-dev-runtime.js'),
+    },
+  },
+  optimizeDeps: {
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'jcode-ui', 'jcode-ui-core'],
+    // Force rebundle when local packages change
+    exclude: [],
+  },
+  server: {
+    // Keep off 5173 — that port is reserved for the product web UI
+    // (web/vite.config.ts + desktop/src-tauri/tauri.conf.json devUrl).
+    // Running `pnpm dev` in site on 5173 makes `make desktop-dev` load the
+    // marketing site instead of jcode.
+    port: 5199,
+    strictPort: false,
+    fs: {
+      // allow importing from monorepo packages/
+      allow: [root, path.resolve(root, '..')],
+    },
+  },
   build: {
     chunkSizeWarningLimit: 1200,
+    commonjsOptions: {
+      include: [/node_modules/],
+    },
   },
 })

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -50,7 +50,7 @@ import {
   SparklesIcon,
 } from '@heroicons/react/24/outline'
 import { StarIcon as StarIconSolid, CheckCircleIcon } from '@heroicons/react/24/solid'
-import { useRuntimeActions, useRuntimeState } from 'jcode-ui'
+import { AttachmentList, useRuntimeActions, useRuntimeState } from 'jcode-ui'
 import type { ChatImage as RuntimeChatImage } from 'jcode-ui-core'
 import { useAppDispatch, useAppSelector } from '../app/hooks'
 import { chatActions, modelActions } from '../app/store'
@@ -153,8 +153,8 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
 
   // Composer-local state.
   const [input, setInput] = useState('')
+  /** Pending vision images — same shape as jcode-ui `ChatImage` / AttachmentList. */
   const [pendingImages, setPendingImages] = useState<ChatImage[]>([])
-  const [pendingPreviews, setPendingPreviews] = useState<string[]>([])
   const [showSlashMenu, setShowSlashMenu] = useState(false)
   const [slashFilter, setSlashFilter] = useState('')
   const [selectedSlashIdx, setSelectedSlashIdx] = useState(0)
@@ -305,7 +305,9 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
     const text = input.trim()
     if (!text && pendingImages.length === 0) return
     const images: RuntimeChatImage[] | undefined =
-      pendingImages.length > 0 ? pendingImages.map((i) => ({ data: i.data, media_type: i.media_type })) : undefined
+      pendingImages.length > 0
+        ? pendingImages.map((i) => ({ data: i.data, media_type: i.media_type, name: i.name }))
+        : undefined
     const body = text || '(see attached images)'
     if (isRunning) {
       actions.enqueueMessage(body, images)
@@ -314,7 +316,6 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
     }
     setInput('')
     setPendingImages([])
-    setPendingPreviews([])
     setShowSlashMenu(false)
     onSent?.()
   }, [actions, input, isRunning, onSent, pendingImages])
@@ -401,8 +402,10 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
       const commaIdx = result.indexOf(',')
       if (commaIdx < 0) return
       const base64Data = result.substring(commaIdx + 1)
-      setPendingImages((prev) => [...prev, { data: base64Data, media_type: file.type }])
-      setPendingPreviews((prev) => [...prev, result])
+      setPendingImages((prev) => [
+        ...prev,
+        { data: base64Data, media_type: file.type, name: file.name || undefined },
+      ])
     }
     reader.readAsDataURL(file)
   }
@@ -432,7 +435,6 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
 
   function removeImage(index: number) {
     setPendingImages((prev) => prev.filter((_, i) => i !== index))
-    setPendingPreviews((prev) => prev.filter((_, i) => i !== index))
   }
 
   function triggerImageUpload() {
@@ -584,7 +586,6 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
   useEffect(() => {
     if (!imageSupport && pendingImages.length > 0) {
       setPendingImages([])
-      setPendingPreviews([])
     }
   }, [imageSupport, pendingImages.length])
 
@@ -729,25 +730,9 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
               style={{ minHeight: 28, maxHeight: 200, fontFamily: 'var(--font-sans)' }}
             />
 
-            {pendingPreviews.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-2">
-                {pendingPreviews.map((preview, i) => (
-                  <div key={i} className="group relative">
-                    <img
-                      src={preview}
-                      alt={`attachment ${i + 1}`}
-                      className="h-14 w-14 rounded-[var(--radius-md)] border border-[var(--color-border)] object-cover"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => removeImage(i)}
-                      className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border-none bg-[var(--color-destructive)] text-[9px] text-[var(--color-on-destructive)] opacity-0 transition-opacity group-hover:opacity-100"
-                      aria-label="Remove image"
-                    >
-                      ✕
-                    </button>
-                  </div>
-                ))}
+            {pendingImages.length > 0 && (
+              <div className="mt-2">
+                <AttachmentList images={pendingImages} onRemove={removeImage} size={56} />
               </div>
             )}
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -475,6 +475,8 @@ export function normalizeMode(m?: string): AgentMode {
 export interface ChatImage {
   data: string       // base64 data (without data: prefix)
   media_type: string // e.g. "image/png", "image/jpeg"
+  /** Original filename when known (file picker / paste). */
+  name?: string
 }
 
 export interface ChatMessage {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -133,20 +133,28 @@ select:focus-visible {
 }
 .jcode-prose pre {
   border-radius: var(--radius-lg);
-  border: 1px solid var(--code-border);
+  border: 1px solid var(--code-border, #3f3f48);
   font-size: 0.8125rem;
   line-height: 1.625;
   padding: 0.875em 1em;
-  background: var(--code-bg);
-  color: var(--hljs-fg);
+  background: var(--code-bg, #222228);
+  color: var(--code-fg, var(--hljs-fg, #f0f0f4));
+}
+.jcode-prose pre code,
+.jcode-prose pre .hljs {
+  background: transparent !important;
+  color: inherit !important;
+  padding: 0 !important;
+  border: 0 !important;
 }
 .jcode-prose code:not(pre code) {
   padding: 0.15em 0.4em;
   border-radius: var(--radius-sm);
   font-size: 0.8125em;
   font-family: var(--font-mono);
-  background: var(--color-muted);
-  color: var(--color-foreground);
+  background: var(--code-inline-bg, var(--color-muted));
+  color: var(--code-fg, var(--color-foreground));
+  border: 1px solid var(--code-border, transparent);
 }
 .jcode-prose a {
   text-decoration: underline;


### PR DESCRIPTION
## Summary
- Expand jcode-ui docs with per-component pages, guides, API reference, live demos, and minimal/Zustand examples
- Improve chat surface quality: code/card contrast, dark-token inheritance (tool subtitles), soft approval/thinking chrome, code wrap without horizontal scroll
- Align image attachments across library, product, and docs (composer picker, AttachmentList, preview lightbox)

## Details
- **Library (`jcode-ui` / `jcode-ui-core`)**: elevated code surfaces, tool header/subtitle fixes, attachment tiles + paperclip flow, mockRuntime sequence keys
- **Site**: ComponentDemo shell, highlight.js for demo Code tabs and Chat UI Quick start, docs isolation from host article styles, site Vite port 5199 to avoid desktop 5173 conflict
- **Product (`web`)**: reuse `AttachmentList` for pending images; `ChatImage.name` optional

## Test plan
- [ ] `cd site && pnpm dev` → open `/chat-ui` (Quick start highlighting), `/chat-ui/docs/components/*` demos (Thread, ToolCallCard subtitles, Attachment tiles)
- [ ] `cd packages/jcode-ui && pnpm build` succeeds
- [ ] Product web / desktop: attach image via paste or picker; thumbnails + remove + preview
- [ ] `make desktop-dev` loads product UI on 5173 (not marketing site)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two runnable chat UI examples: a minimal in-memory demo and a Zustand-backed integration example.
  * Introduced image attachment support improvements, including image previews and easier attachment handling.
  * Added a searchable API/docs experience with new demo previews and quick-start samples.

* **Bug Fixes**
  * Improved scrolling, rendering, and styling across chat threads, messages, tool calls, and composer controls.
  * Made runtime behavior more reliable for queued messages, approvals, and user prompts.

* **Documentation**
  * Expanded the chat UI docs with installation, API, component, guide, and example pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->