### PR TITLE
feat: multimodal-safe model switch, persisted model, composer drafts, desktop links

### DIFF
--- a/internal/command/acp.go
+++ b/internal/command/acp.go
@@ -261,13 +261,8 @@ func (a *acpAgent) Initialize(_ context.Context, params acp.InitializeRequest) (
 	if cfg, err := config.LoadConfig(); err == nil {
 		providerName, modelName := cfg.GetProviderModel()
 		registry := internalmodel.NewModelRegistryWithConfig(cfg)
-		if _, m, ok := registry.LookupModel(providerName, modelName); ok && m != nil && m.Modalities != nil {
-			for _, mod := range m.Modalities.Input {
-				if mod == "image" {
-					imageSupport = true
-					break
-				}
-			}
+		if _, m, ok := registry.LookupModel(providerName, modelName); ok && m != nil {
+			imageSupport = m.SupportsImageInput()
 		}
 	}
 
@@ -378,7 +373,7 @@ func (a *acpAgent) buildAgentSession(
 	// over the provider-level default before constructing the model.
 	acpEffortCfg := *providerCfg
 	acpEffortCfg.ReasoningEffort = config.ResolveEffort(providerName, modelName, providerCfg.ReasoningEffort)
-	chatModel, err := internalmodel.NewChatModelFromProvider(ctx, modelName, baseURL, &acpEffortCfg)
+	chatModel, err := internalmodel.NewChatModelFromProvider(ctx, providerName, modelName, baseURL, &acpEffortCfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating model: %w", err)
 	}

--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -700,7 +700,7 @@ func (s *interactiveState) handleConfig(cfgMsg *config.Config) {
 	// over the provider-level default before constructing the model.
 	newEffortCfg := *newProvCfg
 	newEffortCfg.ReasoningEffort = config.ResolveEffort(newProvName, newModelName, newProvCfg.ReasoningEffort)
-	newChatModel, err := internalmodel.NewChatModelFromProvider(s.ctx, newModelName, newBaseURL, &newEffortCfg)
+	newChatModel, err := internalmodel.NewChatModelFromProvider(s.ctx, newProvName, newModelName, newBaseURL, &newEffortCfg)
 	if err != nil {
 		return
 	}
@@ -779,7 +779,7 @@ func (s *interactiveState) handleAddModel() {
 	}
 	newEffortCfg2 := *newProvCfg
 	newEffortCfg2.ReasoningEffort = config.ResolveEffort(newProvName, newModelName, newProvCfg.ReasoningEffort)
-	newChatModel, cmErr := internalmodel.NewChatModelFromProvider(s.ctx, newModelName, newBaseURL, &newEffortCfg2)
+	newChatModel, cmErr := internalmodel.NewChatModelFromProvider(s.ctx, newProvName, newModelName, newBaseURL, &newEffortCfg2)
 	if cmErr != nil {
 		return
 	}
@@ -1056,7 +1056,7 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 
 	effortCfg := *providerCfg
 	effortCfg.ReasoningEffort = config.ResolveEffort(providerName, modelName, providerCfg.ReasoningEffort)
-	chatModel, err := internalmodel.NewChatModelFromProvider(ctx, modelName, baseURL, &effortCfg)
+	chatModel, err := internalmodel.NewChatModelFromProvider(ctx, providerName, modelName, baseURL, &effortCfg)
 	if err != nil {
 		return fmt.Errorf("error creating model: %w", err)
 	}

--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -340,7 +340,7 @@ func runWebServer(port int, host string, openBrowser bool, authToken string) err
 		pcEffort := config.ResolveEffort(prov, mod, provCfg.ReasoningEffort)
 		effortCfg := *provCfg
 		effortCfg.ReasoningEffort = pcEffort
-		cm, err := internalmodel.NewChatModelFromProvider(ctx, mod, bURL, &effortCfg)
+		cm, err := internalmodel.NewChatModelFromProvider(ctx, prov, mod, bURL, &effortCfg)
 		if err != nil {
 			return nil, 0, fmt.Errorf("create model %s/%s: %w", prov, mod, err)
 		}

--- a/internal/command/workflow.go
+++ b/internal/command/workflow.go
@@ -232,7 +232,7 @@ func buildFlowSpawn(ctx context.Context, pwd string) (flow.SpawnFunc, func(strin
 	}
 	effortCfg := *providerCfg
 	effortCfg.ReasoningEffort = config.ResolveEffort(providerName, modelName, providerCfg.ReasoningEffort)
-	chatModel, err := internalmodel.NewChatModelFromProvider(ctx, modelName, baseURL, &effortCfg)
+	chatModel, err := internalmodel.NewChatModelFromProvider(ctx, providerName, modelName, baseURL, &effortCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create model: %w", err)
 	}

--- a/internal/handler/web.go
+++ b/internal/handler/web.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	internalmodel "github.com/cnjack/jcode/internal/model"
 	"github.com/cnjack/jcode/internal/tools"
 )
 
@@ -412,9 +413,11 @@ type WebSubagentProgressData struct {
 	Detail    string `json:"detail"`
 }
 
-// WebDoneData signals agent completion.
+// WebDoneData signals agent completion. Error is a short user-facing summary;
+// Detail carries the full raw error text for a collapsible "details" view.
 type WebDoneData struct {
-	Error string `json:"error,omitempty"`
+	Error  string `json:"error,omitempty"`
+	Detail string `json:"detail,omitempty"`
 }
 
 // WebApprovalRequestData carries an approval request. ToolCallID (when known)
@@ -588,11 +591,14 @@ func (h *WebHandler) OnAgentStart() {
 }
 
 func (h *WebHandler) OnAgentDone(err error) {
-	errMsg := ""
-	if err != nil {
-		errMsg = err.Error()
+	if err == nil {
+		h.emit("agent_done", WebDoneData{})
+		return
 	}
-	h.emit("agent_done", WebDoneData{Error: errMsg})
+	// Raw run errors (eino NodeRunError wrapping go-openai API errors) are too
+	// noisy for the timeline — send a one-line summary plus the raw detail.
+	summary, detail := internalmodel.SummarizeRunError(err)
+	h.emit("agent_done", WebDoneData{Error: summary, Detail: detail})
 }
 
 func (h *WebHandler) OnTokenUpdate(info TokenUsage) {

--- a/internal/model/chatmodel.go
+++ b/internal/model/chatmodel.go
@@ -362,14 +362,24 @@ func NewChatModel(_ context.Context, cfg *ChatModelConfig) (einomodel.ToolCallin
 
 // NewChatModelFromProvider builds a ChatModel from a provider config, applying
 // its advanced settings (custom headers, thinking depth, explicit thinking
-// toggle, and the vision capability — which defaults to enabled). baseURL is the
-// already-resolved endpoint (config override or registry default). This is the
-// single place that maps ProviderConfig → ChatModelConfig so every entrypoint
-// (web, TUI, ACP, subagents) honors the same settings.
-func NewChatModelFromProvider(ctx context.Context, modelName, baseURL string, pc *config.ProviderConfig) (einomodel.ToolCallingChatModel, error) {
+// toggle, and the vision capability). baseURL is the already-resolved endpoint
+// (config override or registry default). This is the single place that maps
+// ProviderConfig → ChatModelConfig so every entrypoint (web, TUI, ACP,
+// subagents) honors the same settings.
+//
+// Vision resolution order: explicit pc.Vision override → registry modalities
+// (a text-only model gets vision disabled so image parts are stripped from
+// requests instead of 400-ing the provider) → default enabled (unknown or
+// custom models keep the historical permissive behavior).
+func NewChatModelFromProvider(ctx context.Context, provider, modelName, baseURL string, pc *config.ProviderConfig) (einomodel.ToolCallingChatModel, error) {
 	vision := true
 	if pc.Vision != nil {
 		vision = *pc.Vision
+	} else if m := lookupStaticModel(provider, modelName); m != nil && m.Modalities != nil {
+		vision = m.SupportsImageInput()
+		if !vision {
+			config.Logger().Printf("[chatmodel] %s/%s has no image input modality; image parts will be stripped", provider, modelName)
+		}
 	}
 	return NewChatModel(ctx, &ChatModelConfig{
 		Model:           modelName,

--- a/internal/model/chatmodel_vision_test.go
+++ b/internal/model/chatmodel_vision_test.go
@@ -1,0 +1,122 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudwego/eino/schema"
+	"github.com/cnjack/jcode/internal/config"
+)
+
+func TestSupportsImageInput(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		m    *RegistryModel
+		want bool
+	}{
+		{"nil model", nil, false},
+		{"nil modalities", &RegistryModel{ID: "x"}, false},
+		{"text only", &RegistryModel{ID: "x", Modalities: &ModelModalities{Input: []string{"text"}}}, false},
+		{"text+image", &RegistryModel{ID: "x", Modalities: &ModelModalities{Input: []string{"text", "image"}}}, true},
+		{"video no image", &RegistryModel{ID: "x", Modalities: &ModelModalities{Input: []string{"text", "video"}}}, false},
+	}
+	for _, tc := range cases {
+		if got := tc.m.SupportsImageInput(); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestLookupStaticModel(t *testing.T) {
+	t.Parallel()
+	// glm-5.2 is merged into zhipuai at init() with text-only modalities.
+	m := lookupStaticModel("zhipuai", "glm-5.2")
+	if m == nil {
+		t.Fatal("expected glm-5.2 in static registry")
+	}
+	if m.Modalities == nil {
+		t.Fatal("expected modalities on glm-5.2")
+	}
+	if m.SupportsImageInput() {
+		t.Error("glm-5.2 should not support image input")
+	}
+	if got := lookupStaticModel("no-such-provider", "x"); got != nil {
+		t.Errorf("unknown provider: got %v, want nil", got)
+	}
+	if got := lookupStaticModel("zhipuai", "no-such-model"); got != nil {
+		t.Errorf("unknown model: got %v, want nil", got)
+	}
+}
+
+// TestVisionDerivation verifies NewChatModelFromProvider derives the vision
+// flag from registry modalities when the provider config has no explicit
+// override: a text-only registry model must strip image parts from requests
+// instead of forwarding them to a provider that 400s on image content.
+func TestVisionDerivation(t *testing.T) {
+	t.Parallel()
+	boolPtr := func(b bool) *bool { return &b }
+	cases := []struct {
+		name      string
+		provider  string
+		modelName string
+		pc        *config.ProviderConfig
+		wantStrip bool
+	}{
+		{
+			name:      "text-only registry model strips images",
+			provider:  "zhipuai",
+			modelName: "glm-5.2",
+			pc:        &config.ProviderConfig{APIKey: "k"},
+			wantStrip: true,
+		},
+		{
+			name:      "unknown model keeps vision default (images forwarded)",
+			provider:  "custom-provider",
+			modelName: "whatever",
+			pc:        &config.ProviderConfig{APIKey: "k"},
+			wantStrip: false,
+		},
+		{
+			name:      "explicit vision override wins over registry",
+			provider:  "zhipuai",
+			modelName: "glm-5.2",
+			pc:        &config.ProviderConfig{APIKey: "k", Vision: boolPtr(true)},
+			wantStrip: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cm, err := NewChatModelFromProvider(context.Background(), tc.provider, tc.modelName, "http://127.0.0.1:1/v1", tc.pc)
+			if err != nil {
+				t.Fatalf("build model: %v", err)
+			}
+			m, ok := cm.(*chatModel)
+			if !ok {
+				t.Fatalf("unexpected model type %T", cm)
+			}
+			imgData := "aGk="
+			req := m.buildRequest([]*schema.Message{{
+				Role: schema.User,
+				UserInputMultiContent: []schema.MessageInputPart{
+					{Type: schema.ChatMessagePartTypeText, Text: "hello"},
+					{Type: schema.ChatMessagePartTypeImageURL, Image: &schema.MessageInputImage{
+						MessagePartCommon: schema.MessagePartCommon{MIMEType: "image/png", Base64Data: &imgData},
+					}},
+				},
+			}}, false)
+			if len(req.Messages) != 1 {
+				t.Fatalf("expected 1 message, got %d", len(req.Messages))
+			}
+			msg := req.Messages[0]
+			stripped := len(msg.MultiContent) == 0
+			if stripped != tc.wantStrip {
+				t.Errorf("stripped=%v, want %v (MultiContent=%d, Content=%q)",
+					stripped, tc.wantStrip, len(msg.MultiContent), msg.Content)
+			}
+			if stripped && msg.Content != "hello" {
+				t.Errorf("stripped message should keep text, got %q", msg.Content)
+			}
+		})
+	}
+}

--- a/internal/model/error_summary.go
+++ b/internal/model/error_summary.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// SummarizeRunError turns a raw agent-run error into a short user-facing
+// summary plus the full raw detail. Eino wraps model failures as NodeRunError
+// ("[NodeRunError] …\nnode path: [node_1, ChatModel]") and go-openai API
+// failures as "error, status code: 400, status: 400 Bad Request, message: …" —
+// neither is fit for direct display in a chat timeline. The returned summary
+// is a single line; detail is the complete original text (empty when the
+// summary already carries all of it).
+func SummarizeRunError(err error) (summary, detail string) {
+	if err == nil {
+		return "", ""
+	}
+	detail = strings.TrimSpace(err.Error())
+
+	work := nodePathPattern.ReplaceAllString(detail, "")
+	work = nodeErrTagPattern.ReplaceAllString(work, "")
+	work = strings.TrimSpace(work)
+
+	status := lastSubmatch(statusCodePattern, work)
+	apiMsg := lastSubmatch(apiMessagePattern, work)
+
+	switch {
+	case status != "" && apiMsg != "":
+		summary = fmt.Sprintf("API error %s: %s", status, apiMsg)
+	case apiMsg != "":
+		summary = apiMsg
+	case work != "":
+		summary = work
+	default:
+		summary = detail
+	}
+
+	// A 400 rejecting non-text content parts almost always means the selected
+	// model has no image-input capability — surface that hint explicitly.
+	if status == "400" {
+		lower := strings.ToLower(work)
+		if strings.Contains(lower, "content.type") || strings.Contains(lower, "image") {
+			summary += " — this model may not support image input"
+		}
+	}
+
+	if r := []rune(summary); len(r) > maxSummaryLen {
+		summary = string(r[:maxSummaryLen-1]) + "…"
+	}
+	if summary == detail {
+		detail = ""
+	}
+	return summary, detail
+}
+
+const maxSummaryLen = 300
+
+var (
+	// nodePathPattern drops eino's trailing "node path: [node_1, ChatModel]" line.
+	nodePathPattern = regexp.MustCompile(`(?m)\s*node path: \[[^\]]*\]\s*$`)
+	// nodeErrTagPattern strips eino's leading "[NodeRunError]" / "[NodeError]" tags.
+	nodeErrTagPattern = regexp.MustCompile(`^\s*(?:\[Node(?:Run)?Error\]\s*)+`)
+	statusCodePattern = regexp.MustCompile(`status code: (\d+)`)
+	// apiMessagePattern captures the trailing "message: …" segment produced by
+	// go-openai's APIError.Error(); the last occurrence wins for nested wraps.
+	apiMessagePattern = regexp.MustCompile(`message: (.+?)\s*$`)
+)
+
+// lastSubmatch returns the first capture group of the last match, or "".
+func lastSubmatch(re *regexp.Regexp, s string) string {
+	matches := re.FindAllStringSubmatch(s, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(matches[len(matches)-1][1])
+}

--- a/internal/model/error_summary_test.go
+++ b/internal/model/error_summary_test.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSummarizeRunError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name            string
+		err             string
+		wantSummary     string
+		wantDetailEmpty bool
+	}{
+		{
+			name: "nil",
+			err:  "",
+		},
+		{
+			name: "eino NodeRunError with 400 image rejection",
+			err: "[NodeRunError] error, status code: 400, status: 400 Bad Request, message: messages.content.type 参数非法，取值范围 ['text']\n" +
+				"node path: [node_1, ChatModel]",
+			wantSummary: "API error 400: messages.content.type 参数非法，取值范围 ['text'] — this model may not support image input",
+		},
+		{
+			name:        "401 auth error keeps status and message",
+			err:         "[NodeRunError] error, status code: 401, status: 401 Unauthorized, message: invalid api key\nnode path: [ChatModel]",
+			wantSummary: "API error 401: invalid api key",
+		},
+		{
+			name:        "plain error passes through without detail dup",
+			err:         "context deadline exceeded",
+			wantSummary: "context deadline exceeded",
+			// summary == raw ⇒ detail must be empty to avoid double display
+			wantDetailEmpty: true,
+		},
+		{
+			name:        "go-openai error without eino wrapper",
+			err:         "error, status code: 429, status: 429 Too Many Requests, message: rate limit reached",
+			wantSummary: "API error 429: rate limit reached",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			if tc.err != "" {
+				err = errors.New(tc.err)
+			}
+			summary, detail := SummarizeRunError(err)
+			if summary != tc.wantSummary {
+				t.Errorf("summary = %q, want %q", summary, tc.wantSummary)
+			}
+			if tc.wantDetailEmpty && detail != "" {
+				t.Errorf("detail = %q, want empty", detail)
+			}
+			if !tc.wantDetailEmpty && err != nil && detail == "" {
+				t.Error("detail should carry the raw error")
+			}
+			if detail != "" && !strings.Contains(detail, strings.Split(tc.err, "\n")[0]) && tc.err != "" {
+				t.Errorf("detail %q should contain raw error", detail)
+			}
+		})
+	}
+}
+
+func TestSummarizeRunErrorTruncatesLongSummary(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("x", 500)
+	summary, _ := SummarizeRunError(errors.New("error, status code: 500, status: 500, message: " + long))
+	if n := len([]rune(summary)); n > maxSummaryLen {
+		t.Errorf("summary len = %d runes, want <= %d", n, maxSummaryLen)
+	}
+}

--- a/internal/model/factory.go
+++ b/internal/model/factory.go
@@ -118,7 +118,7 @@ func (f *ModelFactory) GetModel(ctx context.Context, providerModel string) (eino
 	// over the provider-level default before constructing the model.
 	facEffortCfg := *providerCfg
 	facEffortCfg.ReasoningEffort = config.ResolveEffort(provider, modelName, providerCfg.ReasoningEffort)
-	m, err := NewChatModelFromProvider(ctx, modelName, baseURL, &facEffortCfg)
+	m, err := NewChatModelFromProvider(ctx, provider, modelName, baseURL, &facEffortCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create model %q: %w", providerModel, err)
 	}

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -69,6 +69,43 @@ type ModelModalities struct {
 	Output []string `json:"output,omitempty"`
 }
 
+// SupportsImageInput reports whether the model advertises "image" among its
+// input modalities. Returns false when modalities are unknown (nil) — callers
+// that need a permissive default for unknown models must handle nil
+// Modalities themselves.
+func (m *RegistryModel) SupportsImageInput() bool {
+	if m == nil || m.Modalities == nil {
+		return false
+	}
+	for _, mod := range m.Modalities.Input {
+		if mod == "image" {
+			return true
+		}
+	}
+	return false
+}
+
+// lookupStaticModel finds a model in the static registry (generated data +
+// init-time merges) without deep-copying it. Read-only lookups only. Custom
+// providers/models merged at runtime are not visible here — callers should
+// treat a miss as "unknown", not "absent".
+func lookupStaticModel(providerID, modelID string) *RegistryModel {
+	prov, ok := generatedProviders[providerID]
+	if !ok {
+		return nil
+	}
+	if m, ok := prov.Models[modelID]; ok {
+		return m
+	}
+	// Mirror LookupModel's partial matching for prefixed model ids.
+	for mid, m := range prov.Models {
+		if strings.HasSuffix(mid, "/"+modelID) || strings.HasPrefix(mid, modelID) {
+			return m
+		}
+	}
+	return nil
+}
+
 // ModelCost describes per-token costs in USD per 1M tokens.
 type ModelCost struct {
 	Input      float64 `json:"input"`

--- a/internal/tools/subagent_model_routing_test.go
+++ b/internal/tools/subagent_model_routing_test.go
@@ -66,7 +66,7 @@ func routingFixture(t *testing.T, srvURL, smallModel string) *subagentTool {
 		SmallModel: smallModel,
 		Providers:  map[string]*config.ProviderConfig{"mock": pc},
 	}
-	parent, err := internalmodel.NewChatModelFromProvider(context.Background(), "main-model", srvURL, pc)
+	parent, err := internalmodel.NewChatModelFromProvider(context.Background(), "mock", "main-model", srvURL, pc)
 	if err != nil {
 		t.Fatalf("build parent model: %v", err)
 	}

--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -74,15 +74,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			}
 			ref := config.ModelRef{Provider: rp.ID, Model: m.ID}
 			enabled := modelState.IsModelEnabled(ref, m.DefaultEnabled)
-			imageSupport := false
-			if m.Modalities != nil {
-				for _, mod := range m.Modalities.Input {
-					if mod == "image" {
-						imageSupport = true
-						break
-					}
-				}
-			}
+			imageSupport := m.SupportsImageInput()
 			pi.Models = append(pi.Models, modelInfo{
 				ID: m.ID, Name: m.Name, ToolCall: m.ToolCall, ContextLimit: ctx,
 				Reasoning: m.Reasoning, Recommended: m.Recommended,
@@ -131,6 +123,29 @@ func (s *Server) handleSwitchModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	eng.applyModelSwitch(ag, req.Provider, req.Model)
+
+	// Persist the selection so a restart resumes on this model — matches the
+	// TUI model picker, which writes cfg.Model on every switch. In-place on the
+	// shared cfg under cfgMu (same discipline as handleSetSmallModel).
+	s.cfgMu.Lock()
+	s.mu.Lock()
+	var persistErr error
+	if s.cfg != nil {
+		prevModel := s.cfg.Model
+		s.cfg.Model = req.Provider + "/" + req.Model
+		if err := config.SaveConfig(s.cfg); err != nil {
+			// Keep memory consistent with disk: a failed save must not leave the
+			// live config advertising a value that won't survive a restart.
+			s.cfg.Model = prevModel
+			persistErr = err
+		}
+	}
+	s.mu.Unlock()
+	s.cfgMu.Unlock()
+	if persistErr != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save config: " + persistErr.Error()})
+		return
+	}
 
 	// Track in recent models.
 	if state, err := config.LoadModelState(); err == nil {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -469,15 +469,7 @@ func (s *Server) currentModelSupportsImage(eng *Engine) bool {
 	}
 	provider, mdl, _ := eng.modelSnapshot()
 	_, m, ok := s.registry.LookupModel(provider, mdl)
-	if !ok || m == nil || m.Modalities == nil {
-		return false
-	}
-	for _, mod := range m.Modalities.Input {
-		if mod == "image" {
-			return true
-		}
-	}
-	return false
+	return ok && m.SupportsImageInput()
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -215,7 +215,7 @@ const chatSlice = createSlice({
       // Pops the first queued message — the App thunk resends it on agentDone.
       if (s.queued.length > 0) s.queued.shift()
     },
-    agentDone(s, a: { payload: { error?: string } | undefined }) {
+    agentDone(s, a: { payload: { error?: string; detail?: string } | undefined }) {
       // Stamp duration on the last assistant message.
       for (let i = s.timeline.length - 1; i >= 0; i--) {
         const item = s.timeline[i]
@@ -237,7 +237,14 @@ const chatSlice = createSlice({
       if (a.payload?.error) {
         s.timeline.push({
           kind: 'message',
-          data: { id: genId('sys'), role: 'system', content: a.payload.error, timestamp: Date.now(), level: 'error' },
+          data: {
+            id: genId('sys'),
+            role: 'system',
+            content: a.payload.error,
+            detail: a.payload.detail || undefined,
+            timestamp: Date.now(),
+            level: 'error',
+          },
           seq: nextSeq(),
         })
       }

--- a/web/src/app/wsBridge.ts
+++ b/web/src/app/wsBridge.ts
@@ -62,7 +62,7 @@ export function createWSHandlers(
       ),
     onTokenUpdate: (d) => dispatch(chatActions.setTokenSnapshot(d)),
     onAgentDone: (d) => {
-      dispatch(chatActions.agentDone(d ? { error: d.error } : undefined))
+      dispatch(chatActions.agentDone(d ? { error: d.error, detail: d.detail } : undefined))
       // Refresh sidebar metadata (title / updated_at / running) after a turn.
       void dispatch(loadTasks() as never)
       void dispatch(loadSessions() as never)

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -55,6 +55,7 @@ import type { ChatImage as RuntimeChatImage } from 'jcode-ui-core'
 import { useAppDispatch, useAppSelector } from '../app/hooks'
 import { chatActions, modelActions } from '../app/store'
 import { api } from '../lib/api'
+import { readDraft, writeDraft } from '../lib/drafts'
 import { BranchPicker } from './BranchPicker'
 import { ProviderIcon } from './ProviderIcon'
 import { WorkspacePicker } from './WorkspacePicker'
@@ -152,8 +153,9 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
   const goalArmed = useAppSelector((s) => s.chat.goalArmed)
   const currentSessionId = useAppSelector((s) => s.session.currentSessionId)
 
-  // Composer-local state.
-  const [input, setInput] = useState('')
+  // Composer-local state. The input text initializes from the saved draft for
+  // this conversation (covers remounts on welcome ↔ conversation crossing).
+  const [input, setInput] = useState(() => readDraft(currentSessionId))
   /** Pending vision images — same shape as jcode-ui `ChatImage` / AttachmentList. */
   const [pendingImages, setPendingImages] = useState<ChatImage[]>([])
   const [showSlashMenu, setShowSlashMenu] = useState(false)
@@ -300,6 +302,29 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
     autoResize()
   }, [input, autoResize])
 
+  // ─── Per-conversation draft persistence ───────────────────────────────────
+  // liveRef always holds the latest {sessionId, text} so the switch effect can
+  // flush the outgoing conversation's draft before loading the incoming one.
+  const draftLiveRef = useRef({ sessionId: currentSessionId, text: input })
+  draftLiveRef.current = { sessionId: currentSessionId, text: input }
+  const draftSessionRef = useRef(currentSessionId)
+
+  useEffect(() => {
+    const prevId = draftSessionRef.current
+    if (prevId === currentSessionId) return
+    // draftLiveRef still holds the outgoing conversation's text at this point.
+    writeDraft(prevId, draftLiveRef.current.text)
+    draftSessionRef.current = currentSessionId
+    setInput(readDraft(currentSessionId))
+  }, [currentSessionId])
+
+  // Flush on unmount (app close / panel teardown).
+  useEffect(() => {
+    return () => {
+      writeDraft(draftLiveRef.current.sessionId, draftLiveRef.current.text)
+    }
+  }, [])
+
   // ─── Send / queue ─────────────────────────────────────────────────────────
 
   const send = useCallback(() => {
@@ -316,10 +341,11 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
       actions.sendMessage(body, images)
     }
     setInput('')
+    writeDraft(currentSessionId, '')
     setPendingImages([])
     setShowSlashMenu(false)
     onSent?.()
-  }, [actions, input, isRunning, onSent, pendingImages])
+  }, [actions, input, isRunning, onSent, pendingImages, currentSessionId])
 
   // ─── Model / mode selection ───────────────────────────────────────────────
 

--- a/web/src/lib/drafts.ts
+++ b/web/src/lib/drafts.ts
@@ -1,0 +1,34 @@
+/**
+ * Composer drafts — remembers unsent input text per conversation.
+ *
+ * Keyed by session id in localStorage so drafts survive conversation switches,
+ * composer remounts (welcome ↔ conversation layout), and full app restarts
+ * (desktop). All access is try/catch-guarded: localStorage may be unavailable
+ * in hardened webviews (same discipline as Sidebar filters / authToken).
+ */
+
+const KEY_PREFIX = 'jcode-composer-draft:'
+
+/** readDraft returns the saved draft for a session ('' when none). */
+export function readDraft(sessionId: string): string {
+  if (!sessionId) return ''
+  try {
+    return localStorage.getItem(KEY_PREFIX + sessionId) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+/** writeDraft saves a draft; empty text removes the entry. */
+export function writeDraft(sessionId: string, text: string): void {
+  if (!sessionId) return
+  try {
+    if (text) {
+      localStorage.setItem(KEY_PREFIX + sessionId, text)
+    } else {
+      localStorage.removeItem(KEY_PREFIX + sessionId)
+    }
+  } catch {
+    // storage unavailable — drafts are best-effort
+  }
+}

--- a/web/src/lib/useDesktop.ts
+++ b/web/src/lib/useDesktop.ts
@@ -40,6 +40,46 @@ export async function openUrl(url: string): Promise<void> {
   }
 }
 
+/**
+ * Route external link clicks out of the app webview.
+ *
+ * Chat markdown renders plain `<a href>` anchors (no target), so in the Tauri
+ * desktop shell a click navigates the app window itself away from the UI, and
+ * `target="_blank"` clicks are dead (new-window creation is denied). One
+ * delegated capture-phase listener covers every current and future anchor:
+ * external http(s) links are opened in the system browser (Tauri) or a new
+ * tab (browser); same-origin and loopback (sidecar API, Bearer-auth'd) links
+ * are left alone.
+ */
+export function initExternalLinks(): void {
+  if (typeof document === 'undefined') return
+  document.addEventListener(
+    'click',
+    (e) => {
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+      const anchor = (e.target as Element | null)?.closest?.('a[href]')
+      if (!anchor) return
+      const href = anchor.getAttribute('href') ?? ''
+      let url: URL
+      try {
+        url = new URL(href, window.location.href)
+      } catch {
+        return
+      }
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') return
+      if (url.origin === window.location.origin) return
+      if (isLoopback(url.hostname)) return
+      e.preventDefault()
+      void openUrl(url.href)
+    },
+    true,
+  )
+}
+
+function isLoopback(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname.endsWith('.localhost')
+}
+
 /** Show a native notification (Tauri) or fall back to the Web Notifications API. */
 export async function notify(title: string, body?: string): Promise<void> {
   if (isTauri) {

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -46,7 +46,7 @@ export interface WSHandlers {
     presentation?: import('./types').ToolResultPresentation
   }) => void
   onTokenUpdate?: (data: import('./types').TokenUpdateData) => void
-  onAgentDone?: (data: { error?: string }) => void
+  onAgentDone?: (data: { error?: string; detail?: string }) => void
   onTodoUpdate?: () => void
   onGoalUpdate?: (data: import('jcode-ui-core').Goal | null) => void
   onApprovalRequest?: (data: import('./types').ApprovalRequestData) => void

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -13,7 +13,7 @@ import { Provider } from 'react-redux'
 import { store } from './app/store'
 import { initApiBase } from './lib/apiBase'
 import { setAuthExpiredHandler } from './lib/authToken'
-import { initDesktop } from './lib/useDesktop'
+import { initDesktop, initExternalLinks } from './lib/useDesktop'
 import { uiActions } from './app/store'
 import App from './App'
 import './styles.css'
@@ -22,6 +22,8 @@ import './i18n'
 async function bootstrap() {
   // Tag <html> for native desktop shell CSS before the first render.
   initDesktop()
+  // Route external link clicks to the system browser (Tauri) / new tab (browser).
+  initExternalLinks()
 
   // Dual-host: resolve the API base + wait for the sidecar to be healthy before
   // mounting. In browser mode this is a no-op.


### PR DESCRIPTION
## 概述

四个 web/desktop 体验修复（相互独立但同域，故同 PR）：

### 1. 多模态 → 文本模型切换自动过滤图片
**问题**：从多模态模型切到纯文本模型后，历史消息中的 image parts 原样提交，provider 400：`messages.content.type 参数非法，取值范围 ['text']`。

**修复**：`NewChatModelFromProvider` 新增 provider 参数，vision 解析顺序：显式 `pc.Vision` 覆盖 → registry modalities → 默认开启（未知/自定义模型保持原行为）。模型切换本就会重建 chatModel，已有的 `toOpenAIMessage` 剥离逻辑随之对整个历史生效。新增 `RegistryModel.SupportsImageInput()` 并去重 web/acp 三处 modality 循环。

### 2. web 运行错误美化
**问题**：`[NodeRunError] error, status code: 400, ... node path: [node_1, ChatModel]` 原文直接刷在时间线。

**修复**：新增 `model.SummarizeRunError` —— 剥离 eino/go-openai 包装，输出单行摘要（`API error 400: …`，400 图片拒绝时附加 "this model may not support image input" 提示），原文进 `WebDoneData.detail`。前端透传后由 jcode-ui `Message` 组件渲染为摘要 + 可折叠 details。

### 3. 模型切换持久化到 config
**问题**：web/desktop 切换模型只写内存，重启回退。

**修复**：`handleSwitchModel` 切换成功后按 `handleSetSmallModel` 的锁纪律（`cfgMu`→`mu`、失败回滚）写 `cfg.Model` + `SaveConfig`，与 TUI 选择器行为对齐。

### 4. 输入框草稿按会话记忆
新增 `web/src/lib/drafts.ts`（localStorage 按 session id，try/catch 防御 hardened webview），`ChatInput` 懒初始化恢复、会话切换 flush/恢复、发送后清除、卸载兜底。重启 app 草稿保留。

### 5. desktop 外链走系统浏览器
**问题**：desktop 内点聊天链接直接在 app webview 里导航（`target=_blank` 则因 Tauri 默认拒绝新窗口成为死链）。

**修复**：`initExternalLinks()` 委托捕获阶段点击监听，外部 http(s) 链接经 `tauri-plugin-opener` 走系统浏览器（浏览器模式新开标签页）；同源与 loopback（Bearer 鉴权的 sidecar API）放行。插件与 capability 已存在，零 Rust 改动。

## 测试

- [x] 新增单测：vision 推导（含显式覆盖优先级）+ 错误摘要器共 12 用例
- [x] `go test ./...` 通过（26 包）
- [x] `golangci-lint` 0 issues
- [x] `make lint-web`（tsc × 3）+ `make build-web` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Composer text is saved as a per-session draft and restored when returning to a conversation.
  * External links now open in the system browser instead of the app window.
  * Selected model changes persist across sessions.
  * Image support is detected more accurately for configured models.

* **Bug Fixes**
  * Improved provider/model selection across chat, web, workflow, and agent sessions.
  * Agent errors now show concise summaries with expandable technical details.
  * Added clearer guidance for image-related request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->