### PR TITLE
feat(acp): register subagent tool and bridge its events to ACP clients

### DIFF
--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -384,6 +384,21 @@ func (a *acpAgent) buildAgentSession(
 		mcpTools, _ = tools.LoadMCPTools(ctx, cfg.MCPServers)
 	}
 
+	// The ACPHandler is created before the tool list so the subagent tool can
+	// bridge its lifecycle/progress callbacks into ACP tool_call_update
+	// notifications (parity with the TUI notifier and the web SSE events).
+	acpHandler := handler.NewACPHandler(a.conn, sessionID, pwd)
+
+	// Langfuse tracer — created before the tools so subagent runs nest child
+	// traces under the session trace.
+	var tracer *telemetry.LangfuseTracer
+	if cfg.Telemetry != nil && cfg.Telemetry.Langfuse != nil {
+		tracer = telemetry.NewLangfuseTracer(cfg.Telemetry.Langfuse)
+	}
+
+	// One factory serves subagent + workflow model overrides (incl. the
+	// "small" alias); fallback is this session's current model.
+	factory := internalmodel.NewModelFactory(cfg, chatModel)
 	allTools := []tool.BaseTool{
 		env.NewReadTool(), env.NewEditTool(), env.NewWriteTool(),
 		env.NewExecuteTool(bgManager), env.NewGrepTool(),
@@ -392,9 +407,18 @@ func (a *acpAgent) buildAgentSession(
 		env.NewAutomationCreateTool(),
 		env.NewSwitchEnvTool(),
 		env.NewCheckBackgroundTool(bgManager),
-		env.NewWorkflowRunTool(&tools.WorkflowToolDeps{
-			ModelFactory: internalmodel.NewModelFactory(cfg, chatModel),
+		env.NewSubagentTool(&tools.SubagentDeps{
+			ChatModel:    chatModel,
+			ModelFactory: factory,
 			Recorder:     rec,
+			Tracer:       tracer,
+			Notifier:     acpHandler.OnSubagentEvent,
+			ProgressFn:   acpHandler.OnSubagentProgress,
+		}),
+		env.NewWorkflowRunTool(&tools.WorkflowToolDeps{
+			ModelFactory: factory,
+			Recorder:     rec,
+			Tracer:       tracer,
 			Loader:       flowLoader,
 		}),
 	}
@@ -427,8 +451,6 @@ func (a *acpAgent) buildAgentSession(
 	startupMode := resolveStartupMode(cfg, false)
 	approvalState := runner.NewApprovalStateWithMode(pwd, startupMode)
 
-	// Create ACPHandler
-	acpHandler := handler.NewACPHandler(a.conn, sessionID, pwd)
 	approvalState.SetHandler(acpHandler)
 
 	// Wire up environment change callback so switch_env properly restores
@@ -457,12 +479,6 @@ func (a *acpAgent) buildAgentSession(
 			rec.RecordTodoSnapshot(snapItems)
 		}
 		env.GoalStore.OnUpdate = tools.GoalRecorderHook(rec)
-	}
-
-	// Langfuse tracer
-	var tracer *telemetry.LangfuseTracer
-	if cfg.Telemetry != nil && cfg.Telemetry.Langfuse != nil {
-		tracer = telemetry.NewLangfuseTracer(cfg.Telemetry.Langfuse)
 	}
 
 	// Build agent with middlewares

--- a/internal/handler/acp.go
+++ b/internal/handler/acp.go
@@ -45,6 +45,11 @@ type ACPHandler struct {
 	// middleware does not pass the Eino tool call ID, so we match by
 	// (toolName, toolArgs) in arrival order.
 	pendingApprovals []pendingApproval
+	// subagentCalls maps a running subagent's name to the ACP tool call ID of
+	// its "subagent" tool call, so lifecycle/progress callbacks (which only
+	// carry the subagent name) can be forwarded as tool_call_update
+	// notifications on the right call.
+	subagentCalls map[string]acp.ToolCallId
 
 	// onModeChange, when set, is invoked after the handler promotes the session
 	// mode (e.g. "Allow All" → Full access) so the owning session can reconcile its
@@ -73,6 +78,7 @@ func NewACPHandler(conn *acp.AgentSideConnection, sessionID acp.SessionId, workD
 		einoToACP:      make(map[string]acp.ToolCallId),
 		toolArgs:       make(map[acp.ToolCallId]string),
 		toolTerminated: make(map[acp.ToolCallId]bool),
+		subagentCalls:  make(map[string]acp.ToolCallId),
 	}
 }
 
@@ -327,6 +333,11 @@ func (h *ACPHandler) OnToolCall(ev ToolCallEvent) {
 	h.pendingApprovals = append(h.pendingApprovals, pendingApproval{
 		acpID: id, toolName: name, toolArgs: args,
 	})
+	if name == "subagent" {
+		if sub := subagentNameFromArgs(args); sub != "" {
+			h.subagentCalls[sub] = id
+		}
+	}
 	h.mu.Unlock()
 
 	presentation := h.presentationForTool(name, args)
@@ -399,6 +410,13 @@ func (h *ACPHandler) OnToolResult(ev ToolResultEvent) {
 				break
 			}
 		}
+		// Drop the subagent progress mapping for this call in case the done
+		// lifecycle event never fired (rejected permission, tool error).
+		for sub, acpID := range h.subagentCalls {
+			if acpID == id {
+				delete(h.subagentCalls, sub)
+			}
+		}
 	}
 	h.mu.Unlock()
 
@@ -468,6 +486,95 @@ func (h *ACPHandler) OnAgentDone(err error) {
 
 func (h *ACPHandler) OnTokenUpdate(info TokenUsage) {
 	// ACP does not have a standard token update notification.
+}
+
+// --- Subagent events ---
+
+// OnSubagentEvent bridges subagent lifecycle events (tools.SubagentNotifier)
+// onto the "subagent" tool call as tool_call_update notifications. The final
+// status and result ride the regular OnToolResult update; the done event only
+// clears the progress mapping.
+func (h *ACPHandler) OnSubagentEvent(name, agentType string, done bool, result string, err error) {
+	h.mu.Lock()
+	id, ok := h.subagentCalls[name]
+	if done {
+		delete(h.subagentCalls, name)
+	}
+	h.mu.Unlock()
+	if !ok || done {
+		return
+	}
+
+	if updateErr := h.conn.SessionUpdate(context.Background(), acp.SessionNotification{
+		SessionId: h.sessionID,
+		Update: acp.UpdateToolCall(id,
+			acp.WithUpdateStatus(acp.ToolCallStatusInProgress),
+			acp.WithUpdateContent([]acp.ToolCallContent{
+				acp.ToolContent(acp.TextBlock(fmt.Sprintf("%s subagent started", agentType))),
+			}),
+		),
+	}); updateErr != nil {
+		logACPError("SubagentEvent", updateErr)
+	}
+}
+
+// OnSubagentProgress bridges intermediate subagent tool activity
+// (tools.SubagentProgressFn) onto the "subagent" tool call as a rolling
+// content update — ACP replaces the content collection on each update, so the
+// client shows the latest activity line while the subagent runs.
+func (h *ACPHandler) OnSubagentProgress(agentName, event, toolName, detail string) {
+	h.mu.Lock()
+	id, ok := h.subagentCalls[agentName]
+	h.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	if err := h.conn.SessionUpdate(context.Background(), acp.SessionNotification{
+		SessionId: h.sessionID,
+		Update: acp.UpdateToolCall(id,
+			acp.WithUpdateContent([]acp.ToolCallContent{
+				acp.ToolContent(acp.TextBlock(subagentProgressLine(event, toolName, detail))),
+			}),
+		),
+	}); err != nil {
+		logACPError("SubagentProgress", err)
+	}
+}
+
+// subagentNameFromArgs extracts the "name" field from a subagent tool call's
+// raw args JSON ("" when absent or unparsable).
+func subagentNameFromArgs(argsJSON string) string {
+	var args struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return ""
+	}
+	return args.Name
+}
+
+// subagentProgressLine renders one progress event as a short single-line
+// summary ("tool_call" / "tool_result" are the events subagents emit today).
+func subagentProgressLine(event, toolName, detail string) string {
+	prefix := event
+	switch event {
+	case "tool_call":
+		prefix = "→"
+	case "tool_result":
+		prefix = "←"
+	}
+	return strings.TrimSpace(fmt.Sprintf("%s %s %s", prefix, toolName, compactProgressDetail(detail)))
+}
+
+// compactProgressDetail flattens tool args/output to one truncated line.
+func compactProgressDetail(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	const max = 160
+	if len(s) > max {
+		s = strings.ToValidUTF8(s[:max-3], "") + "..."
+	}
+	return s
 }
 
 // --- Approval flow ---

--- a/internal/handler/acp_test.go
+++ b/internal/handler/acp_test.go
@@ -68,6 +68,61 @@ func TestACPToolPresentationWriteIncludesDiffContent(t *testing.T) {
 	}
 }
 
+func TestACPSubagentNameFromArgs(t *testing.T) {
+	if got := subagentNameFromArgs(`{"name":"scan-repo","prompt":"..."}`); got != "scan-repo" {
+		t.Fatalf("name = %q, want scan-repo", got)
+	}
+	if got := subagentNameFromArgs(`not json`); got != "" {
+		t.Fatalf("name = %q, want empty for invalid JSON", got)
+	}
+	if got := subagentNameFromArgs(`{"prompt":"..."}`); got != "" {
+		t.Fatalf("name = %q, want empty when absent", got)
+	}
+}
+
+func TestACPSubagentProgressLine(t *testing.T) {
+	if got := subagentProgressLine("tool_call", "grep", `{"pattern":"foo"}`); got != `→ grep {"pattern":"foo"}` {
+		t.Fatalf("tool_call line = %q", got)
+	}
+	if got := subagentProgressLine("tool_result", "read", "line one\nline two"); got != "← read line one line two" {
+		t.Fatalf("tool_result line = %q", got)
+	}
+	long := strings.Repeat("x", 500)
+	if got := subagentProgressLine("tool_result", "read", long); len(got) > 200 {
+		t.Fatalf("long detail not truncated: len=%d", len(got))
+	}
+}
+
+func TestACPSubagentDoneClearsMappingWithoutUpdate(t *testing.T) {
+	// nil conn: the test passes only if the done path never touches the
+	// connection (it must only clear the progress mapping).
+	h := NewACPHandler(nil, "sess", "/repo")
+	h.subagentCalls["scan-repo"] = "tc_1"
+
+	h.OnSubagentEvent("scan-repo", "explore", true, "result", nil)
+
+	if _, ok := h.subagentCalls["scan-repo"]; ok {
+		t.Fatal("done event did not clear subagent mapping")
+	}
+	// Unknown subagent progress must be a silent no-op (no conn access).
+	h.OnSubagentProgress("scan-repo", "tool_call", "grep", "{}")
+}
+
+func TestACPToolResultClearsStaleSubagentMapping(t *testing.T) {
+	h := NewACPHandler(nil, "sess", "/repo")
+	h.einoToACP["eino_1"] = "tc_1"
+	h.subagentCalls["scan-repo"] = "tc_1"
+	// Terminal status already sent (e.g. permission rejection): OnToolResult
+	// returns before sending, but must still drop the stale mapping.
+	h.toolTerminated["tc_1"] = true
+
+	h.OnToolResult(ToolResultEvent{Name: "subagent", ToolCallID: "eino_1"})
+
+	if _, ok := h.subagentCalls["scan-repo"]; ok {
+		t.Fatal("tool result did not clear stale subagent mapping")
+	}
+}
+
 func TestACPToolFailureOutputDetection(t *testing.T) {
 	cases := []string{
 		"Tool execution failed: exit status 1",


### PR DESCRIPTION
## What

The ACP entry point (`jcode acp`) was the only surface without the subagent tool — TUI (`interactive.go`) and web (`web.go`) both register it. Editor-driven sessions (Zed etc.) could not delegate to subagents, and the agent-eval harness couldn't exercise them either.

### `internal/command/acp.go`
- `buildAgentSession` now registers `NewSubagentTool`, following the interactive/web wiring: one shared `ModelFactory` serves both subagent and workflow deps (incl. the `"small"` model alias), with the session `Recorder` and Langfuse tracer injected.
- `ACPHandler` and tracer creation moved before tool assembly (the subagent callbacks need them); the workflow deps pick up the previously missing `Tracer` for TUI parity.

### `internal/handler/acp.go`
ACP has no custom event channel like the web SSE bridge, so subagent lifecycle/progress events are folded onto the `subagent` tool call as standard `tool_call_update` notifications:
- `OnToolCall` registers a subagent-name → ACP tool-call-id mapping when it sees a `subagent` call.
- `OnSubagentEvent` (lifecycle): "explore subagent started" content + in_progress on start; done only clears the mapping (final status/result still ride the regular `OnToolResult` update).
- `OnSubagentProgress`: renders the child agent's internal tool activity as rolling single-line content updates (`→ grep {...}` / `← read ...`, 160-byte UTF-8-safe truncation). ACP replaces content per update, so clients show the latest activity while the subagent runs.
- `OnToolResult` drops stale mappings for runs whose done event never fired (permission rejected, tool error).

Plan mode intentionally stays without subagent — matches the TUI/web plan tool subsets.

## Why

Parity across the three entry points; unblocks subagent coverage in the ACP-driven e2e harness.

## Testing

- `go test ./internal/...` green; `golangci-lint run --new-from-rev=$(git merge-base HEAD origin/main)` (pre-push mirror) reports 0 issues.
- 4 new unit tests in `acp_test.go`: args name parsing, progress-line formatting/truncation, done-event mapping cleanup, stale-mapping cleanup on tool result.
- Real-model e2e via the agent-eval ACP harness (glm-5.2, isolated HOME/sandbox): the agent delegated to an `explore` subagent (`kind: "think"` tool call), streamed 10 progress content updates (`started` → `→ execute find` → `← read ...`), finished `completed`/`end_turn`, and the final answer contained facts only readable by the subagent (the parent made no read calls of its own).

## Reviewer notes

Known tradeoff, consistent with TUI/web behavior: the progress mapping is keyed by subagent name, so parallel same-named subagents merge onto the newest call, and nested (coordinator-spawned) subagents' own progress is dropped — the coordinator's activity, including spawning them, is still visible.

Generated with Jack AI bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live progress updates for subagent activity.
  * Subagent tool calls now show status changes, intermediate activity, and completion updates in the ACP interface.
  * Long progress details are compacted and truncated for clearer display.

* **Bug Fixes**
  * Improved cleanup of completed and interrupted subagent call tracking to prevent stale status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->