### PR TITLE
fix(jcode-ui): stop file-viewer line numbers wrapping vertically

### DIFF
--- a/packages/jcode-ui/src/styles/components.css
+++ b/packages/jcode-ui/src/styles/components.css
@@ -694,11 +694,14 @@
 .jcode-file-table tr:hover {
   background: color-mix(in srgb, var(--jcode-color-foreground) 4%, transparent);
 }
-.jcode-file-lineno {
+/* NOTE: must out-specify `.jcode-file-table td` (0-1-1) or `white-space: pre-wrap`
+   + `word-break: break-all` there wins and multi-digit line numbers wrap vertically. */
+.jcode-file-table td.jcode-file-lineno {
   color: color-mix(in srgb, var(--jcode-code-fg, var(--jcode-color-muted-foreground)) 45%, transparent);
   user-select: none;
   text-align: right;
   white-space: nowrap;
+  word-break: normal;
   width: 1px;
   padding: 0.05rem 0.75rem 0.05rem 0.65rem;
   border-right: 1px solid var(--jcode-code-border);


### PR DESCRIPTION
## 问题

文件查看器（`read`/`write` 工具渲染）中，两位数及以上的行号被纵向拆开显示（如 `22` 显示为上下两个 `2`）。

## 根因

CSS 特异性冲突：

| 规则 | 特异性 | 属性 |
|---|---|---|
| `.jcode-file-table td` | 0-1-1 ✅ 胜出 | `white-space: pre-wrap; word-break: break-all` |
| `.jcode-file-lineno` | 0-1-0 ❌ 落败 | `white-space: nowrap; width: 1px` |

行号列依赖 `width: 1px` + `nowrap` 做收缩适应，但 `nowrap` 因特异性低而失效，`word-break: break-all` 允许任意字符间断行，导致行号逐字符折行。

## 修复

- 选择器提升为 `.jcode-file-table td.jcode-file-lineno`（特异性 0-2-1）
- 显式 `word-break: normal` 防御回归
- 添加注释说明特异性要求的原因

## 验证

- [x] `pnpm build` 通过，`dist/styles.css` 中确认规则为 `white-space:nowrap; word-break:normal`
- [x] `web/` 通过 workspace 软链引用，重建后即可看到效果

注：`site/` 走 npm registry（`^0.4.1`），需要后续 bump `0.4.2` + publish 才能拿到此修复。