### PR TITLE
fix(web): let the browser extension WS handshake past the Origin gate

### DIFF
--- a/internal/web/cors_test.go
+++ b/internal/web/cors_test.go
@@ -67,6 +67,58 @@ func TestCORSMiddlewareRejectsUntrustedSimpleRequestsBeforeSideEffects(t *testin
 	}
 }
 
+// TestCORSMiddlewareExtensionWSHandshake pins the PR #141 regression: a Chrome
+// extension always sends `Origin: chrome-extension://<id>` on the WS handshake,
+// which is never same-origin. The Origin gate must let that handshake through so
+// the bridge's own pairing-token auth (bridge.HandleWS) can run — otherwise the
+// extension can never connect. The exemption must stay scoped to GET on the exact
+// WS path so it cannot be abused to smuggle a cross-origin mutating POST.
+func TestCORSMiddlewareExtensionWSHandshake(t *testing.T) {
+	const wsPath = "/api/browser/ext/ws"
+	const extOrigin = "chrome-extension://ekcnniaefmnhnemnpphikhgfoofnojnd"
+	reached := func(rec *httptest.ResponseRecorder) bool { return rec.Code == http.StatusTeapot }
+
+	mkInner := func() http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTeapot) // 418 = "reached the inner handler"
+		})
+	}
+	req := func(method, path, origin string) *http.Request {
+		r := httptest.NewRequest(method, "http://127.0.0.1:8080"+path, nil)
+		r.Host = "127.0.0.1:8080"
+		if origin != "" {
+			r.Header.Set("Origin", origin)
+		}
+		return r
+	}
+
+	cases := []struct {
+		name        string
+		method      string
+		path        string
+		origin      string
+		wantThrough bool // true = passes the Origin gate (reaches inner handler)
+	}{
+		{"extension origin on WS path is admitted", http.MethodGet, wsPath, extOrigin, true},
+		// Untrusted origins are also admitted here; the bridge token check is the
+		// real boundary on this endpoint. Pinning it documents the trade-off.
+		{"untrusted origin on WS path reaches token check", http.MethodGet, wsPath, "https://evil.com", true},
+		{"extension origin on a mutating path is still blocked", http.MethodPost, "/api/browser/config", extOrigin, false},
+		{"extension origin POST to WS path is blocked (GET-only)", http.MethodPost, wsPath, extOrigin, false},
+		{"untrusted origin on a normal API is still blocked", http.MethodGet, "/api/config", "https://evil.com", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			corsMiddleware(mkInner()).ServeHTTP(rec, req(c.method, c.path, c.origin))
+			if got := reached(rec); got != c.wantThrough {
+				t.Errorf("%s %s origin=%q: through=%v (status %d), want through=%v",
+					c.method, c.path, c.origin, got, rec.Code, c.wantThrough)
+			}
+		})
+	}
+}
+
 func TestCORSMiddlewareAllowsTrustedOriginsAndNonBrowserClients(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusTeapot)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -654,6 +654,13 @@ func isAllowedWebOrigin(r *http.Request) bool {
 	return false
 }
 
+// isBrowserExtensionWS reports whether r is the Chrome extension's WS handshake.
+// The bridge authenticates via its own pairing token (see isAuthExempt), so the
+// Origin gate must not 403 it merely for carrying a chrome-extension:// Origin.
+func isBrowserExtensionWS(r *http.Request) bool {
+	return r.Method == http.MethodGet && r.URL.Path == "/api/browser/ext/ws"
+}
+
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
@@ -661,7 +668,15 @@ func corsMiddleware(next http.Handler) http.Handler {
 		// page can send a "simple" no-cors POST whose response is unreadable but
 		// whose side effect still happens. Reject an untrusted browser Origin before
 		// any API handler can mutate config, start an agent, or control the Mac.
-		if origin != "" && !isAllowedWebOrigin(r) {
+		//
+		// Exception: the extension WS endpoint. Chrome extensions always send
+		// `Origin: chrome-extension://<id>` on the WS handshake, which is never
+		// same-origin, so this gate would otherwise 403 the bridge before its own
+		// pairing-token auth runs (mirrors the isAuthExempt carve-out). This
+		// endpoint only ever upgrades a WS; it performs no config/agent mutation on
+		// a cross-origin simple request, so the exemption does not reopen the
+		// drive-by-POST vector this middleware exists to close.
+		if origin != "" && !isAllowedWebOrigin(r) && !isBrowserExtensionWS(r) {
 			http.Error(w, "cross-origin request denied", http.StatusForbidden)
 			return
 		}


### PR DESCRIPTION
## Problem

The browser plugin (jcode Browser Bridge extension) could no longer connect.

PR #141 (commit `f71f5a8`) hardened `corsMiddleware` to return **403 for any untrusted `Origin` before the request reaches a handler** — closing a drive-by-POST vector. But a Chrome extension always sends `Origin: chrome-extension://<id>` on its WebSocket handshake, which is never same-origin. As a result `GET /api/browser/ext/ws` was 403'd at the Origin gate **before the bridge's own pairing-token auth could run**, so the extension could never connect.

## Fix

Exempt the extension WS endpoint (**GET only, exact path**) from the Origin gate, mirroring the existing `isAuthExempt` carve-out for the same route. Added `isBrowserExtensionWS()` and a comment explaining the trade-off.

Security is unchanged: the bridge still authenticates via its pairing token (`bridge.go:83`). The exemption is scoped to a GET upgrade endpoint that performs no cross-origin simple-request side effects, so the drive-by-POST vector PR #141 closed stays closed.

## Verification (live server, real WS handshakes)

Started a local `jcode web` server and drove real handshakes from both the plugin's and an attacker's perspective:

| Case | Result |
|---|---|
| extension Origin handshake | **101** (was 403 before fix) ✅ |
| loopback (web UI) handshake | **101** ✅ |
| evil Origin → normal API (`/api/config`) | **403** ✅ |
| extension Origin → wrong path | **403** ✅ (path-scoped) |
| extension Origin POST → WS path | **403** ✅ (GET-only) |
| **evil Origin → WS, no token** | upgrade 101, then bridge rejects with `authentication required` ✅ |
| **evil Origin → WS, wrong token** | same rejection ✅ |

The last two rows confirm the pairing token remains the real authorization boundary — an untrusted origin gains nothing from the exemption.

## Tests

- New `TestCORSMiddlewareExtensionWSHandshake` (5 subcases, pins the regression)
- `go test ./internal/web/ ./internal/browser/` green
- `go vet` + `golangci-lint` 0 issues; full pre-push suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser extension WebSocket connections being incorrectly blocked by cross-origin security checks.
  * Extension connections to the supported WebSocket endpoint now establish successfully while other request types and endpoints remain protected.
  * Added coverage to verify that only the intended WebSocket handshake is allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->