### PR TITLE
feat(web): floating goal pill behind composer

### DIFF
--- a/design/goal-banner-composer.html
+++ b/design/goal-banner-composer.html
@@ -1,0 +1,737 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>jcode · Goal 胶囊浮条 × Composer — 设计稿 v2</title>
+<style>
+/* ════════════════════════════════════════════════════════════════════
+   Design Tokens — verbatim copy of web/src/styles/tokens.css (light + dark).
+   所有颜色/圆角/阴影/动效均来自此处，原型不硬编码任何颜色。
+   ════════════════════════════════════════════════════════════════════ */
+:root {
+  --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --radius-xs: 3px; --radius-sm: 4px; --radius-md: 6px;
+  --radius-lg: 8px; --radius-xl: 12px; --radius-2xl: 16px; --radius-pill: 9999px;
+  --shadow-sm: 0 1px 2px rgba(24,20,16,.06);
+  --shadow-md: 0 4px 14px -4px rgba(24,20,16,.12);
+  --shadow-lg: 0 14px 36px -14px rgba(24,20,16,.20);
+  --shadow-xl: 0 1px 2px rgba(24,20,16,.04), 0 24px 56px -28px rgba(24,20,16,.26);
+  --backdrop: rgba(20,18,16,.5);
+  --accent-wash-soft: color-mix(in srgb, var(--color-primary) 8%, transparent);
+  --accent-wash: color-mix(in srgb, var(--color-primary) 11%, transparent);
+  --accent-wash-strong: color-mix(in srgb, var(--color-primary) 16%, transparent);
+  --accent-border: color-mix(in srgb, var(--color-primary) 30%, transparent);
+  --color-accent-neutral: var(--color-foreground);
+  --neutral-wash-soft: color-mix(in srgb, var(--color-foreground) 8%, transparent);
+  --neutral-wash: color-mix(in srgb, var(--color-foreground) 11%, transparent);
+  --neutral-wash-strong: color-mix(in srgb, var(--color-foreground) 16%, transparent);
+  --neutral-border: color-mix(in srgb, var(--color-foreground) 30%, transparent);
+  --color-border-active: var(--color-primary);
+  --icon-stroke: 2;
+  --color-success: #16A34A;
+  --z-sidebar:30; --z-header:20; --z-dropdown:40; --z-modal:50; --z-toast:60;
+  --ease-out: cubic-bezier(.16,1,.3,1);
+  --ease-in: cubic-bezier(.7,0,.84,0);
+  --ease-spring: cubic-bezier(.34,1.56,.64,1);
+  --duration-fast:100ms; --duration-normal:150ms; --duration-slow:300ms; --duration-slower:500ms;
+  --sidebar-width:20rem; --sidebar-collapsed-width:0px; --header-height:3.25rem;
+  /* light */
+  --color-primary:#FF8400; --color-background:#F2F3F0; --color-surface:#FFFFFF;
+  --color-foreground:#111111; --color-muted-foreground:#666666; --color-border:#CBCCC9;
+  --color-muted:#F2F3F0; --color-secondary:#E7E8E5; --color-secondary-foreground:#111111;
+  --color-success-bg:#DFE6E1; --color-success-fg:#004D1A;
+  --color-error-bg:#E5DCDA; --color-error-fg:#8C1C00;
+  --color-warning-bg:#E9E3D8; --color-warning-fg:#804200;
+  --color-info-bg:#DFDFE6; --color-info-fg:#000066;
+  --color-destructive:#D93C15; --color-sidebar-bg:#FAFAF8;
+  --color-on-primary:#FFFFFF; --color-on-destructive:#FFFFFF;
+  --code-bg:#f6f8fa; --code-border:#d0d7de;
+}
+.dark {
+  --color-primary:#FF8400; --color-background:#111111; --color-surface:#1A1A1A;
+  --color-foreground:#FFFFFF; --color-muted-foreground:#B8B9B6; --color-border:#2E2E2E;
+  --color-muted:#2E2E2E; --color-secondary:#2E2E2E; --color-secondary-foreground:#FFFFFF;
+  --color-success-bg:#222924; --color-success-fg:#B6FFCE;
+  --color-error-bg:#24100B; --color-error-fg:#FF5C33;
+  --color-warning-bg:#291C0F; --color-warning-fg:#FF8400;
+  --color-info-bg:#222229; --color-info-fg:#B2B2FF;
+  --color-destructive:#FF5C33; --color-sidebar-bg:#1A1A1A; --color-success:#22C55E;
+  --color-on-primary:#FFFFFF; --color-on-destructive:#FFFFFF;
+  --code-bg:#1A1A1A; --code-border:var(--color-border);
+}
+
+/* ── Page chrome ── */
+*{box-sizing:border-box}
+html{background:var(--color-background);transition:background var(--duration-normal)}
+body{margin:0;font-family:var(--font-sans);color:var(--color-foreground);
+  -webkit-font-smoothing:antialiased;min-height:100vh;
+  display:flex;flex-direction:column;align-items:center;
+  padding:18px 14px 90px}
+
+.toolbar{width:100%;max-width:960px;display:flex;align-items:center;gap:12px;
+  flex-wrap:wrap;margin-bottom:8px}
+.toolbar h1{font-size:14px;font-weight:600;margin:0;letter-spacing:-.01em;
+  display:flex;align-items:center;gap:8px}
+.toolbar h1 .tag{font-size:10px;font-family:var(--font-mono);font-weight:500;
+  color:var(--color-muted-foreground);background:var(--color-muted);
+  padding:2px 7px;border-radius:var(--radius-pill)}
+.toolbar .spacer{flex:1}
+.focus-toggle{display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 12px;
+  border:1px solid var(--color-border);background:var(--color-surface);color:var(--color-foreground);
+  border-radius:var(--radius-md);font-size:11.5px;font-weight:500;cursor:pointer;
+  font-family:var(--font-sans);transition:background var(--duration-fast)}
+.focus-toggle:hover{background:var(--color-muted)}
+.focus-toggle[aria-pressed='true']{background:var(--accent-wash);border-color:var(--accent-border);color:var(--color-primary)}
+.theme-toggle{width:28px;height:28px;display:grid;place-items:center;border:1px solid var(--color-border);
+  background:var(--color-surface);color:var(--color-foreground);border-radius:var(--radius-md);
+  cursor:pointer;transition:background var(--duration-fast)}
+.theme-toggle:hover{background:var(--color-muted)}
+
+.lede{width:100%;max-width:960px;font-size:12.5px;line-height:1.6;
+  color:var(--color-muted-foreground);margin:0 0 22px}
+.lede b{color:var(--color-foreground);font-weight:600}
+
+/* ── Sections ── */
+section{width:100%;max-width:960px;margin:0 0 40px}
+.sec-head{display:flex;align-items:baseline;gap:10px;margin:0 0 4px}
+.sec-head h2{font-size:13px;font-weight:600;margin:0;letter-spacing:-.01em}
+.sec-head .sec-no{font-family:var(--font-mono);font-size:10.5px;font-weight:600;
+  color:var(--color-on-primary);background:var(--color-foreground);
+  border-radius:var(--radius-sm);padding:2px 6px}
+.sec-head .verdict{font-size:10.5px;font-family:var(--font-mono);font-weight:600;
+  padding:2px 7px;border-radius:var(--radius-pill)}
+.verdict.bad{background:var(--color-error-bg);color:var(--color-error-fg)}
+.verdict.good{background:var(--color-success-bg);color:var(--color-success-fg)}
+.verdict.alt{background:var(--color-muted);color:var(--color-muted-foreground)}
+.sec-sub{font-size:12px;line-height:1.55;color:var(--color-muted-foreground);margin:0 0 16px;max-width:760px}
+
+/* Stage */
+.stage{border:1px dashed color-mix(in srgb,var(--color-border) 70%,transparent);
+  border-radius:var(--radius-2xl);padding:26px 26px 30px;
+  background:
+    radial-gradient(1200px 300px at 50% -80px, color-mix(in srgb,var(--color-primary) 4%,transparent), transparent),
+    var(--color-background)}
+.stage-label{font-family:var(--font-mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;
+  color:var(--color-muted-foreground);margin:0 0 14px;display:flex;align-items:center;gap:8px}
+.stage-label::after{content:'';flex:1;height:1px;background:color-mix(in srgb,var(--color-border) 55%,transparent)}
+.composer-col{max-width:640px;margin:0 auto}
+.stack{display:flex;flex-direction:column;gap:20px}
+
+/* ════════════════════════════════════════════════════════════════════
+   参考图风格 · 浮动 goal 胶囊（floating pill）
+   独立小卡，surface 底 + 极淡边框 + shadow-md 浮起，叠在 composer 上方，
+   负 margin 制造 ~14px 的叠压。无任何分割线、无彩色 tile。
+   ════════════════════════════════════════════════════════════════════ */
+.goal-pill{position:relative;z-index:1;width:calc(100% - 12px);margin:0 auto -14px;
+  /* default: 压在 composer 上方 */
+  display:flex;align-items:center;gap:8px;padding:9px 14px;
+  background:#FFFFFF;
+  border:1px solid #CBCCC98C;
+  border-radius:var(--radius-2xl);
+  box-shadow:0 4px 14px -4px rgba(24,20,16,.12);
+  cursor:pointer;
+  transition:box-shadow var(--duration-normal),transform var(--duration-normal)}
+.dark .goal-pill{background:#1A1A1A;border-color:#2E2E2E8C;box-shadow:0 4px 14px -4px rgba(0,0,0,.4)}
+.goal-pill.pill-below{margin:-14px auto 0;z-index:1}
+.goal-pill:hover{box-shadow:0 14px 36px -14px rgba(24,20,16,.20);transform:translateY(-1px)}
+.dark .goal-pill:hover{box-shadow:0 14px 36px -14px rgba(0,0,0,.55)}
+.goal-pill .g-icon{width:15px;height:15px;flex-shrink:0;color:var(--color-muted-foreground)}
+.goal-pill .g-icon svg{width:15px;height:15px;display:block}
+.goal-pill.tone-active .g-icon{color:var(--color-foreground)}
+.goal-pill.tone-complete .g-icon{color:var(--color-success-fg)}
+.goal-pill.tone-blocked .g-icon{color:var(--color-error-fg)}
+.goal-pill .g-text{min-width:0;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+  font-size:12.5px;line-height:1}
+.goal-pill .g-text .status{font-weight:600;color:var(--color-foreground);margin-right:6px}
+.goal-pill.tone-complete .g-text .status{color:var(--color-success-fg)}
+.goal-pill.tone-blocked .g-text .status{color:var(--color-error-fg)}
+.goal-pill .g-text .objective{color:var(--color-muted-foreground)}
+.goal-pill.tone-active .g-text .objective{color:var(--color-foreground);opacity:.85}
+.goal-pill .g-time{flex-shrink:0;font-family:var(--font-mono);font-size:10.5px;
+  color:var(--color-muted-foreground);font-variant-numeric:tabular-nums}
+.goal-pill .g-actions{display:flex;align-items:center;gap:2px;flex-shrink:0}
+.g-act{width:22px;height:22px;display:grid;place-items:center;border:none;background:transparent;
+  border-radius:var(--radius-sm);color:var(--color-muted-foreground);cursor:pointer;
+  transition:background var(--duration-fast),color var(--duration-fast)}
+.g-act:hover{background:var(--color-muted);color:var(--color-foreground)}
+.g-act.danger:hover{color:var(--color-error-fg)}
+.g-act svg{width:13px;height:13px;display:block}
+.g-act.chev{color:var(--color-muted-foreground)}
+.g-act.chev svg{width:14px;height:14px}
+/* live pulse dot on active (tiny, top-right of the leading icon) */
+.goal-pill.tone-active .g-icon{position:relative}
+.goal-pill.tone-active .g-icon::after{content:'';position:absolute;right:-3px;top:-2px;
+  width:6px;height:6px;border-radius:50%;background:var(--color-primary);
+  border:1.5px solid var(--color-surface);animation:pulse 1.6s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.35}}
+
+/* expanded detail — 同一张胶囊向下展开，仍是独立浮层 */
+.goal-detail{padding:2px 14px 11px;border-top:1px dashed color-mix(in srgb,var(--color-border) 60%,transparent);
+  margin-top:8px}
+.goal-detail .objective-full{padding-top:9px;font-size:12px;line-height:1.6;color:var(--color-foreground);
+  max-height:160px;overflow-y:auto;white-space:pre-wrap}
+.goal-detail .meta{display:flex;flex-wrap:wrap;gap:4px 12px;margin-top:8px;
+  font-size:10px;color:var(--color-muted-foreground)}
+.goal-detail .meta .mono{font-family:var(--font-mono)}
+.goal-detail .actions{display:flex;align-items:center;gap:8px;margin-top:10px}
+.btn-ghost-sm{display:inline-flex;align-items:center;gap:6px;height:26px;padding:0 10px;
+  border:1px solid var(--color-border);border-radius:var(--radius-md);
+  background:var(--color-surface);font-size:11px;font-weight:500;color:var(--color-foreground);
+  cursor:pointer;font-family:var(--font-sans);transition:background var(--duration-fast)}
+.btn-ghost-sm:hover{background:var(--color-muted)}
+.btn-ghost-sm svg{width:12px;height:12px}
+.btn-text-sm{display:inline-flex;align-items:center;gap:6px;height:26px;padding:0 10px;border:none;
+  border-radius:var(--radius-md);background:transparent;font-size:11px;font-weight:500;
+  color:var(--color-muted-foreground);cursor:pointer;font-family:var(--font-sans);
+  transition:background var(--duration-fast),color var(--duration-fast)}
+.btn-text-sm:hover{background:var(--color-muted);color:var(--color-error-fg)}
+.btn-text-sm svg{width:12px;height:12px}
+
+/* todo progress — 胶囊行内文字后，不用整宽条 */
+.g-progress{flex-shrink:0;display:inline-flex;align-items:center;gap:5px}
+.g-progress .track{width:44px;height:3px;border-radius:var(--radius-pill);overflow:hidden;
+  background:#1111111A}
+.dark .g-progress .track{background:#FFFFFF1A}
+.g-progress .fill{height:100%;border-radius:var(--radius-pill);background:var(--color-primary)}
+.g-progress .frac{font-family:var(--font-mono);font-size:10px;color:var(--color-muted-foreground)}
+
+/* ════════════════════════════════════════════════════════════════════
+   Composer — 独立一张卡，不再与 goal 共边
+   ════════════════════════════════════════════════════════════════════ */
+.composer-card{position:relative;z-index:2;
+  border:1px solid var(--color-border);border-radius:var(--radius-2xl);
+  background:var(--color-surface);box-shadow:var(--shadow-sm);
+  transition:border-color var(--duration-normal);
+  /* 输入框在前（z-index 2），胶囊藏在后面只露出上半截，
+     因此无需任何 padding 补偿 */
+  padding:14px 6px 10px}
+body.sim-focus .composer-card.focusable{border-color:var(--neutral-border)}
+.composer-zone{padding:0 10px}
+/* 胶囊在下方的变体：胶囊同样藏在 composer 后面（z-index 1 < 2），无需补偿 */
+.placeholder{font-size:14px;line-height:1.6;color:var(--color-muted-foreground);min-height:28px}
+.composer-toolbar{display:flex;align-items:center;justify-content:space-between;gap:8px;
+  padding:10px 10px 2px}
+.tb-left,.tb-right{display:flex;align-items:center;gap:6px;min-width:0}
+.chip-btn{display:inline-flex;align-items:center;gap:5px;height:30px;padding:0 8px;border:none;
+  background:transparent;border-radius:var(--radius-md);font-size:12px;font-weight:500;
+  color:var(--color-muted-foreground);cursor:pointer;font-family:var(--font-sans);
+  transition:background var(--duration-fast),color var(--duration-fast);white-space:nowrap}
+.chip-btn:hover{background:var(--color-secondary);color:var(--color-foreground)}
+.chip-btn svg{width:14px;height:14px}
+.chip-btn .chev{width:12px;height:12px;opacity:.7}
+.chip-btn.mode-danger{color:var(--color-warning-fg)}
+.chip-btn.mode-danger:hover{background:var(--color-warning-bg)}
+.chip-btn .model-name{color:var(--color-foreground)}
+.btn-stop{display:inline-flex;align-items:center;gap:5px;height:28px;padding:0 12px;border:none;
+  border-radius:var(--radius-lg);background:var(--color-destructive);color:var(--color-on-destructive);
+  font-size:12px;font-weight:500;cursor:pointer;font-family:var(--font-sans);white-space:nowrap}
+.btn-stop svg{width:13px;height:13px}
+.icon-btn{width:24px;height:24px;display:grid;place-items:center;border:none;background:transparent;
+  border-radius:var(--radius-sm);color:var(--color-muted-foreground);cursor:pointer;
+  transition:background var(--duration-fast),color var(--duration-fast)}
+.icon-btn:hover{background:var(--color-muted);color:var(--color-foreground)}
+.icon-btn svg{width:14px;height:14px}
+.provider-dot{width:15px;height:15px;border-radius:var(--radius-sm);flex-shrink:0;
+  background:var(--neutral-wash);display:grid;place-items:center;
+  font-family:var(--font-mono);font-size:8px;font-weight:700;color:var(--color-foreground)}
+
+/* no-goal composer: normal top padding */
+.composer-card.solo{padding-top:10px}
+
+/* ════════════════════════════════════════════════════════════════════
+   ① CURRENT — 现状还原
+   ════════════════════════════════════════════════════════════════════ */
+.card{border:1px solid var(--color-border);border-radius:var(--radius-xl);
+  background:var(--color-surface);box-shadow:var(--shadow-sm);overflow:hidden}
+.current .goal-row{display:flex;align-items:center;gap:10px;padding:8px 12px;
+  border-bottom:1px solid var(--color-border);cursor:pointer}
+.current .goal-row:hover{background:color-mix(in srgb,var(--color-muted) 45%,transparent)}
+.current .goal-tile{position:relative;width:26px;height:26px;flex-shrink:0;display:grid;place-items:center;
+  border-radius:var(--radius-md);background:var(--accent-wash);color:var(--color-primary)}
+.current .goal-tile svg{width:16px;height:16px}
+.current .pulse{position:absolute;right:-2px;top:-2px;width:8px;height:8px;border-radius:50%;
+  border:1.5px solid var(--color-surface);background:var(--color-primary);
+  animation:pulse 1.6s ease-in-out infinite}
+.current .goal-text{min-width:0;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:12px}
+.current .goal-text .status{font-weight:600;margin-right:6px;color:var(--color-primary)}
+.current .goal-meta{flex-shrink:0;font-family:var(--font-mono);font-size:10px;
+  color:var(--color-muted-foreground);font-variant-numeric:tabular-nums}
+.current .goal-actions{display:flex;align-items:center;gap:2px;flex-shrink:0}
+.current .composer-outer{padding:4px 6px 10px}
+.current .inner-box{border:1px solid var(--color-border);
+  background:color-mix(in srgb,var(--color-surface) 90%,#000);
+  border-radius:var(--radius-lg);padding:14px 16px 0}
+.current .inner-box .composer-toolbar{padding:10px 0 12px}
+
+/* annotation markers */
+.mark{position:relative}
+.mark::after{content:attr(data-mark);position:absolute;z-index:5;
+  width:18px;height:18px;display:grid;place-items:center;
+  font-family:var(--font-mono);font-size:10px;font-weight:700;border-radius:50%;
+  background:var(--color-destructive);color:var(--color-on-destructive);
+  box-shadow:var(--shadow-md)}
+.mark-1::after{left:-9px;top:calc(50% - 9px)}
+.mark-2::after{left:50%;top:-9px;transform:translateX(-50%)}
+.mark-3::after{left:-9px;top:14px}
+.card-outline-highlight{outline:2px dashed color-mix(in srgb,var(--color-destructive) 65%,transparent);
+  outline-offset:3px}
+.divider-highlight{box-shadow:0 2px 0 0 color-mix(in srgb,var(--color-destructive) 55%,transparent)}
+.inner-highlight{outline:2px dashed color-mix(in srgb,var(--color-destructive) 65%,transparent);
+  outline-offset:2px}
+.legend{display:flex;flex-direction:column;gap:8px;margin:16px auto 0;max-width:640px}
+.legend-item{display:flex;gap:10px;align-items:flex-start;font-size:12px;line-height:1.5;
+  color:var(--color-muted-foreground)}
+.legend-item .n{width:18px;height:18px;flex-shrink:0;display:grid;place-items:center;
+  font-family:var(--font-mono);font-size:10px;font-weight:700;border-radius:50%;
+  background:var(--color-destructive);color:var(--color-on-destructive);margin-top:1px}
+.legend-item code{font-family:var(--font-mono);font-size:10.5px;background:var(--color-muted);
+  border-radius:var(--radius-sm);padding:1px 5px;color:var(--color-foreground)}
+
+/* ── Implementation mapping table ── */
+.map-table{width:100%;border-collapse:collapse;font-size:12px}
+.map-table th,.map-table td{text-align:left;padding:8px 10px;vertical-align:top;
+  border-bottom:1px solid color-mix(in srgb,var(--color-border) 55%,transparent);line-height:1.55}
+.map-table th{font-size:10px;letter-spacing:.06em;text-transform:uppercase;
+  color:var(--color-muted-foreground);font-weight:600}
+.map-table td.file{font-family:var(--font-mono);font-size:11px;white-space:nowrap}
+.map-table code{font-family:var(--font-mono);font-size:10.5px;background:var(--color-muted);
+  border-radius:var(--radius-sm);padding:1px 5px;white-space:nowrap}
+.map-table .del{color:var(--color-error-fg);text-decoration:line-through}
+.map-table .add{color:var(--color-success-fg)}
+
+/* acceptance checklist */
+.accept{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:7px}
+.accept li{display:flex;gap:8px;align-items:flex-start;font-size:12px;line-height:1.5;
+  color:var(--color-muted-foreground)}
+.accept li svg{width:14px;height:14px;flex-shrink:0;color:var(--color-success);margin-top:2px}
+.accept li b{color:var(--color-foreground);font-weight:600}
+
+/* compare table */
+.cmp{width:100%;border-collapse:collapse;font-size:12px}
+.cmp th,.cmp td{text-align:left;padding:7px 10px;border-bottom:1px solid color-mix(in srgb,var(--color-border) 55%,transparent);line-height:1.5;vertical-align:top}
+.cmp th{font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--color-muted-foreground);font-weight:600}
+.cmp td:first-child{color:var(--color-muted-foreground);white-space:nowrap}
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <h1>Goal 浮条 × Composer <span class="tag">v2 · 参考 Codex：独立胶囊，浮在输入框上方</span></h1>
+  <div class="spacer"></div>
+  <button class="focus-toggle" id="focusToggle" aria-pressed="false">
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5"/></svg>
+    模拟聚焦
+  </button>
+  <button class="theme-toggle" id="themeToggle" aria-label="切换明暗主题"></button>
+</div>
+
+<p class="lede">
+  参考图的做法：goal 条是<b>独立的胶囊小卡</b>——白底、大圆角、柔和阴影，<b>浮在输入框上方并轻微叠压</b>，
+  与输入框之间靠 z 向层级（间隙 + 投影）区分，而不是共享一张卡片。
+  图标是纯线性灰、没有彩色 tile；计时、编辑、删除、› 展开一字排开。
+  对应到我们的改动：<b>拆开 ChatView 外层卡片</b>，GoalBanner 变成浮层胶囊，ChatInput 恢复为独立的单卡 composer —— 两个元素各只有一条轮廓，无分割线。
+</p>
+
+<!-- ════════════════════════════ ① 现状 ════════════════════════════ -->
+<section>
+  <div class="sec-head">
+    <span class="sec-no">01</span><h2>现状还原</h2>
+    <span class="verdict bad">问题：三层边框 + 一块异色底</span>
+  </div>
+  <p class="sec-sub">与截图一一对应：外层卡片边框 ① → banner 底部分割线 ② → 输入区自己的边框 + <code>color-mix(surface 90%, #000)</code> 深色底 ③。</p>
+
+  <div class="stage">
+    <p class="stage-label">current · 会话内 composer（isRunning）</p>
+    <div class="composer-col current">
+      <div class="card card-outline-highlight mark mark-1" data-mark="1">
+        <div class="goal-row divider-highlight mark mark-2" data-mark="2">
+          <span class="goal-tile">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5M12 8.25v7.5M8.25 12h7.5"/></svg>
+            <span class="pulse"></span>
+          </span>
+          <span class="goal-text"><span class="status">进行中</span><span class="objective">设置一个 goal 测试一下当前项目修改</span></span>
+          <span class="goal-meta">8秒</span>
+          <span class="goal-actions">
+            <button class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"/></svg></button>
+            <button class="icon-btn danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg></button>
+            <button class="icon-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+          </span>
+        </div>
+        <div class="composer-outer">
+          <div class="inner-box inner-highlight mark mark-3" data-mark="3">
+            <div class="placeholder">Agent 正在工作 — 输入将排队，稍后自动发送…</div>
+            <div class="composer-toolbar" style="padding-left:0;padding-right:0">
+              <div class="tb-left">
+                <button class="icon-btn" style="width:30px;height:30px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 4.5v15m7.5-7.5h-15"/></svg></button>
+                <button class="chip-btn mode-danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.249-8.25-3.286zm0 13.036h.008v.008H12v-.008z"/></svg>完全访问<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+              </div>
+              <div class="tb-right">
+                <button class="chip-btn"><span class="provider-dot">K</span><span class="model-name">Kimi K3</span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+                <button class="chip-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09zM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456z"/></svg>强度<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+                <button class="btn-stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>停止</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="legend">
+      <div class="legend-item"><span class="n">1</span><span>外层卡片边框（ChatView 包装层）—— v1 想用它把两者"拼"成一体，但这正是卡片套卡片的根源，<b>拆掉</b>。</span></div>
+      <div class="legend-item"><span class="n">2</span><span>GoalBanner 的 <code>border-b</code> 分割线 —— 浮层方案里没有拼接缝，自然消失。</span></div>
+      <div class="legend-item"><span class="n">3</span><span>ChatInput 内层框的 <code>border + 深色底</code> —— docked 模式下去掉，composer 自己就是那一张卡。</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ════════════════════════════ ② 方案 A：浮动胶囊 ════════════════════════════ -->
+<section>
+  <div class="sec-head">
+    <span class="sec-no">02</span><h2>方案 A · 浮动胶囊（推荐，还原参考图）</h2>
+    <span class="verdict good">goal 条独立浮起 · composer 单卡</span>
+  </div>
+  <p class="sec-sub">
+    GoalBanner 脱离卡片：自己的 <code>surface + rounded-2xl + shadow-md</code>，宽度比 composer 内缩 12px，
+    底部 <code>-14px</code> 负 margin 让胶囊<b>藏在 composer 上沿后面</b>（胶囊 z-index 1，composer z-index 2），只露出上半截。
+    输入框上沿完整压过胶囊，内容无需任何补偿；聚焦时<b>composer 自己的</b>边框加深（点右上角"模拟聚焦"）。
+    全程无分割线；goal 条上唯一的动态元素是图标右上角的活性小点。
+  </p>
+
+  <div class="stage">
+    <p class="stage-label">A · collapsed — active + todos（参考图还原）</p>
+    <div class="composer-col">
+      <!-- floating pill -->
+      <div class="goal-pill tone-active">
+        <span class="g-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5M12 8.25v7.5M8.25 12h7.5"/></svg>
+        </span>
+        <span class="g-text"><span class="status">进行中</span><span class="objective">设置一个 goal 测试一下当前项目修改，验证 UI 展示效果</span></span>
+        <span class="g-progress"><span class="frac">3/5</span><span class="track"><span class="fill" style="display:block;width:60%"></span></span></span>
+        <span class="g-time">18h 34m 52s</span>
+        <span class="g-actions">
+          <button class="g-act" title="编辑"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"/></svg></button>
+          <button class="g-act danger" title="清除"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg></button>
+          <button class="g-act chev" title="展开"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></button>
+        </span>
+      </div>
+      <!-- composer card -->
+      <div class="composer-card focusable">
+        <div class="composer-zone">
+          <div class="placeholder">Agent 正在工作 — 输入将排队，稍后自动发送…</div>
+        </div>
+        <div class="composer-toolbar">
+          <div class="tb-left">
+            <button class="icon-btn" style="width:30px;height:30px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 4.5v15m7.5-7.5h-15"/></svg></button>
+            <button class="chip-btn mode-danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.249-8.25-3.286zm0 13.036h.008v.008H12v-.008z"/></svg>完全访问<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+          </div>
+          <div class="tb-right">
+            <button class="chip-btn"><span class="provider-dot">K</span><span class="model-name">Kimi K3</span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            <button class="chip-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09zM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456z"/></svg>强度<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            <button class="btn-stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>停止</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="stage" style="margin-top:18px">
+    <p class="stage-label">A · collapsed — 胶囊在输入框下方（变体）</p>
+    <div class="composer-col">
+      <!-- composer card first -->
+      <div class="composer-card focusable above-pill">
+        <div class="composer-zone">
+          <div class="placeholder">Agent 正在工作 — 输入将排队，稍后自动发送…</div>
+        </div>
+        <div class="composer-toolbar">
+          <div class="tb-left">
+            <button class="icon-btn" style="width:30px;height:30px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 4.5v15m7.5-7.5h-15"/></svg></button>
+            <button class="chip-btn mode-danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.249-8.25-3.286zm0 13.036h.008v.008H12v-.008z"/></svg>完全访问<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+          </div>
+          <div class="tb-right">
+            <button class="chip-btn"><span class="provider-dot">K</span><span class="model-name">Kimi K3</span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            <button class="chip-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09zM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456z"/></svg>强度<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            <button class="btn-stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>停止</button>
+          </div>
+        </div>
+      </div>
+      <!-- floating pill below -->
+      <div class="goal-pill pill-below tone-active">
+        <span class="g-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5M12 8.25v7.5M8.25 12h7.5"/></svg>
+        </span>
+        <span class="g-text"><span class="status">进行中</span><span class="objective">设置一个 goal 测试一下当前项目修改，验证 UI 展示效果</span></span>
+        <span class="g-progress"><span class="frac">3/5</span><span class="track"><span class="fill" style="display:block;width:60%"></span></span></span>
+        <span class="g-time">18h 34m 52s</span>
+        <span class="g-actions">
+          <button class="g-act" title="编辑"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"/></svg></button>
+          <button class="g-act danger" title="清除"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg></button>
+          <button class="g-act chev" title="展开"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></button>
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <div class="stage" style="margin-top:18px">
+    <p class="stage-label">A · expanded — 同一张胶囊向下展开（虚线分隔，仍是浮层）</p>
+    <div class="composer-col">
+      <div class="goal-pill tone-active" style="cursor:default">
+        <div style="width:100%">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span class="g-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5M12 8.25v7.5M8.25 12h7.5"/></svg>
+            </span>
+            <span class="g-text"><span class="status">进行中</span><span class="objective">设置一个 goal 测试一下当前项目修改，验证 UI 展示效果</span></span>
+            <span class="g-progress"><span class="frac">3/5</span><span class="track"><span class="fill" style="display:block;width:60%"></span></span></span>
+            <span class="g-time">18h 34m 52s</span>
+            <span class="g-actions">
+              <button class="g-act"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"/></svg></button>
+              <button class="g-act danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg></button>
+              <button class="g-act chev" style="transform:rotate(90deg)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></button>
+            </span>
+          </div>
+          <div class="goal-detail">
+            <div class="objective-full">设置一个 goal 测试一下当前项目修改，验证 UI 展示效果</div>
+            <div class="meta">
+              <span>开始于 2026/7/17 23:58:04</span>
+              <span>已进行 18h 34m 52s</span>
+              <span class="mono">12.4K tokens</span>
+            </div>
+            <div class="actions">
+              <button class="btn-ghost-sm"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"/></svg>编辑目标</button>
+              <button class="btn-text-sm"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg>清除目标</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="composer-card focusable">
+        <div class="composer-zone">
+          <div class="placeholder">Agent 正在工作 — 输入将排队，稍后自动发送…</div>
+        </div>
+        <div class="composer-toolbar">
+          <div class="tb-left">
+            <button class="icon-btn" style="width:30px;height:30px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 4.5v15m7.5-7.5h-15"/></svg></button>
+            <button class="chip-btn mode-danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.249-8.25-3.286zm0 13.036h.008v.008H12v-.008z"/></svg>完全访问<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+          </div>
+          <div class="tb-right">
+            <button class="chip-btn"><span class="provider-dot">K</span><span class="model-name">Kimi K3</span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            <button class="btn-stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>停止</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="stage" style="margin-top:18px">
+    <p class="stage-label">A · 其余状态（blocked / complete / 无 goal）</p>
+    <div class="composer-col stack">
+
+      <div>
+        <div class="goal-pill tone-blocked">
+          <span class="g-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/></svg>
+          </span>
+          <span class="g-text"><span class="status">受阻</span><span class="objective">重构 session 存储层 —— 等待确认迁移策略</span></span>
+          <span class="g-time">42m 18s</span>
+          <span class="g-actions">
+            <button class="g-act"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"/></svg></button>
+            <button class="g-act danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg></button>
+            <button class="g-act chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></button>
+          </span>
+        </div>
+        <div class="composer-card focusable">
+          <div class="composer-zone"><div class="placeholder">输入消息…</div></div>
+          <div class="composer-toolbar">
+            <div class="tb-left">
+              <button class="icon-btn" style="width:30px;height:30px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 4.5v15m7.5-7.5h-15"/></svg></button>
+              <button class="chip-btn mode-danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.249-8.25-3.286zm0 13.036h.008v.008H12v-.008z"/></svg>完全访问<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            </div>
+            <div class="tb-right">
+              <button class="chip-btn"><span class="provider-dot">K</span><span class="model-name">Kimi K3</span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="goal-pill tone-complete">
+          <span class="g-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/></svg>
+          </span>
+          <span class="g-text"><span class="status">已完成</span><span class="objective">发布 0.1.2 版本并更新文档站</span></span>
+          <span class="g-time">1h 7m</span>
+          <span class="g-actions">
+            <button class="g-act danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg></button>
+            <button class="g-act chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></button>
+          </span>
+        </div>
+        <div class="composer-card focusable">
+          <div class="composer-zone"><div class="placeholder">输入消息…</div></div>
+          <div class="composer-toolbar">
+            <div class="tb-left">
+              <button class="icon-btn" style="width:30px;height:30px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 4.5v15m7.5-7.5h-15"/></svg></button>
+              <button class="chip-btn mode-danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.249-8.25-3.286zm0 13.036h.008v.008H12v-.008z"/></svg>完全访问<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            </div>
+            <div class="tb-right">
+              <button class="chip-btn"><span class="provider-dot">K</span><span class="model-name">Kimi K3</span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="composer-card focusable solo">
+          <div class="composer-zone"><div class="placeholder">输入消息…</div></div>
+          <div class="composer-toolbar">
+            <div class="tb-left">
+              <button class="icon-btn" style="width:30px;height:30px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 4.5v15m7.5-7.5h-15"/></svg></button>
+              <button class="chip-btn mode-danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.249-8.25-3.286zm0 13.036h.008v.008H12v-.008z"/></svg>完全访问<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            </div>
+            <div class="tb-right">
+              <button class="chip-btn"><span class="provider-dot">K</span><span class="model-name">Kimi K3</span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            </div>
+          </div>
+        </div>
+        <p style="margin:8px 0 0;text-align:center;font-size:11px;color:var(--color-muted-foreground)">无 goal：composer 保持同样的一张卡（顶部不再预留叠压空间）</p>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<!-- ════════════════════════════ ③ 方案 B ════════════════════════════ -->
+<section>
+  <div class="sec-head">
+    <span class="sec-no">03</span><h2>方案 B · 备选：胶囊不叠压，纯悬浮（间隙 8px）</h2>
+    <span class="verdict alt">更保守 · 但失去"趴在 input 上"的感觉</span>
+  </div>
+  <p class="sec-sub">同样的胶囊，但不做负 margin 叠压，只是浮在 composer 上方。实现最简单（不需要 composer 顶部补偿），代价是 goal 条和输入框看起来"分家"了。</p>
+
+  <div class="stage">
+    <p class="stage-label">B · collapsed — no overlap</p>
+    <div class="composer-col">
+      <div class="goal-pill tone-active" style="margin-bottom:8px;width:100%">
+        <span class="g-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5M12 8.25v7.5M8.25 12h7.5"/></svg>
+        </span>
+        <span class="g-text"><span class="status">进行中</span><span class="objective">设置一个 goal 测试一下当前项目修改，验证 UI 展示效果</span></span>
+        <span class="g-progress"><span class="frac">3/5</span><span class="track"><span class="fill" style="display:block;width:60%"></span></span></span>
+        <span class="g-time">18h 34m 52s</span>
+        <span class="g-actions">
+          <button class="g-act"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"/></svg></button>
+          <button class="g-act danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg></button>
+          <button class="g-act chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg></button>
+        </span>
+      </div>
+      <div class="composer-card focusable solo">
+        <div class="composer-zone">
+          <div class="placeholder">Agent 正在工作 — 输入将排队，稍后自动发送…</div>
+        </div>
+        <div class="composer-toolbar">
+          <div class="tb-left">
+            <button class="icon-btn" style="width:30px;height:30px"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 4.5v15m7.5-7.5h-15"/></svg></button>
+            <button class="chip-btn mode-danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.249-8.25-3.286zm0 13.036h.008v.008H12v-.008z"/></svg>完全访问<svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+          </div>
+          <div class="tb-right">
+            <button class="chip-btn"><span class="provider-dot">K</span><span class="model-name">Kimi K3</span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg></button>
+            <button class="btn-stop"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>停止</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ════════════════════════════ ④ 设计决策对照 ════════════════════════════ -->
+<section>
+  <div class="sec-head">
+    <span class="sec-no">04</span><h2>与参考图的对照 & 取舍</h2>
+  </div>
+  <div class="stage" style="padding:6px 0 0;border-style:solid;border-color:var(--color-border);background:var(--color-surface);border-radius:var(--radius-xl);overflow:hidden">
+    <table class="cmp">
+      <thead><tr><th style="width:130px">维度</th><th>参考图（Codex）</th><th>本设计稿</th></tr></thead>
+      <tbody>
+        <tr><td>层级关系</td><td>独立胶囊，藏在输入框上沿后面（只露出上半截）</td><td>相同：负 margin -14px + shadow-md + z-index（胶囊 1，composer 2）</td></tr>
+        <tr><td>胶囊底/框</td><td>白底无边框 + 投影</td><td>surface 底 + 55% 透明发丝边框（暗色主题下必须有，否则轮廓丢失）+ shadow-md</td></tr>
+        <tr><td>图标</td><td>纯灰线性靶心</td><td>相同；active 时加 6px 橙色活性小点（我们要表达"正在跑"，参考图没有运行态诉求）</td></tr>
+        <tr><td>色彩</td><td>全文黑灰</td><td>状态词黑（blocked 红 / complete 绿）；不用橙色大色块，保持安静</td></tr>
+        <tr><td>展开箭头</td><td>› 向右</td><td>相同（ChevronRight），展开后旋转 90°；点击整行也可展开</td></tr>
+        <tr><td>todo 进度</td><td>无（Codex 把"第1/5步"放聊天流里）</td><td>行内 44px 小进度 + 分数，不进聊天流也不拉整条横幅</td></tr>
+        <tr><td>输入框</td><td>一张卡</td><td>相同：去掉 docked 内层框，composer 自己就是那张卡</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ════════════════════════════ ⑤ 实现映射 ════════════════════════════ -->
+<section>
+  <div class="sec-head">
+    <span class="sec-no">05</span><h2>实现映射（按方案 A）</h2>
+  </div>
+  <div class="stage" style="padding:6px 0 0;border-style:solid;border-color:var(--color-border);background:var(--color-surface);border-radius:var(--radius-xl);overflow:hidden">
+    <table class="map-table">
+      <thead><tr><th style="width:220px">文件</th><th>改动</th></tr></thead>
+      <tbody>
+        <tr>
+          <td class="file">web/src/components/ChatView.tsx</td>
+          <td>
+            <span class="del">外层包装卡片 <code>overflow-hidden rounded-xl border bg-surface shadow-sm</code></span>
+            → <span class="add">普通 flex 列容器</span>；GoalBanner 与 ChatInput 恢复为兄弟节点
+          </td>
+        </tr>
+        <tr>
+          <td class="file">web/src/components/GoalBanner.tsx</td>
+          <td>
+            根节点改为浮层胶囊：<span class="add"><code>relative z-10 mx-auto -mb-3.5 w-[calc(100%-12px)] rounded-2xl border border-[color-mix(border,55%)] bg-surface shadow-md</code></span>（藏在 composer 后面，z-index 低于 composer）；
+            彩色 wash tile <span class="del">26px 方块</span> → <span class="add">15px 线性图标 + active 活性小点</span>；
+            状态词颜色收敛（active 用前景色，blocked/complete 才用状态色）；
+            todo 整宽进度条 <span class="del">h-[2px] 全宽</span> → <span class="add">行内 44px 迷你进度 + 分数</span>；
+            ChevronDown <span class="del">⌄</span> → <span class="add">ChevronRight ›（展开时 rotate-90）</span>；
+            展开详情用虚线分隔（浮层内部，不算拼接缝）
+          </td>
+        </tr>
+        <tr>
+          <td class="file">web/src/components/ChatInput.tsx</td>
+          <td>
+            docked（<code>!isElevated</code>）内层框 <span class="del"><code>border + bg-[color-mix(surface 90%,#000)]</code></span> → <span class="add">无边框</span>；
+            外层容器升级为 composer 本体：<span class="add"><code>rounded-2xl border bg-surface shadow-sm focus-within:border-[foreground_30%] relative z-20</code></span>（z-index 高于胶囊，把胶囊下缘遮住）；
+            <span class="del">有 goal 时顶部 padding +24px 承接叠压</span>（输入框在前，无需补偿）；elevated 分支不动
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ════════════════════════════ ⑥ 验收 ════════════════════════════ -->
+<section>
+  <div class="sec-head">
+    <span class="sec-no">06</span><h2>验收标准</h2>
+  </div>
+  <ul class="accept">
+    <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg><span><b>整个区域只有两条轮廓</b>：goal 胶囊一条、composer 一条；没有任何分割线/异色底块。</span></li>
+    <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg><span>goal 胶囊<b>藏在 composer 上沿后面</b>（露出上半截，约 14px 被遮住），随 composer 同宽内缩 12px、水平居中。</span></li>
+    <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg><span>明暗主题下胶囊轮廓都清晰（暗色靠发丝边框，不靠阴影）。</span></li>
+    <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg><span>展开详情时胶囊向下生长，<b>composer 始终在前</b>，遮住关系不变；› 箭头旋转 90°。</span></li>
+    <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg><span>无 goal / 欢迎页 elevated composer 形态不变。</span></li>
+  </ul>
+</section>
+
+<script>
+const root = document.documentElement;
+const themeBtn = document.getElementById('themeToggle');
+const sun = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32 1.41 1.41M2 12h2m16 0h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>';
+const moon = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>';
+function paintThemeBtn(){ themeBtn.innerHTML = root.classList.contains('dark') ? sun : moon; }
+themeBtn.addEventListener('click', () => { root.classList.toggle('dark'); paintThemeBtn(); });
+paintThemeBtn();
+
+const focusBtn = document.getElementById('focusToggle');
+focusBtn.addEventListener('click', () => {
+  const on = document.body.classList.toggle('sim-focus');
+  focusBtn.setAttribute('aria-pressed', String(on));
+});
+</script>
+</body>
+</html>

--- a/extension/README.md
+++ b/extension/README.md
@@ -4,7 +4,7 @@ Lets jcode see and operate **your** Chrome — with your logins and sessions —
 via the Chrome DevTools Protocol. This is the `extension` backend of jcode's
 browser-use feature (the other backend is a managed Chrome jcode launches
 itself; that one needs no extension). See
-[`internal-doc/browser-use-design.md`](../internal-doc/browser-use-design.md).
+[`site/docs/overview/browser-use.md`](../site/docs/overview/browser-use.md).
 
 The extension has a **fixed id** (`ekcnniaefmnhnemnpphikhgfoofnojnd`, pinned by
 the `key` field in `manifest.json`) so the id is stable across machines and

--- a/internal-doc/computer-use-design.md
+++ b/internal-doc/computer-use-design.md
@@ -532,17 +532,16 @@ type ComputerAppPermission struct {
 
 Hung off `Config.Computer *ComputerConfig`, JSON key `computer`. Defaults:
 `max_actions_per_batch=20`, all grant flags false.
-**Default `enabled=false`** — unlike browser-use. Computer use can touch
-anything on the machine; it is opt-in.
+**Default `enabled=false`**, matching browser-use. Computer use can touch
+anything on the machine and additionally requires native OS grants.
 
 The Go struct temporarily retains an omitted, deprecated `backend` field only
 so `LoadConfig` can migrate old files safely. It is absent from REST DTOs and is
 never consulted by runtime backend selection.
 
-> **Do not reproduce the browser config-mapper fork.** `browserManagerConfig`
-> (`command/web.go:136`) and `browserConfigToManager` (`web/browser.go:50`) are
-> near-duplicates that already disagree on the viewport default. Computer use
-> gets **one** mapper, in one place, consumed by both call sites.
+> Browser and computer use each have **one** config mapper in their capability
+> package, consumed by every transport. Defaults must not be copied into command
+> or web handlers.
 
 ---
 

--- a/internal/browser/cdp.go
+++ b/internal/browser/cdp.go
@@ -2,7 +2,7 @@
 // the agent can see (text a11y snapshots + screenshots) and operate (click,
 // fill, navigate) behind tiered approvals. Two backends share one TabConn
 // abstraction: a managed Chrome launched by jcode, and the user's own Chrome
-// reached through the jcode extension bridge. See internal-doc/browser-use-design.md.
+// reached through the jcode extension bridge. See site/docs/overview/browser-use.md.
 package browser
 
 import (

--- a/internal/browser/configmap.go
+++ b/internal/browser/configmap.go
@@ -1,0 +1,31 @@
+package browser
+
+import "github.com/cnjack/jcode/internal/config"
+
+const defaultViewport = "1280x720"
+
+// FromConfig maps the persisted browser settings into the runtime shape and
+// applies defaults in one place. A nil config means browser use has not been
+// enabled yet, so it remains off while the non-sensitive runtime defaults are
+// still populated for the settings/status UI.
+func FromConfig(c *config.BrowserConfig) Config {
+	if c == nil {
+		return Config{Backend: "auto", Viewport: defaultViewport}
+	}
+	backend := c.Backend
+	if backend == "" {
+		backend = "auto"
+	}
+	viewport := c.Viewport
+	if viewport == "" {
+		viewport = defaultViewport
+	}
+	return Config{
+		Enabled:    c.Enabled,
+		Backend:    backend,
+		ChromePath: c.ChromePath,
+		Headless:   c.Headless,
+		Viewport:   viewport,
+		DevMode:    c.DevMode,
+	}
+}

--- a/internal/browser/configmap_test.go
+++ b/internal/browser/configmap_test.go
@@ -1,0 +1,35 @@
+package browser
+
+import (
+	"testing"
+
+	"github.com/cnjack/jcode/internal/config"
+)
+
+func TestFromConfigDefaultsToDisabledAutoManagedBrowser(t *testing.T) {
+	got := FromConfig(nil)
+	if got.Enabled {
+		t.Fatal("nil browser config must remain disabled")
+	}
+	if got.Backend != "auto" || got.Viewport != defaultViewport {
+		t.Fatalf("defaults = %+v, want backend=auto viewport=%s", got, defaultViewport)
+	}
+}
+
+func TestFromConfigAppliesDefaultsAndPreservesSettings(t *testing.T) {
+	got := FromConfig(&config.BrowserConfig{
+		Enabled:    true,
+		ChromePath: "/opt/chrome",
+		Headless:   true,
+		DevMode:    true,
+	})
+	if !got.Enabled || got.Backend != "auto" || got.Viewport != defaultViewport ||
+		got.ChromePath != "/opt/chrome" || !got.Headless || !got.DevMode {
+		t.Fatalf("mapped config = %+v", got)
+	}
+
+	got = FromConfig(&config.BrowserConfig{Backend: "extension", Viewport: "1440x900"})
+	if got.Backend != "extension" || got.Viewport != "1440x900" {
+		t.Fatalf("explicit settings were not preserved: %+v", got)
+	}
+}

--- a/internal/browser/manager.go
+++ b/internal/browser/manager.go
@@ -57,6 +57,13 @@ func (m *Manager) GetConfig() Config {
 	return m.cfg
 }
 
+// Enabled reports whether browser-use tools should be exposed to agents.
+func (m *Manager) Enabled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cfg.Enabled
+}
+
 // DevMode reports whether high-risk actions (eval / raw CDP) are unlocked.
 func (m *Manager) DevMode() bool {
 	m.mu.Lock()

--- a/internal/browser/session.go
+++ b/internal/browser/session.go
@@ -326,7 +326,7 @@ func (s *Session) Screenshot(ctx context.Context, fullPage bool) ([]byte, error)
 	return base64.StdEncoding.DecodeString(r.Data)
 }
 
-// --- Read (console / network / text) ---
+// --- Read page text ---
 
 // PageText returns document.body innerText (bounded).
 func (s *Session) PageText(ctx context.Context, limit int) (string, error) {

--- a/internal/command/interactive.go
+++ b/internal/command/interactive.go
@@ -1070,7 +1070,7 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 	// Browser-use manager (managed Chrome backend; the extension backend needs a
 	// server and is unavailable in the pure TUI). Shared with this session's env
 	// so the browser_* tools work in the terminal.
-	browserMgr := browser.NewManager(browserManagerConfig(cfg))
+	browserMgr := browser.NewManager(browser.FromConfig(cfg.Browser))
 	env.Browser = browserMgr
 	defer func() { _ = browserMgr.Close() }()
 
@@ -1270,12 +1270,34 @@ func RunInteractive(prompt, resumeUUID string, unsafe bool) error {
 			}
 		},
 		SetEnabled: func(enable bool) error {
+			created := false
 			if cfg.Browser == nil {
 				cfg.Browser = &config.BrowserConfig{Backend: "auto"}
+				created = true
 			}
+			previousEnabled := cfg.Browser.Enabled
 			cfg.Browser.Enabled = enable
-			browserMgr.SetConfig(browserManagerConfig(cfg))
-			return config.SaveConfig(cfg)
+			if err := config.SaveConfig(cfg); err != nil {
+				cfg.Browser.Enabled = previousEnabled
+				if created {
+					cfg.Browser = nil
+				}
+				return err
+			}
+			browserMgr.SetConfig(browser.FromConfig(cfg.Browser))
+			// Tool schemas are fixed on an agent instance. Rebuild immediately so
+			// /browser on|off changes the current task's model-visible tools.
+			if st.agentMode == tui.ModePlanning {
+				st.toolList = st.buildPlanTools()
+			} else {
+				st.toolList = st.buildAllTools()
+			}
+			newAg, err := st.createAgent()
+			if err != nil {
+				return fmt.Errorf("saved setting but could not refresh agent tools: %w", err)
+			}
+			st.ag = newAg
+			return nil
 		},
 	}
 

--- a/internal/command/web.go
+++ b/internal/command/web.go
@@ -131,31 +131,6 @@ func browserSitePreapproved(cfg *config.Config, origin, class string) bool {
 	return false
 }
 
-// browserManagerConfig maps persisted config into the browser manager's Config,
-// applying defaults (backend=auto, viewport=1280x720) when unset.
-func browserManagerConfig(cfg *config.Config) browser.Config {
-	bc := cfg.Browser
-	if bc == nil {
-		return browser.Config{Backend: "auto", Viewport: "1280x720"}
-	}
-	backend := bc.Backend
-	if backend == "" {
-		backend = "auto"
-	}
-	viewport := bc.Viewport
-	if viewport == "" {
-		viewport = "1280x720"
-	}
-	return browser.Config{
-		Enabled:    bc.Enabled,
-		Backend:    backend,
-		ChromePath: bc.ChromePath,
-		Headless:   bc.Headless,
-		Viewport:   viewport,
-		DevMode:    bc.DevMode,
-	}
-}
-
 // resolveWebToken decides the web auth token and whether auth must be enforced.
 //
 // Auth is required when the bind host is non-loopback (exposed to the network),
@@ -352,7 +327,7 @@ func runWebServer(port int, host string, openBrowser bool, authToken string) err
 	// shared with every per-task Env so the settings UI and the agent's browser_*
 	// tools operate the same Chrome. Created regardless of needsSetup so the
 	// settings page works before providers are configured.
-	browserMgr := browser.NewManager(browserManagerConfig(cfg))
+	browserMgr := browser.NewManager(browser.FromConfig(cfg.Browser))
 
 	// Computer-use manager (native desktop app control), process-wide like the
 	// browser one so the settings UI and the agent's computer_* tools share one

--- a/internal/computer/configmap.go
+++ b/internal/computer/configmap.go
@@ -10,11 +10,8 @@ import (
 // defaults.
 //
 // This is the *only* mapper between the two shapes, and it is deliberately here
-// rather than in the command or web layer. browser-use has two near-duplicate
-// mappers (command/web.go:136 browserManagerConfig and web/browser.go:50
-// browserConfigToManager) which already disagree about the viewport default —
-// a live bug born purely from having two copies. One mapper, one default set,
-// both call sites.
+// rather than in the command or web layer. Keeping one mapper and one default
+// set prevents transport-specific behavior drift.
 func FromConfig(c *config.ComputerConfig) Config {
 	if c == nil {
 		// A nil config is "not configured", which is off — not "on with

--- a/internal/computer/manager.go
+++ b/internal/computer/manager.go
@@ -16,9 +16,7 @@ import (
 //
 // It deliberately mirrors config.ComputerConfig rather than importing it, so
 // this package does not depend on the config package. Exactly one mapper
-// converts between them (see internal/computer/configmap.go) — browser-use grew
-// two near-duplicate mappers that already disagree on a default, and that fork
-// is not being reproduced here.
+// converts between them (see internal/computer/configmap.go).
 type Config struct {
 	Enabled bool
 	// Backend is a compatibility field for internal callers compiled against the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -382,8 +382,8 @@ func (c *Config) SetApprovalReview(rc *ApprovalReviewConfig) {
 	c.ApprovalReview = rc
 }
 
-// BrowserConfig controls the browser-use capability. See
-// internal-doc/browser-use-design.md.
+// BrowserConfig controls the browser-use capability. Browser use is opt-in:
+// an absent block and Enabled=false both keep its tools out of the agent schema.
 type BrowserConfig struct {
 	Enabled    bool   `json:"enabled,omitempty"`
 	Backend    string `json:"backend,omitempty"`     // auto | managed | extension (default auto)
@@ -409,8 +409,8 @@ type BrowserSitePermission struct {
 // ComputerConfig controls the computer-use capability (native desktop app
 // control). See internal-doc/computer-use-design.md.
 //
-// Enabled defaults to false, unlike BrowserConfig: computer use can reach
-// anything on the machine, so it is opt-in.
+// Enabled defaults to false. Like browser use, computer use is opt-in; it also
+// requires native OS permissions because it can reach anything on the machine.
 type ComputerConfig struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Backend is retained only to migrate configurations written before computer

--- a/internal/skills/builtin/browser-use/SKILL.md
+++ b/internal/skills/builtin/browser-use/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: browser-use
-description: Discipline for driving the browser well with the browser_* tools (snapshot-first, safe navigation, approvals). Load before any browser work.
+description: Discipline for driving enabled browser_* tools (snapshot-first, safe navigation, approvals). Load when browser tools are available.
 ---
 
 # Browser Use
 
-You can see and operate a browser through the `browser_*` tools. Read this before browser work; it is how you avoid wasting turns and how you stay safe.
+When browser use is enabled, you can see and operate a browser through the
+`browser_*` tools. Read this before using those tools; it is how you avoid
+wasting turns and how you stay safe. If the tools are absent, browser use is
+disabled in this session; do not claim that you can operate a browser.
 
 ## See before you act
 - `browser_snapshot` is your primary way to see the page. It lists interactive elements each tagged with a uid like `[e3]`. `browser_act` targets those uids.

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -15,18 +15,25 @@ import (
 // NewBrowserTools returns the browser-use tool set for this Env. When browser
 // use is unavailable or disabled, the tools are absent from the model schema.
 func (e *Env) NewBrowserTools() []tool.BaseTool {
-	if e.Browser == nil || !e.Browser.Enabled() {
+	if e.Browser == nil {
 		return nil
 	}
-	return []tool.BaseTool{
+	cfg := e.Browser.GetConfig()
+	if !cfg.Enabled {
+		return nil
+	}
+	tools := []tool.BaseTool{
 		&browserTool{env: e, info: browserOpenInfo()},
 		&browserTool{env: e, info: browserSnapshotInfo()},
 		&browserTool{env: e, info: browserScreenshotInfo()},
 		&browserTool{env: e, info: browserActInfo()},
 		&browserTool{env: e, info: browserReadInfo()},
 		&browserTool{env: e, info: browserTabsInfo()},
-		&browserTool{env: e, info: browserEvalInfo()},
 	}
+	if cfg.DevMode {
+		tools = append(tools, &browserTool{env: e, info: browserEvalInfo()})
+	}
+	return tools
 }
 
 // NewBrowserPlanTools returns the read-only browser subset for plan mode:
@@ -285,10 +292,9 @@ func browserActInfo() *schema.ToolInfo {
 func browserReadInfo() *schema.ToolInfo {
 	return &schema.ToolInfo{
 		Name: "browser_read",
-		Desc: "Read page content. kind=text returns the visible body text (bounded). console/network are not yet available.",
+		Desc: "Read the current page's visible body text, bounded by a character limit.",
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
-			"kind":  strParam("text (default). console/network reserved.", false),
-			"limit": intParam("Max characters for kind=text (default 20000)."),
+			"limit": intParam("Maximum characters to return (default 20000)."),
 		}),
 	}
 }

--- a/internal/tools/browser.go
+++ b/internal/tools/browser.go
@@ -12,10 +12,10 @@ import (
 	"github.com/cnjack/jcode/internal/browser"
 )
 
-// NewBrowserTools returns the browser-use tool set for this Env. When the Env
-// has no Browser manager, it returns nil (the tools are simply absent).
+// NewBrowserTools returns the browser-use tool set for this Env. When browser
+// use is unavailable or disabled, the tools are absent from the model schema.
 func (e *Env) NewBrowserTools() []tool.BaseTool {
-	if e.Browser == nil {
+	if e.Browser == nil || !e.Browser.Enabled() {
 		return nil
 	}
 	return []tool.BaseTool{
@@ -32,7 +32,7 @@ func (e *Env) NewBrowserTools() []tool.BaseTool {
 // NewBrowserPlanTools returns the read-only browser subset for plan mode:
 // navigation (GET) + inspection, no interaction or eval.
 func (e *Env) NewBrowserPlanTools() []tool.BaseTool {
-	if e.Browser == nil {
+	if e.Browser == nil || !e.Browser.Enabled() {
 		return nil
 	}
 	return []tool.BaseTool{

--- a/internal/tools/browser_tools_test.go
+++ b/internal/tools/browser_tools_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cnjack/jcode/internal/browser"
@@ -21,10 +22,43 @@ func TestBrowserToolsFollowManagerEnabledState(t *testing.T) {
 	}
 
 	mgr.SetConfig(browser.Config{Enabled: true, Backend: "auto"})
-	if got := len(env.NewBrowserTools()); got != 7 {
-		t.Fatalf("enabled browser exposed %d full tools, want 7", got)
+	if got := len(env.NewBrowserTools()); got != 6 {
+		t.Fatalf("enabled browser exposed %d full tools, want 6", got)
 	}
 	if got := len(env.NewBrowserPlanTools()); got != 5 {
 		t.Fatalf("enabled browser exposed %d plan tools, want 5", got)
+	}
+
+	mgr.SetConfig(browser.Config{Enabled: true, Backend: "auto", DevMode: true})
+	if got := len(env.NewBrowserTools()); got != 7 {
+		t.Fatalf("developer-mode browser exposed %d full tools, want 7", got)
+	}
+}
+
+func TestBrowserSessionRejectsCachedSessionAfterDisable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	env := NewEnv(t.TempDir(), "darwin")
+	mgr := browser.NewManager(browser.Config{Enabled: true, Backend: "auto"})
+	t.Cleanup(func() { _ = mgr.Close() })
+	env.Browser = mgr
+	env.browserSession = browser.NewSession(nil)
+
+	mgr.SetConfig(browser.Config{Backend: "auto"})
+	if _, err := env.BrowserSession(context.Background()); err == nil {
+		t.Fatal("cached browser session remained usable after browser use was disabled")
+	}
+}
+
+func TestBrowserReadSchemaOnlyAdvertisesSupportedInput(t *testing.T) {
+	info := browserReadInfo()
+	js, err := info.ToJSONSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if js.Properties.Value("limit") == nil {
+		t.Fatal("browser_read schema is missing limit")
+	}
+	if js.Properties.Value("kind") != nil {
+		t.Fatal("browser_read schema advertises unsupported console/network kinds")
 	}
 }

--- a/internal/tools/browser_tools_test.go
+++ b/internal/tools/browser_tools_test.go
@@ -1,0 +1,30 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/cnjack/jcode/internal/browser"
+)
+
+func TestBrowserToolsFollowManagerEnabledState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	env := NewEnv(t.TempDir(), "darwin")
+	mgr := browser.NewManager(browser.Config{Backend: "auto"})
+	t.Cleanup(func() { _ = mgr.Close() })
+	env.Browser = mgr
+
+	if got := len(env.NewBrowserTools()); got != 0 {
+		t.Fatalf("disabled browser exposed %d full tools, want 0", got)
+	}
+	if got := len(env.NewBrowserPlanTools()); got != 0 {
+		t.Fatalf("disabled browser exposed %d plan tools, want 0", got)
+	}
+
+	mgr.SetConfig(browser.Config{Enabled: true, Backend: "auto"})
+	if got := len(env.NewBrowserTools()); got != 7 {
+		t.Fatalf("enabled browser exposed %d full tools, want 7", got)
+	}
+	if got := len(env.NewBrowserPlanTools()); got != 5 {
+		t.Fatalf("enabled browser exposed %d plan tools, want 5", got)
+	}
+}

--- a/internal/tools/env.go
+++ b/internal/tools/env.go
@@ -173,6 +173,12 @@ func (e *Env) BrowserSession(ctx context.Context) (*browser.Session, error) {
 	}
 	e.browserMu.Lock()
 	defer e.browserMu.Unlock()
+	// Tool schemas are rebuilt after a settings change, but an older agent turn
+	// may still hold a browser tool. Re-check the live manager before returning a
+	// cached session so disabling the capability also revokes execution.
+	if !e.Browser.Enabled() {
+		return nil, fmt.Errorf("browser use is disabled (enable it in settings)")
+	}
 	if e.browserSession != nil {
 		return e.browserSession, nil
 	}

--- a/internal/web/browser.go
+++ b/internal/web/browser.go
@@ -46,25 +46,6 @@ func (s *Server) SetupNativeMessaging() {
 	}
 }
 
-// browserConfigToManager maps the persisted config into the manager's Config.
-func browserConfigToManager(bc *config.BrowserConfig) browser.Config {
-	if bc == nil {
-		return browser.Config{Backend: "auto"}
-	}
-	backend := bc.Backend
-	if backend == "" {
-		backend = "auto"
-	}
-	return browser.Config{
-		Enabled:    bc.Enabled,
-		Backend:    backend,
-		ChromePath: bc.ChromePath,
-		Headless:   bc.Headless,
-		Viewport:   bc.Viewport,
-		DevMode:    bc.DevMode,
-	}
-}
-
 func (s *Server) handleBrowserStatus(w http.ResponseWriter, r *http.Request) {
 	if s.browserMgr == nil {
 		writeJSON(w, http.StatusOK, map[string]any{"available": false})
@@ -103,28 +84,36 @@ func (s *Server) handleBrowserConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.cfgMu.Lock()
+	defer s.cfgMu.Unlock()
 	s.mu.Lock()
 	if s.cfg == nil {
 		s.mu.Unlock()
-		s.cfgMu.Unlock()
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "config unavailable"})
 		return
 	}
+	previous := s.cfg.Browser
 	s.cfg.Browser = &req
 	err := config.SaveConfig(s.cfg)
+	if err != nil {
+		s.cfg.Browser = previous
+	}
 	s.mu.Unlock()
-	s.cfgMu.Unlock()
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	s.browserMgr.SetConfig(browserConfigToManager(&req))
+	s.browserMgr.SetConfig(browser.FromConfig(&req))
 	// Enabling browser use should make native auto-connect available without a
 	// restart: refresh the endpoint file + native-host manifest now.
 	if req.Enabled {
 		s.SetupNativeMessaging()
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	response := map[string]string{"status": "ok"}
+	if err := s.rebuildToolAgents(); err != nil {
+		config.Logger().Printf("[browser] config saved but active-agent tool refresh failed: %v", err)
+		response["warning_code"] = "agent_refresh_failed"
+	}
+	writeJSON(w, http.StatusOK, response)
 }
 
 // handleBrowserExtWS is the extension bridge websocket. It is auth-exempt (the

--- a/internal/web/browser_test.go
+++ b/internal/web/browser_test.go
@@ -1,0 +1,72 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cnjack/jcode/internal/browser"
+	"github.com/cnjack/jcode/internal/config"
+)
+
+func TestBrowserConfigRefreshesLiveAgentAndRuntimeDefaults(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	rebuilds := 0
+	eng := &Engine{
+		taskID: "active",
+		createAgent: func(_, _ string) (*adk.ChatModelAgent, error) {
+			rebuilds++
+			return nil, nil
+		},
+	}
+	mgr := browser.NewManager(browser.Config{})
+	t.Cleanup(func() { _ = mgr.Close() })
+	s := &Server{Engine: eng, cfg: &config.Config{}, browserMgr: mgr}
+
+	rec := httptest.NewRecorder()
+	s.handleBrowserConfig(rec, httptest.NewRequest(http.MethodPost, "/api/browser/config",
+		strings.NewReader(`{"enabled":false}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rebuilds != 1 {
+		t.Fatalf("agent rebuilds=%d, want 1", rebuilds)
+	}
+	got := mgr.GetConfig()
+	if got.Enabled || got.Backend != "auto" || got.Viewport != "1280x720" {
+		t.Fatalf("runtime browser config=%+v", got)
+	}
+}
+
+func TestBrowserConfigReturnsStableAgentRefreshWarningCode(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	eng := &Engine{
+		taskID: "active",
+		createAgent: func(_, _ string) (*adk.ChatModelAgent, error) {
+			return nil, errors.New("provider unavailable")
+		},
+	}
+	mgr := browser.NewManager(browser.Config{})
+	t.Cleanup(func() { _ = mgr.Close() })
+	s := &Server{Engine: eng, cfg: &config.Config{}, browserMgr: mgr}
+
+	rec := httptest.NewRecorder()
+	s.handleBrowserConfig(rec, httptest.NewRequest(http.MethodPost, "/api/browser/config",
+		strings.NewReader(`{"enabled":false}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		WarningCode string `json:"warning_code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.WarningCode != "agent_refresh_failed" {
+		t.Fatalf("warning_code=%q, want agent_refresh_failed", response.WarningCode)
+	}
+}

--- a/internal/web/computer.go
+++ b/internal/web/computer.go
@@ -193,7 +193,7 @@ func (s *Server) handleComputerConfig(w http.ResponseWriter, r *http.Request) {
 	// cfgMu intentionally remains held through live policy publication and tool
 	// rebuild. Without this, concurrent saves can commit B to disk but publish A
 	// to the Manager when A's slower rebuild resumes out of order.
-	if err := s.rebuildComputerAgent(); err != nil {
+	if err := s.rebuildToolAgents(); err != nil {
 		config.Logger().Printf("[computer] config saved but active-agent tool refresh failed: %v", err)
 		response["warning_code"] = "agent_refresh_failed"
 	}
@@ -283,11 +283,11 @@ func validateComputerPermissions(perms []config.ComputerAppPermission) error {
 	return nil
 }
 
-// rebuildComputerAgent refreshes fixed tool schemas for every live task, so
-// enabling or disabling Computer Use takes effect without an app restart or a
-// foreground-task switch. Runtime policy revocation is already immediate; this
-// keeps the model-visible tool surface in sync as well.
-func (s *Server) rebuildComputerAgent() error {
+// rebuildToolAgents refreshes fixed tool schemas for every live task after a
+// process-wide capability changes. Runtime policy publication is immediate;
+// this keeps the model-visible tool surface in sync without an app restart or
+// foreground-task switch.
+func (s *Server) rebuildToolAgents() error {
 	if s.needsSetup {
 		return nil
 	}

--- a/internal/web/computer_test.go
+++ b/internal/web/computer_test.go
@@ -193,7 +193,7 @@ func TestComputerConfigRebuildsAllLiveTaskToolSchemas(t *testing.T) {
 			"background": background,
 		},
 	}
-	if err := s.rebuildComputerAgent(); err != nil {
+	if err := s.rebuildToolAgents(); err != nil {
 		t.Fatal(err)
 	}
 	if calls["active"] != 1 || calls["background"] != 1 {
@@ -219,7 +219,7 @@ func TestComputerAgentRebuildDoesNotOverwriteConcurrentModeSwitch(t *testing.T) 
 	}
 	s := &Server{Engine: eng}
 	done := make(chan error, 1)
-	go func() { done <- s.rebuildComputerAgent() }()
+	go func() { done <- s.rebuildToolAgents() }()
 	<-started
 	eng.applyModeSwitch("plan", newAgent)
 	close(release)

--- a/site/docs/overview/browser-use.md
+++ b/site/docs/overview/browser-use.md
@@ -22,12 +22,12 @@ in the web UI chat), but they are not the primary channel.
 
 ## Two backends, one tool set
 
-The same seven tools work over either backend — the model doesn't know or care
-which one is active.
+The same six core tools work over either backend — the model doesn't know or
+care which one is active. Developer mode adds the optional `browser_eval` tool.
 
 | Backend | What it is | Best for |
 | --- | --- | --- |
-| **Managed** (default) | jcode launches its own Chrome/Chromium with an isolated profile under `~/.jcode/browser/`. No extension needed, nothing touches your daily browser. | localhost verification, scraping public pages, anything that doesn't need your logins |
+| **Managed** | jcode launches its own Chrome/Chromium with an isolated profile under `~/.jcode/browser/`. No extension needed, nothing touches your daily browser. | localhost verification, scraping public pages, anything that doesn't need your logins |
 | **Extension** | The **jcode Browser Bridge** Chrome extension connects *your* Chrome to jcode over a local WebSocket. The agent works in your real browser — with your sessions and logins. | tasks on sites you're signed into, taking over a tab you already have open |
 
 With `"backend": "auto"` (the default) jcode prefers the extension when it is

--- a/site/docs/overview/browser-use.md
+++ b/site/docs/overview/browser-use.md
@@ -67,7 +67,7 @@ limited to `127.0.0.1` / `localhost`) and sends nothing to any third party.
 | `browser_snapshot` | Text snapshot of the page — uid-tagged interactive elements; the primary way to "see" |
 | `browser_screenshot` | PNG screenshot; renders inline in the web UI chat, injected as an image for vision models |
 | `browser_act` | One interaction: click / fill / press / hover / scroll / select on a uid from the latest snapshot |
-| `browser_read` | Read page text, console output, or network activity |
+| `browser_read` | Read visible page text, bounded by a configurable character limit |
 | `browser_tabs` | List / open / select / close tabs; `claim` takes over one of your tabs (extension backend) |
 | `browser_eval` | Evaluate a JavaScript expression — requires developer mode |
 
@@ -75,8 +75,8 @@ limited to `127.0.0.1` / `localhost`) and sends nothing to any third party.
 
 Browser actions plug into the standard jcode approval flow, in three tiers:
 
-- **Read-only — no approval.** Snapshots, screenshots, reading text/console/
-  network, listing tabs.
+- **Read-only — no approval.** Snapshots, screenshots, reading visible page
+  text, and listing tabs.
 - **Interaction — ask once per site.** Navigation and page actions prompt the
   first time for each origin; you can answer *just this once* or *always allow
   this site*. Site permissions are stored in config and manageable from the
@@ -117,6 +117,7 @@ In **Plan mode** the browser is read-only: the agent can look but not touch.
 
 | Field | Meaning |
 | --- | --- |
+| `enabled` | Enable browser tools. Off by default; turn it on in Settings or with `/browser on` |
 | `backend` | `auto` (extension if connected, else managed), `managed`, or `extension` |
 | `chrome_path` | Path to a Chrome/Chromium binary; empty = auto-discover |
 | `headless` | Run the managed browser without a visible window |

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,10 +23,12 @@ import {
 import {
   RuntimeProvider,
   ToolRegistryProvider,
+  ApiBaseProvider,
   createDefaultToolRegistry,
 } from 'jcode-ui'
 import { WSClient } from './lib/ws'
 import { api } from './lib/api'
+import { apiBase } from './lib/apiBase'
 import { normalizeMode } from './lib/types'
 import { useAppDispatch, useAppSelector } from './app/hooks'
 import {
@@ -51,6 +53,7 @@ import { AuthGate } from './components/AuthGate'
 import { SetupView } from './components/SetupView'
 import { SettingsDialog } from './components/SettingsDialog'
 import { TopBar } from './components/TopBar'
+import { ComputerShotPiP } from './components/ComputerShotPiP'
 import { RightPanel } from './components/RightPanel'
 import { TerminalPanel } from './components/TerminalPanel'
 import { RemoteConnectWizard } from './components/RemoteConnectWizard'
@@ -261,7 +264,12 @@ function Shell({ activeView }: { activeView: 'chat' | 'automations' | 'channels'
 
   return (
     <RuntimeProvider runtime={runtime}>
-      <ToolRegistryProvider registry={registry}>
+      {/* ApiBaseProvider lets tool renderers (browser/computer screenshots)
+          resolve "/api/…" image refs against the real backend origin — required
+          in the Tauri shell, where the page itself is served from tauri://localhost
+          and a bare relative <img src> would 404. '' in browser mode (same-origin). */}
+      <ApiBaseProvider apiBase={apiBase}>
+        <ToolRegistryProvider registry={registry}>
         <div className="app-shell relative flex h-[100dvh] overflow-hidden bg-[var(--color-background)] text-[var(--color-foreground)]">
           {/* Native title-bar drag strip — hidden in browser, shown in Tauri (CSS). */}
           <div className="titlebar-drag" data-tauri-drag-region aria-hidden="true" />
@@ -275,6 +283,9 @@ function Shell({ activeView }: { activeView: 'chat' | 'automations' | 'channels'
               onTogglePanel={togglePanel}
             />
           )}
+          {/* Codex-style computer-use PiP — floats under the TopBar, shows the
+              latest screenshot from the session's computer_screenshot calls. */}
+          {activeView === 'chat' && <ComputerShotPiP />}
 
           {/* Sidebar floats on the shell background — no border, no shared frame
               with the main canvas (matches Vue App.vue). */}
@@ -330,7 +341,8 @@ function Shell({ activeView }: { activeView: 'chat' | 'automations' | 'channels'
             }}
           />
         </div>
-      </ToolRegistryProvider>
+        </ToolRegistryProvider>
+      </ApiBaseProvider>
     </RuntimeProvider>
   )
 }
@@ -426,16 +438,17 @@ function statusClass(status: 'success' | 'error' | 'running'): string {
 }
 
 function ErrorScreen({ message }: { message: string }) {
+  const { t } = useTranslation()
   return (
     <div className="flex h-screen flex-col items-center justify-center gap-2 bg-[var(--color-background)] text-[var(--color-foreground)]">
-      <h1 className="text-xl font-semibold">Can't reach the jcode backend</h1>
+      <h1 className="text-xl font-semibold">{t('connection.errorTitle')}</h1>
       <p className="max-w-md text-center text-sm text-[var(--color-muted-foreground)]">{message}</p>
       <button
         type="button"
         onClick={() => location.reload()}
         className="mt-2 rounded-[var(--radius-md)] bg-[var(--color-primary)] px-3 py-1.5 text-sm text-[var(--color-on-primary)]"
       >
-        Retry
+        {t('common.retry')}
       </button>
     </div>
   )

--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -1022,8 +1022,8 @@ export const loadSession = createAsyncThunk(
     const timeline: ThreadItem[] = []
     const pendingToolCalls = new Map<string, ToolCall>()
     for (const e of entries) {
-      if (e.type === 'user' && e.content) {
-        timeline.push({ kind: 'message', seq: nextSeq(), data: { id: genId('msg'), role: 'user', content: e.content, timestamp: ts(e.timestamp) } })
+      if (e.type === 'user' && (e.content || (e.images && e.images.length > 0))) {
+        timeline.push({ kind: 'message', seq: nextSeq(), data: { id: genId('msg'), role: 'user', content: e.content || '', timestamp: ts(e.timestamp), images: e.images } })
       } else if (e.type === 'assistant' && e.content) {
         timeline.push({ kind: 'message', seq: nextSeq(), data: { id: genId('asst'), role: 'assistant', content: e.content, timestamp: ts(e.timestamp) } })
       } else if (e.type === 'tool_call' && e.name) {
@@ -1147,8 +1147,8 @@ export const replaySession = createAsyncThunk(
     const timeline: ThreadItem[] = []
     const pendingToolCalls = new Map<string, ToolCall>()
     for (const e of entries) {
-      if (e.type === 'user' && e.content) {
-        timeline.push({ kind: 'message', seq: nextSeq(), data: { id: genId('msg'), role: 'user', content: e.content, timestamp: ts(e.timestamp) } })
+      if (e.type === 'user' && (e.content || (e.images && e.images.length > 0))) {
+        timeline.push({ kind: 'message', seq: nextSeq(), data: { id: genId('msg'), role: 'user', content: e.content || '', timestamp: ts(e.timestamp), images: e.images } })
       } else if (e.type === 'assistant' && e.content) {
         timeline.push({ kind: 'message', seq: nextSeq(), data: { id: genId('asst'), role: 'assistant', content: e.content, timestamp: ts(e.timestamp) } })
       } else if (e.type === 'tool_call' && e.name) {

--- a/web/src/components/AuthGate.tsx
+++ b/web/src/components/AuthGate.tsx
@@ -1,6 +1,7 @@
 /** AuthGate — login form shown when the server requires a token (non-loopback bind). */
 
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { api } from '../lib/api'
 import { normalizeMode } from '../lib/types'
 import { setAuthToken, clearAuthToken } from '../lib/authToken'
@@ -8,6 +9,7 @@ import { useAppDispatch } from '../app/hooks'
 import { chatActions, loadWorkspaceState, modelActions, sessionActions, uiActions } from '../app/store'
 
 export function AuthGate() {
+  const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const [token, setToken] = useState('')
   const [error, setError] = useState('')
@@ -33,10 +35,10 @@ export function AuthGate() {
         await dispatch(loadWorkspaceState())
         dispatch(uiActions.setNeedsAuth(false))
       } else {
-        setError('Invalid token')
+        setError(t('auth.invalid'))
       }
     } catch {
-      setError('Invalid token')
+      setError(t('auth.invalid'))
     } finally {
       setChecking(false)
     }
@@ -51,13 +53,13 @@ export function AuthGate() {
       >
         <h1 className="text-lg font-semibold">jcode</h1>
         <p className="mt-1 text-sm text-[var(--color-muted-foreground)]">
-          This server requires an access token. Enter it below.
+          {t('auth.body')}
         </p>
         <input
           type="password"
           value={token}
           onChange={(e) => setToken(e.target.value)}
-          placeholder="Access token"
+          placeholder={t('auth.placeholder')}
           autoFocus
           className="mt-4 w-full rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-muted)] px-3 py-2 text-sm outline-none focus:border-[var(--color-primary)]"
         />
@@ -67,7 +69,7 @@ export function AuthGate() {
           disabled={checking || !token}
           className="mt-4 w-full rounded-[var(--radius-md)] bg-[var(--color-primary)] px-3 py-2 text-sm font-medium text-[var(--color-on-primary)] disabled:opacity-50"
         >
-          {checking ? 'Checking…' : 'Unlock'}
+          {checking ? t('auth.verifying') : t('auth.submit')}
         </button>
       </form>
     </div>

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -88,24 +88,25 @@ export interface ChatInputProps {
 type ModeValue = AgentMode
 interface ModeDef {
   value: ModeValue
-  label: string
-  sub: string
+  /** i18n keys under chat.modes (resolved with t() at render). */
+  labelKey: string
+  subKey: string
   risk: 'neutral' | 'plan' | 'info' | 'danger'
   Icon: typeof HandRaisedIcon
 }
 
 const MODE_DEFS: ModeDef[] = [
-  { value: 'approval', label: 'Ask for approval', sub: 'Agent asks before running tools', risk: 'neutral', Icon: HandRaisedIcon },
-  { value: 'plan', label: 'Plan', sub: 'Agent plans, then waits for your go-ahead', risk: 'plan', Icon: ClipboardDocumentListIcon },
-  { value: 'auto', label: 'Auto', sub: 'AI reviewer allows safe tools; uncertain ones ask', risk: 'info', Icon: SparklesIcon },
-  { value: 'full_access', label: 'Full access', sub: 'Agent can act without asking', risk: 'danger', Icon: ShieldExclamationIcon },
+  { value: 'approval', labelKey: 'chat.modes.approval', subKey: 'chat.modes.approvalSub', risk: 'neutral', Icon: HandRaisedIcon },
+  { value: 'plan', labelKey: 'chat.modes.plan', subKey: 'chat.modes.planSub', risk: 'plan', Icon: ClipboardDocumentListIcon },
+  { value: 'auto', labelKey: 'chat.modes.auto', subKey: 'chat.modes.autoSub', risk: 'info', Icon: SparklesIcon },
+  { value: 'full_access', labelKey: 'chat.modes.fullAccess', subKey: 'chat.modes.fullAccessSub', risk: 'danger', Icon: ShieldExclamationIcon },
 ]
 
 const STANDARD_EFFORT_OPTIONS = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max']
 
-function modeLabel(m: string): string {
+function modeLabel(t: (key: string) => string, m: string): string {
   const def = MODE_DEFS.find((d) => d.value === m)
-  return def ? def.label : 'Ask for approval'
+  return t(def ? def.labelKey : 'chat.modes.approval')
 }
 
 // ─── Format helpers ─────────────────────────────────────────────────────────
@@ -127,6 +128,28 @@ function modelSubline(modelId: string, info?: { context_limit?: number }): strin
   const ctx = formatContext(info?.context_limit)
   if (ctx) parts.push(ctx)
   return parts.join(' · ')
+}
+
+/**
+ * Slash token at the cursor: walks back from the caret to the nearest "/" with
+ * no whitespace in between, then decides whether that "/" can start a command.
+ * It can when the char before it is NOT a word/path char [A-Za-z0-9_/.-] — i.e.
+ * start of text, whitespace, CJK, or punctuation. That admits "see /goal" and
+ * "帮我/goal" (CJK text rarely has spaces) while excluding paths and URLs like
+ * "/usr/bin" or "http://x/y". Returns the token start offset plus the filter
+ * text typed after "/".
+ */
+function slashTokenAt(text: string, cursor: number): { start: number; filter: string } | null {
+  for (let i = cursor - 1; i >= 0; i--) {
+    const ch = text[i]
+    if (/\s/.test(ch)) return null
+    if (ch !== '/') continue
+    if (i === 0 || !/[A-Za-z0-9_/.-]/.test(text[i - 1])) {
+      return { start: i, filter: text.slice(i + 1, cursor) }
+    }
+    return null
+  }
+  return null
 }
 
 // ─── Component ──────────────────────────────────────────────────────────────
@@ -260,10 +283,22 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
   const manageVisibleCount = filteredProviders.reduce((n, p) => n + p.models.length, 0)
   const manageTotalCount = providers.reduce((n, p) => n + p.models.length, 0)
 
+  // Local pseudo-command: "/goal" arms Goal mode (same as the "+" menu entry)
+  // instead of inserting text. Compared by object identity in applySlashCommand.
+  const goalSlashCmd = useMemo<SlashCommandInfo>(
+    () => ({ slash: '/goal', description: t('chat.goalSlashDesc'), type: 'builtin' }),
+    [t],
+  )
+
   const filteredSlashCommands = useMemo(() => {
     const filter = slashFilter.toLowerCase()
-    return slashCommands.filter((s) => s.slash.toLowerCase().startsWith('/' + filter))
-  }, [slashCommands, slashFilter])
+    const backend = slashCommands.filter((s) => s.slash.toLowerCase().startsWith('/' + filter))
+    // Prepend the local /goal entry unless the backend ships a real one.
+    if ('/goal'.startsWith('/' + filter) && !backend.some((s) => s.slash === '/goal')) {
+      return [goalSlashCmd, ...backend]
+    }
+    return backend
+  }, [slashCommands, slashFilter, goalSlashCmd])
 
   // Context-fill ring (token usage %).
   const ctxRingCirc = 2 * Math.PI * 6.4
@@ -334,7 +369,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
       pendingImages.length > 0
         ? pendingImages.map((i) => ({ data: i.data, media_type: i.media_type, name: i.name }))
         : undefined
-    const body = text || '(see attached images)'
+    const body = text || t('chat.attachedImages')
     if (isRunning) {
       actions.enqueueMessage(body, images)
     } else {
@@ -345,7 +380,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
     setPendingImages([])
     setShowSlashMenu(false)
     onSent?.()
-  }, [actions, input, isRunning, onSent, pendingImages, currentSessionId])
+  }, [actions, input, isRunning, onSent, pendingImages, currentSessionId, t])
 
   // ─── Model / mode selection ───────────────────────────────────────────────
 
@@ -408,10 +443,50 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
 
   // ─── Slash commands ───────────────────────────────────────────────────────
 
+  /** Recompute slash-menu visibility from the text + caret (mid-text aware). */
+  function updateSlashState(text: string, cursor: number) {
+    const tok = slashTokenAt(text, cursor)
+    if (tok) {
+      setSlashFilter(tok.filter)
+      setShowSlashMenu(true)
+      setSelectedSlashIdx(0)
+    } else {
+      setShowSlashMenu(false)
+    }
+  }
+
   function applySlashCommand(cmd: SlashCommandInfo) {
-    setInput(cmd.slash + ' ')
+    const el = textareaRef.current
+    const cursor = el ? el.selectionStart : input.length
+    const tok = slashTokenAt(input, cursor)
+    if (cmd === goalSlashCmd) {
+      // "/goal" is a mode toggle, not message text: arm Goal mode and strip the
+      // typed token so the surrounding message stays intact.
+      dispatch(chatActions.setGoalArmed(true))
+      if (tok) {
+        const next = input.slice(0, tok.start) + input.slice(cursor)
+        setInput(next)
+        requestAnimationFrame(() => {
+          el?.focus()
+          el?.setSelectionRange(tok.start, tok.start)
+        })
+      } else {
+        requestAnimationFrame(() => el?.focus())
+      }
+    } else if (tok) {
+      // Replace only the "/filter" token at the caret; keep the rest of the draft.
+      const next = input.slice(0, tok.start) + cmd.slash + ' ' + input.slice(cursor)
+      setInput(next)
+      const pos = tok.start + cmd.slash.length + 1
+      requestAnimationFrame(() => {
+        el?.focus()
+        el?.setSelectionRange(pos, pos)
+      })
+    } else {
+      setInput(cmd.slash + ' ')
+      requestAnimationFrame(() => el?.focus())
+    }
     setShowSlashMenu(false)
-    requestAnimationFrame(() => textareaRef.current?.focus())
   }
 
   function selectFirstFiltered() {
@@ -474,13 +549,13 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
     autoResize()
     const text = e.target.value
     setInput(text)
-    if (text.startsWith('/')) {
-      setSlashFilter(text.slice(1))
-      setShowSlashMenu(true)
-      setSelectedSlashIdx(0)
-    } else {
-      setShowSlashMenu(false)
-    }
+    updateSlashState(text, e.target.selectionStart ?? text.length)
+  }
+
+  /** Keep the menu in sync when the caret moves (click / arrow keys). */
+  function handleSelect(e: React.SyntheticEvent<HTMLTextAreaElement>) {
+    const el = e.currentTarget
+    updateSlashState(el.value, el.selectionStart ?? el.value.length)
   }
 
   function insertToken(char: string) {
@@ -495,11 +570,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
       const pos = start + char.length
       el?.setSelectionRange(pos, pos)
       // Re-run slash-menu logic if "/" was inserted.
-      if (char === '/') {
-        setSlashFilter(next.slice(1))
-        setShowSlashMenu(next.startsWith('/'))
-        setSelectedSlashIdx(0)
-      }
+      if (char === '/') updateSlashState(next, pos)
     })
   }
 
@@ -676,8 +747,8 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
               )}
               <button
                 type="button"
-                title="Remove queued message"
-                aria-label="Remove queued message"
+                title={t('chat.removeQueued')}
+                aria-label={t('chat.removeQueued')}
                 onClick={() => actions.removeQueuedMessage(q.id)}
                 className="grid h-5 w-5 shrink-0 place-items-center rounded-[var(--radius-md)] border-none bg-transparent text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-secondary)] hover:text-[var(--color-foreground)]"
               >
@@ -692,9 +763,9 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
         className={`relative mx-auto flex flex-col ${
           isElevated
             ? 'rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-xl)]'
-            : 'rounded-[var(--radius-xl)] bg-transparent'
+            : 'z-[2] rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-sm)]'
         }`}
-        style={{ padding: isElevated ? '6px 12px 12px' : '4px 6px 10px' }}
+        style={{ padding: isElevated ? '6px 12px 12px' : '14px 16px 10px' }}
       >
         {/* Slash command menu */}
         {showSlashMenu && filteredSlashCommands.length > 0 && (
@@ -712,7 +783,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                 <span className="shrink-0 font-mono text-xs text-[var(--color-primary)]">{cmd.slash}</span>
                 {cmd.type === 'flow' && (
                   <span className="shrink-0 rounded-[var(--radius-pill)] border border-[var(--accent-wash)] bg-[var(--accent-wash)] px-1.5 py-0.5 text-[10px] font-semibold leading-none text-[var(--color-primary)]">
-                    workflow
+                    {t('chat.workflowBadge')}
                   </span>
                 )}
                 <span className="truncate text-[11px] text-[var(--color-muted-foreground)]">{cmd.description}</span>
@@ -732,10 +803,12 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
         )}
 
         <div
-          className={`border border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-surface)_90%,#000)] transition-colors focus-within:border-[color-mix(in_srgb,var(--color-foreground)_30%,transparent)] ${
-            isElevated ? 'rounded-[var(--radius-xl)]' : 'rounded-[var(--radius-lg)]'
+          className={`transition-colors ${
+            isElevated
+              ? 'rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-surface)_90%,#000)] focus-within:border-[color-mix(in_srgb,var(--color-foreground)_30%,transparent)]'
+              : 'rounded-[var(--radius-lg)]'
           }`}
-          style={{ padding: '14px 16px 0' }}
+          style={isElevated ? { padding: '14px 16px 0' } : undefined}
         >
           {/* Textarea + image previews */}
           <div className="pb-2">
@@ -745,13 +818,14 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
               rows={1}
               onChange={handleInput}
               onKeyDown={handleKeyDown}
+              onSelect={handleSelect}
               onPaste={handlePaste}
               placeholder={
                 isRunning
-                  ? 'Queue a message…'
+                  ? t('chat.queuePlaceholder')
                     : goalArmed
-                    ? 'What is your goal?'
-                    : 'Send a message…'
+                    ? t('chat.goalPlaceholder')
+                    : t('chat.placeholder')
               }
               className="block w-full resize-none border-none bg-transparent text-sm leading-relaxed text-[var(--color-foreground)] outline-none"
               style={{ minHeight: 28, maxHeight: 200, fontFamily: 'var(--font-sans)' }}
@@ -784,7 +858,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
               <div className="relative">
                 <button
                   type="button"
-                  title="Add"
+                  title={t('chat.add')}
                   onClick={(e: ReactMouseEvent) => { e.stopPropagation(); openAdd() }}
                   className={`grid h-[30px] w-[30px] place-items-center rounded-[var(--radius-md)] border-none bg-transparent text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-secondary)] hover:text-[var(--color-foreground)] ${
                     showAddMenu ? 'bg-[var(--color-secondary)] text-[var(--color-foreground)]' : ''
@@ -799,14 +873,14 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                     <button
                       type="button"
                       disabled={!imageSupport}
-                      title={!imageSupport ? 'Current model does not accept images' : ''}
+                      title={!imageSupport ? t('chat.model.noImages') : ''}
                       onClick={() => { triggerImageUpload(); setShowAddMenu(false) }}
                       className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)] ${
                         !imageSupport ? 'cursor-default opacity-50' : ''
                       }`}
                     >
                       <PaperClipIcon className="h-3.5 w-3.5 shrink-0 text-[var(--color-muted-foreground)]" />
-                      <span>Attach files</span>
+                      <span>{t('chat.attachFiles')}</span>
                       {pendingImages.length > 0 && (
                         <span className="ml-auto font-mono text-[10px] text-[var(--color-primary)]">{pendingImages.length}</span>
                       )}
@@ -817,18 +891,18 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                       className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)]"
                     >
                       <span className="w-[15px] shrink-0 text-center font-mono text-sm leading-none text-[var(--color-muted-foreground)]">/</span>
-                      <span>Command</span>
+                      <span>{t('chat.command')}</span>
                     </button>
                     <button
                       type="button"
-                      title={goalArmed ? 'Goal is armed — your next message becomes the objective' : 'Arm Goal mode'}
+                      title={goalArmed ? t('chat.goalHint.nextReplaces') : t('chat.goalHint.next')}
                       onClick={() => { dispatch(chatActions.setGoalArmed(!goalArmed)); setShowAddMenu(false) }}
                       className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)] ${
                         goalArmed ? 'bg-[var(--neutral-wash)] text-[var(--color-foreground)]' : ''
                       }`}
                     >
                       <ViewfinderCircleIcon className={`h-3.5 w-3.5 shrink-0 ${goalArmed ? 'text-[var(--color-primary)]' : 'text-[var(--color-muted-foreground)]'}`} />
-                      <span>Goal</span>
+                      <span>{t('chat.goal')}</span>
                     </button>
                   </div>
                 )}
@@ -857,7 +931,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                             : ''
                     }
                   >
-                    {modeLabel(mode)}
+                    {modeLabel(t, mode)}
                   </span>
                   <ChevronDownIcon
                     className={`h-3 w-3 opacity-55 transition-transform ${showModePicker ? 'rotate-180' : ''}`}
@@ -901,10 +975,10 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                                       : 'text-[var(--color-foreground)]'
                               }`}
                             >
-                              {m.label}
+                              {t(m.labelKey)}
                             </span>
                             <span className="mt-px block text-[10.5px] leading-[1.4] text-[var(--color-muted-foreground)]">
-                              {m.sub}
+                              {t(m.subKey)}
                             </span>
                           </span>
                           {active && <CheckIcon className="mt-[3px] h-3.5 w-3.5 shrink-0 text-[var(--color-primary)]" />}
@@ -920,20 +994,20 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                 <>
                   <span aria-hidden="true" className="mx-0.5 h-4 w-px shrink-0 bg-[var(--color-border)]" />
                   <div
-                    title="Goal armed — your next message replaces the current objective"
+                    title={t('chat.goalHint.nextReplaces')}
                     className="inline-flex h-[26px] items-center gap-1.5 rounded-[var(--radius-md)] bg-[var(--neutral-wash)] px-2 text-xs font-medium text-[var(--color-primary)]"
                     style={{ paddingLeft: 4, paddingRight: 9 }}
                   >
                     <button
                       type="button"
-                      title="Disarm Goal"
+                      title={t('chat.goalHint.remove')}
                       onClick={() => dispatch(chatActions.setGoalArmed(false))}
                       className="grid h-4 w-4 place-items-center rounded-[var(--radius-pill)] border-none bg-[color-mix(in_srgb,var(--color-primary)_18%,transparent)] text-[var(--color-primary)] transition-colors hover:bg-[color-mix(in_srgb,var(--color-primary)_34%,transparent)]"
                     >
                       <XMarkIcon className="h-2.5 w-2.5" />
                     </button>
                     <ViewfinderCircleIcon className="h-3 w-3" />
-                    <span>Goal</span>
+                    <span>{t('chat.goal')}</span>
                   </div>
                 </>
               )}
@@ -946,7 +1020,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                 <div className="relative">
                   <button
                     type="button"
-                    title="Context capacity"
+                    title={t('contextCapacity.title')}
                     onClick={(e) => { e.stopPropagation(); void toggleContextPopup() }}
                     className="inline-flex items-center gap-[5px] rounded-[var(--radius-sm)] border-none bg-transparent px-[5px] py-0.5 font-mono text-[10px] text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-secondary)] hover:text-[var(--color-foreground)]"
                   >
@@ -1066,7 +1140,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                             selectFirstFiltered()
                           }
                         }}
-                        placeholder="Filter models…"
+                        placeholder={t('chat.model.filter')}
                         className="flex-1 border-none bg-transparent text-[13px] text-[var(--color-foreground)] outline-none"
                       />
                       <kbd className="rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-muted)] px-[5px] py-px font-mono text-[10px] text-[var(--color-muted-foreground)]">/</kbd>
@@ -1075,16 +1149,16 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                     {/* Pinned current row */}
                     {providerName && modelName && (
                       <div className="flex items-center gap-2.5 border-b border-[var(--color-border)] px-3 py-2">
-                        <CheckCircleIcon className="h-[17px] w-[17px] shrink-0 text-[var(--color-primary)]" title="Current model" />
+                        <CheckCircleIcon className="h-[17px] w-[17px] shrink-0 text-[var(--color-primary)]" title={t('chat.model.current')} />
                         <ProviderIcon provider={providerName} custom={providerInfoFor(providerName)?.custom} size={22} />
                         <span className="flex min-w-0 flex-1 flex-col">
                           <span className="truncate text-[12.5px] text-[var(--color-foreground)]">{getModelDisplayName(providerName, modelName)}</span>
                           <span className="mt-px truncate font-mono text-[10px] text-[var(--color-muted-foreground)]">{modelSubline(modelName, currentModelInfo)}</span>
                         </span>
                         <span className="inline-flex shrink-0 items-center gap-1.5">
-                          {currentModelInfo?.reasoning && <SparklesIcon className="h-[15px] w-[15px]" title="Reasoning" strokeWidth={1.9} />}
-                          {currentModelInfo?.tool_call && <WrenchScrewdriverIcon className="h-[15px] w-[15px]" title="Tool use" strokeWidth={1.9} />}
-                          {currentModelInfo?.image_support && <PhotoIcon className="h-[15px] w-[15px]" title="Image input" strokeWidth={1.9} />}
+                          {currentModelInfo?.reasoning && <SparklesIcon className="h-[15px] w-[15px]" title={t('chat.model.reasoning')} strokeWidth={1.9} />}
+                          {currentModelInfo?.tool_call && <WrenchScrewdriverIcon className="h-[15px] w-[15px]" title={t('chat.model.tools')} strokeWidth={1.9} />}
+                          {currentModelInfo?.image_support && <PhotoIcon className="h-[15px] w-[15px]" title={t('chat.model.images')} strokeWidth={1.9} />}
                         </span>
                       </div>
                     )}
@@ -1095,7 +1169,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                       {favoriteModelRefs.length > 0 && (
                         <>
                           <div className="flex items-center gap-2 px-2 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.06em] text-[var(--color-muted-foreground)]">
-                            Favorites
+                            {t('chat.model.favorites')}
                             <span className="font-mono font-normal normal-case tracking-normal opacity-70">{favoriteModelRefs.length}</span>
                           </div>
                           {favoriteModelRefs.map((r) => {
@@ -1113,9 +1187,9 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                                   <span className="mt-px truncate font-mono text-[10px] text-[var(--color-muted-foreground)]">{modelSubline(r.model, info)}</span>
                                 </span>
                                 <span className="inline-flex shrink-0 items-center gap-1.5">
-                                  {info?.reasoning && <SparklesIcon className="h-[15px] w-[15px]" title="Reasoning" strokeWidth={1.9} />}
-                                  {info?.tool_call && <WrenchScrewdriverIcon className="h-[15px] w-[15px]" title="Tool use" strokeWidth={1.9} />}
-                                  {info?.image_support && <PhotoIcon className="h-[15px] w-[15px]" title="Image input" strokeWidth={1.9} />}
+                                  {info?.reasoning && <SparklesIcon className="h-[15px] w-[15px]" title={t('chat.model.reasoning')} strokeWidth={1.9} />}
+                                  {info?.tool_call && <WrenchScrewdriverIcon className="h-[15px] w-[15px]" title={t('chat.model.tools')} strokeWidth={1.9} />}
+                                  {info?.image_support && <PhotoIcon className="h-[15px] w-[15px]" title={t('chat.model.images')} strokeWidth={1.9} />}
                                 </span>
                                 <StarIconSolid
                                   className="h-3.5 w-3.5 shrink-0 text-[var(--color-primary)]"
@@ -1158,13 +1232,13 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                                   <span className="mt-px truncate font-mono text-[10px] text-[var(--color-muted-foreground)]">{modelSubline(m.id, m)}</span>
                                 </span>
                                 {m.recommended && (
-                                  <span className="shrink-0 rounded-[var(--radius-xs)] border border-[var(--color-border)] bg-[var(--neutral-wash-strong)] px-1.5 py-px text-[10px] font-semibold text-[var(--color-foreground)]">Recommended</span>
+                                  <span className="shrink-0 rounded-[var(--radius-xs)] border border-[var(--color-border)] bg-[var(--neutral-wash-strong)] px-1.5 py-px text-[10px] font-semibold text-[var(--color-foreground)]">{t('common.recommended')}</span>
                                 )}
                                 <span className="inline-flex shrink-0 items-center gap-1.5">
-                                  {m.reasoning && <SparklesIcon className="h-[15px] w-[15px]" title="Reasoning" strokeWidth={1.9} />}
-                                  {m.tool_call && <WrenchScrewdriverIcon className="h-[15px] w-[15px]" title="Tool use" strokeWidth={1.9} />}
-                                  {m.image_support && <PhotoIcon className="h-[15px] w-[15px]" title="Image input" strokeWidth={1.9} />}
-                                  {m.image_support === false && <PhotoIcon className="h-[15px] w-[15px] text-[var(--color-warning-fg)]" title="No image input" strokeWidth={1.9} />}
+                                  {m.reasoning && <SparklesIcon className="h-[15px] w-[15px]" title={t('chat.model.reasoning')} strokeWidth={1.9} />}
+                                  {m.tool_call && <WrenchScrewdriverIcon className="h-[15px] w-[15px]" title={t('chat.model.tools')} strokeWidth={1.9} />}
+                                  {m.image_support && <PhotoIcon className="h-[15px] w-[15px]" title={t('chat.model.images')} strokeWidth={1.9} />}
+                                  {m.image_support === false && <PhotoIcon className="h-[15px] w-[15px] text-[var(--color-warning-fg)]" title={t('chat.model.noImageInput')} strokeWidth={1.9} />}
                                 </span>
                                 {active && <CheckIcon className="h-3.5 w-3.5 shrink-0 text-[var(--color-primary)]" strokeWidth={2} />}
                                 <StarIcon
@@ -1181,7 +1255,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
 
                       {pickerProviders.length === 0 && (
                         <div className="px-2 py-5 text-center text-[13px] text-[var(--color-muted-foreground)]">
-                          {modelFilter ? 'No matching models' : 'No models available'}
+                          {modelFilter ? t('chat.model.noMatch') : t('chat.model.none')}
                         </div>
                       )}
                     </div>
@@ -1194,7 +1268,7 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                         className="flex w-full items-center gap-2 rounded-[var(--radius-md)] border-none bg-transparent px-2 py-1.5 text-left text-xs text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)]"
                       >
                         <SquaresPlusIcon className="h-3.5 w-3.5" />
-                        Manage models
+                        {t('chat.model.manage')}
                       </button>
                     </div>
                   </div>
@@ -1205,12 +1279,12 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
               {isRunning && (
                 <button
                   type="button"
-                  title={queued.length > 0 ? 'Stop and send next' : 'Stop agent'}
+                  title={queued.length > 0 ? t('chat.stopAndNext') : t('chat.stopAgent')}
                   onClick={() => actions.stop()}
                   className="flex shrink-0 items-center gap-[5px] whitespace-nowrap rounded-[var(--radius-lg)] border-none bg-[var(--color-destructive)] px-3 py-[5px] text-xs font-medium text-[var(--color-on-destructive)]"
                 >
                   <StopIcon className="h-3.5 w-3.5" />
-                  Stop
+                  {t('chat.stop')}
                 </button>
               )}
 
@@ -1219,12 +1293,12 @@ export function ChatInput({ onSent, pickerPlacement = 'top', elevated = false }:
                 <button
                   type="button"
                   disabled={!canSend}
-                  aria-label={isRunning ? 'Queue message' : 'Send message'}
+                  aria-label={isRunning ? t('chat.queue') : t('chat.send')}
                   onClick={send}
                   className="flex shrink-0 items-center gap-[5px] whitespace-nowrap rounded-[var(--radius-lg)] border-none bg-[var(--color-primary)] px-3 py-[5px] text-xs font-medium text-[var(--color-on-primary)] transition-[opacity,transform] disabled:cursor-not-allowed disabled:opacity-45 enabled:hover:opacity-90"
                 >
                   <PaperAirplaneIcon className="h-3.5 w-3.5" />
-                  {isRunning ? 'Queue' : 'Send'}
+                  {isRunning ? t('chat.queue') : t('chat.send')}
                 </button>
               )}
             </div>
@@ -1370,6 +1444,7 @@ function ManageModelsDialog({
   onClose,
   onToggle,
 }: ManageModelsDialogProps) {
+  const { t } = useTranslation()
   return (
     <div
       className="fixed inset-0 z-[var(--z-modal)] flex items-center justify-center bg-[var(--backdrop)]"
@@ -1379,7 +1454,7 @@ function ManageModelsDialog({
       <div
         role="dialog"
         aria-modal="true"
-        aria-label="Manage models"
+        aria-label={t('chat.model.manageTitle')}
         onClick={(e) => e.stopPropagation()}
         className="m-4 flex max-h-[70vh] min-w-0 flex-col overflow-hidden rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-lg)]"
         style={{ width: 'min(560px, 94vw)' }}
@@ -1390,14 +1465,14 @@ function ManageModelsDialog({
             <SquaresPlusIcon className="h-4 w-4" />
           </div>
           <div className="min-w-0 flex-1">
-            <h3 className="m-0 text-sm font-semibold tracking-[-0.01em] text-[var(--color-foreground)]">Manage models</h3>
+            <h3 className="m-0 text-sm font-semibold tracking-[-0.01em] text-[var(--color-foreground)]">{t('chat.model.manageTitle')}</h3>
             <p className="mt-0.5 text-[11.5px] leading-[1.45] text-[var(--color-muted-foreground)]">
-              Toggle which models appear in the picker.
+              {t('chat.model.toggleVisibility')}.
             </p>
           </div>
           <button
             type="button"
-            aria-label="Close"
+            aria-label={t('common.close')}
             onClick={onClose}
             className="ml-auto grid h-7 w-7 shrink-0 place-items-center rounded-[var(--radius-md)] border border-transparent bg-transparent text-[var(--color-muted-foreground)] transition-colors hover:border-[var(--color-border)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
           >
@@ -1412,7 +1487,7 @@ function ManageModelsDialog({
             <input
               value={filter}
               onChange={(e) => onFilter(e.target.value)}
-              placeholder="Filter models…"
+              placeholder={t('chat.model.filter')}
               className="flex-1 border-none bg-transparent text-[12.5px] text-[var(--color-foreground)] outline-none"
             />
           </div>
@@ -1442,13 +1517,13 @@ function ManageModelsDialog({
                       <span className="mt-px font-mono text-[10px] text-[var(--color-muted-foreground)]">{modelSubline(m.id, m)}</span>
                     </span>
                     {m.recommended && (
-                      <span className="shrink-0 rounded-[var(--radius-xs)] border border-[var(--color-border)] bg-[var(--neutral-wash-strong)] px-1.5 py-px text-[10px] font-semibold text-[var(--color-foreground)]">Recommended</span>
+                      <span className="shrink-0 rounded-[var(--radius-xs)] border border-[var(--color-border)] bg-[var(--neutral-wash-strong)] px-1.5 py-px text-[10px] font-semibold text-[var(--color-foreground)]">{t('common.recommended')}</span>
                     )}
                     <button
                       type="button"
                       role="switch"
                       aria-checked={off ? 'false' : 'true'}
-                      aria-label={off ? 'Enable model' : 'Disable model'}
+                      aria-label={off ? t('common.enable') : t('common.disable')}
                       onClick={() => onToggle(p.id, m.id, off)}
                       className="relative h-[18px] w-8 shrink-0 cursor-pointer rounded-[var(--radius-pill)] border-none bg-[var(--color-border)] transition-colors"
                       style={off ? undefined : { background: 'var(--color-primary)' }}
@@ -1465,7 +1540,7 @@ function ManageModelsDialog({
           ))}
           {providers.length === 0 && (
             <div className="py-8 text-center text-[13px] text-[var(--color-muted-foreground)]">
-              {filter ? 'No matching models' : 'No models available'}
+              {filter ? t('chat.model.noMatch') : t('chat.model.none')}
             </div>
           )}
         </div>
@@ -1473,7 +1548,7 @@ function ManageModelsDialog({
         {/* Footer */}
         <div className="flex items-center justify-between border-t border-[var(--color-border)] bg-[var(--color-muted)] px-[18px] py-3">
           <span className="text-[11px] text-[var(--color-muted-foreground)]">
-            {visibleCount} visible of {totalCount} models
+            {t('chat.model.visibleCount', { visible: visibleCount, total: totalCount })}
           </span>
           <div className="flex gap-2">
             <button
@@ -1481,7 +1556,7 @@ function ManageModelsDialog({
               onClick={onClose}
               className="inline-flex h-[30px] items-center gap-1.5 rounded-[var(--radius-md)] border border-transparent bg-[var(--color-primary)] px-3.5 text-xs font-medium text-[var(--color-on-primary)] transition-colors hover:bg-[color-mix(in_srgb,var(--color-primary)_88%,var(--color-background))]"
             >
-              Done
+              {t('common.done')}
             </button>
           </div>
         </div>

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -76,8 +76,9 @@ export function ChatView({ readOnly }: ChatViewProps) {
             {subtitleAfter}
           </p>
         </div>
-        {/* Centered elevated composer */}
-        <div className="welcome-composer w-full max-w-2xl px-5">
+        {/* Centered elevated composer. z-[2] keeps its upward-opening menus
+            (model picker, slash palette) above the welcome hero text. */}
+        <div className="welcome-composer z-[2] w-full max-w-2xl px-5">
           <ChatInput elevated pickerPlacement="bottom" onSent={() => { /* timeline auto-follows */ }} />
         </div>
         {/* Bottom half balances the center */}
@@ -95,7 +96,8 @@ export function ChatView({ readOnly }: ChatViewProps) {
       <div className="chat-content-layer min-h-0 flex-1">
         <Thread overscanBottom={28} />
       </div>
-      <div className="chat-content-layer chat-col relative">
+      {/* z-[2] keeps the composer’s upward-opening menus above the thread layer. */}
+      <div className="chat-content-layer chat-col relative z-[2]">
         {/* Goal pill floats behind the composer; composer sits on top (higher z-index). */}
         <GoalBanner />
         <ChatInput onSent={() => { /* timeline auto-follows via useStreamFollow */ }} />

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -95,7 +95,8 @@ export function ChatView({ readOnly }: ChatViewProps) {
       <div className="chat-content-layer min-h-0 flex-1">
         <Thread overscanBottom={28} />
       </div>
-      <div className="chat-content-layer chat-col">
+      <div className="chat-content-layer chat-col relative">
+        {/* Goal pill floats behind the composer; composer sits on top (higher z-index). */}
         <GoalBanner />
         <ChatInput onSent={() => { /* timeline auto-follows via useStreamFollow */ }} />
       </div>

--- a/web/src/components/ComputerShotPiP.tsx
+++ b/web/src/components/ComputerShotPiP.tsx
@@ -1,0 +1,145 @@
+/**
+ * ComputerShotPiP — Codex-style picture-in-picture for computer use.
+ *
+ * Floats top-right (under the TopBar) and always shows the LATEST screenshot
+ * the agent captured in this session, so the user can watch what the agent is
+ * seeing without scrolling the thread. Derives its data from the chat timeline:
+ * any tool result whose output carries an `image_ref=/api/computer/shots/…`
+ * marker (today: computer_screenshot) — no extra WS channel needed, so it also
+ * works when replaying a historical session.
+ *
+ * The card collapses to a small pill (Codex's 显示/Show toggle). "Open full"
+ * expands the image IN PLACE inside the card (wider card, taller frame) rather
+ * than navigating to a new tab — the raw link used to be a no-op target in the
+ * Tauri shell and a jarring context switch in the browser. Expired shots (the
+ * backend shot store is TTL-bound) render a note instead of a broken img.
+ */
+
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  ArrowsPointingInIcon,
+  ArrowsPointingOutIcon,
+  ChevronUpIcon,
+  ComputerDesktopIcon,
+} from '@heroicons/react/24/outline'
+import { useAppSelector } from '../app/hooks'
+import { apiBase } from '../lib/apiBase'
+
+const SHOT_RE = /image_ref=(\/api\/computer\/shots\/[\w-]+\.png)/
+
+export function ComputerShotPiP() {
+  const { t } = useTranslation()
+  const timeline = useAppSelector((s) => s.chat.timeline)
+  const [collapsed, setCollapsed] = useState(false)
+  /** In-card enlarged view of the latest shot (replaces external-tab open). */
+  const [expanded, setExpanded] = useState(false)
+  /** ref that failed to load — keyed so a NEW shot clears the error state. */
+  const [brokenRef, setBrokenRef] = useState('')
+
+  // Latest shot wins; count every shot so the header can show "n shots".
+  const latest = useMemo(() => {
+    let ref = ''
+    let ts = 0
+    let count = 0
+    for (const item of timeline) {
+      if (item.kind !== 'tool') continue
+      const m = (item.data.output ?? '').match(SHOT_RE)
+      if (m) {
+        count++
+        ref = m[1]
+        ts = item.data.timestamp
+      }
+    }
+    return ref ? { ref, ts, count } : null
+  }, [timeline])
+
+  if (!latest) return null
+
+  const src = `${apiBase}${latest.ref}`
+  const broken = brokenRef === latest.ref
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        onClick={() => setCollapsed(false)}
+        title={t('pip.expand')}
+        className="fixed right-[14px] top-[46px] z-[45] inline-flex items-center gap-1.5 rounded-[var(--radius-pill)] border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 text-[11px] font-medium text-[var(--color-foreground)] shadow-[var(--shadow-md)] transition-colors hover:bg-[var(--color-muted)]"
+      >
+        <ComputerDesktopIcon className="h-3.5 w-3.5 text-[var(--color-primary)]" />
+        {t('pip.computerUse')}
+        <span className="font-mono text-[10px] text-[var(--color-muted-foreground)]">{latest.count}</span>
+      </button>
+    )
+  }
+
+  const ExpandIcon = expanded ? ArrowsPointingInIcon : ArrowsPointingOutIcon
+
+  return (
+    <div
+      className="fixed right-[14px] top-[46px] z-[45] overflow-hidden rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-lg)] transition-[width] duration-200"
+      style={{ width: expanded ? 520 : 240 }}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-1.5 border-b border-[var(--color-border)] px-2.5 py-1.5">
+        <ComputerDesktopIcon className="h-3.5 w-3.5 shrink-0 text-[var(--color-primary)]" />
+        <span className="min-w-0 flex-1 truncate text-[11px] font-semibold text-[var(--color-foreground)]">
+          {t('pip.computerUse')}
+        </span>
+        <span className="shrink-0 rounded-[var(--radius-pill)] bg-[var(--neutral-wash)] px-1.5 py-px font-mono text-[10px] text-[var(--color-muted-foreground)]">
+          {t('pip.shots', { n: latest.count })}
+        </span>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          title={expanded ? t('pip.shrink') : t('pip.openFull')}
+          aria-label={expanded ? t('pip.shrink') : t('pip.openFull')}
+          className="grid h-5 w-5 shrink-0 place-items-center rounded-[var(--radius-sm)] text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
+        >
+          <ExpandIcon className="h-3 w-3" />
+        </button>
+        <button
+          type="button"
+          onClick={() => setCollapsed(true)}
+          title={t('pip.collapse')}
+          className="grid h-5 w-5 shrink-0 place-items-center rounded-[var(--radius-sm)] text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
+        >
+          <ChevronUpIcon className="h-3 w-3" />
+        </button>
+      </div>
+
+      {/* Body — latest frame; click to toggle the in-card enlarged view. */}
+      {broken ? (
+        <div className="grid h-[120px] place-items-center px-3 text-center text-[11px] text-[var(--color-muted-foreground)]">
+          {t('pip.unavailable')}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          title={expanded ? t('pip.shrink') : t('pip.openFull')}
+          className="block w-full cursor-zoom-in border-none bg-transparent p-0"
+          style={{ cursor: expanded ? 'zoom-out' : 'zoom-in' }}
+        >
+          <img
+            key={latest.ref}
+            src={src}
+            alt={t('pip.computerUse')}
+            onError={() => setBrokenRef(latest.ref)}
+            className="w-full object-cover object-top"
+            style={{ maxHeight: expanded ? 'min(70vh, 460px)' : 160 }}
+          />
+        </button>
+      )}
+
+      {/* Footer — capture time */}
+      <div className="flex items-center justify-between px-2.5 py-1 text-[10px] text-[var(--color-muted-foreground)]">
+        <span>{t('pip.latest')}</span>
+        <span className="font-mono">
+          {latest.ts > 0 ? new Date(latest.ts).toLocaleTimeString() : '—'}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/GoalBanner.tsx
+++ b/web/src/components/GoalBanner.tsx
@@ -1,45 +1,100 @@
 /**
- * GoalBanner — active goal display (set via /goal or the Goal toggle).
- * Ported from web/src/components/GoalBanner.vue: a rounded inset card with
- * target/status tint, status label, objective, and clear button — not a full-width
- * border-b strip.
+ * GoalBanner — floating pill behind the composer.
+ *
+ *   ┌──────────────────────────────────────────────────────────────┐
+ *   │ [icon] 进行中 · 目标文本截断…      3/5 ▰▰▰▱ 18h 34m 52s ✎ 🗑 › │  ← floating pill, z-index below composer
+ *   └──────────────────────────────────────────────────────────────┘
+ *   ╭──────────────────────────────────────────────────────────────╮
+ *   │                                                              │
+ *   │  Composer (on top of pill)                                   │
+ *   │                                                              │
+ *   ╰──────────────────────────────────────────────────────────────╯
+ *
+ * The pill overlaps the composer by ~14px; the composer sits on top
+ * (higher z-index) so the pill looks like a tag peeking from behind.
+ * Status icon is a simple line icon with a tiny active dot; the expand
+ * arrow points right (ChevronRight) and rotates down when expanded.
  */
 
-import { ViewfinderCircleIcon } from '@heroicons/react/24/outline'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
+import {
+  CheckCircleIcon,
+  ChevronRightIcon,
+  ExclamationTriangleIcon,
+  PencilSquareIcon,
+  TrashIcon,
+  ViewfinderCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline'
 import { useAppDispatch, useAppSelector } from '../app/hooks'
 import { chatActions } from '../app/store'
 import { api } from '../lib/api'
+import type { GoalStatus } from '../lib/types'
+
+// ─── Status presentation ────────────────────────────────────────────────────
+
+const STATUS_STYLE: Record<GoalStatus, { labelKey: string; Icon: typeof ViewfinderCircleIcon }> = {
+  active: {
+    labelKey: 'goal.status.active',
+    Icon: ViewfinderCircleIcon,
+  },
+  complete: {
+    labelKey: 'goal.status.completed',
+    Icon: CheckCircleIcon,
+  },
+  blocked: {
+    labelKey: 'goal.status.blocked',
+    Icon: ExclamationTriangleIcon,
+  },
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
 
 export function GoalBanner() {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const goal = useAppSelector((s) => s.chat.goal)
+  const todos = useAppSelector((s) => s.chat.todos)
+  const [expanded, setExpanded] = useState(false)
+  const [editing, setEditing] = useState(false)
+
+  // Live elapsed clock — 1s tick only while the goal is active.
+  const isActive = goal?.status === 'active'
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  useEffect(() => {
+    if (!isActive) return
+    const id = window.setInterval(() => setNowMs(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [isActive])
+
+  const { doneCount, totalCount, progressPct } = useMemo(() => {
+    const done = todos.filter((todo) => todo.status === 'completed' || todo.status === 'cancelled').length
+    const total = todos.length
+    return {
+      doneCount: done,
+      totalCount: total,
+      progressPct: total > 0 ? Math.round((done / total) * 100) : 0,
+    }
+  }, [todos])
+
   if (!goal) return null
 
-  const statusColor =
-    goal.status === 'complete'
-      ? 'var(--color-success-fg)'
-      : goal.status === 'blocked'
-        ? 'var(--color-destructive, var(--color-error-fg))'
-        : 'var(--color-accent-neutral)'
+  const style = STATUS_STYLE[goal.status] ?? STATUS_STYLE.active
+  const statusLabel = STATUS_STYLE[goal.status]
+    ? t(style.labelKey)
+    : String(goal.status || '').replace(/_/g, ' ')
 
-  const statusLabel =
-    goal.status === 'active'
-      ? t('goal.status.active')
-      : goal.status === 'complete'
-        ? t('goal.status.completed')
-        : goal.status === 'blocked'
-          ? t('goal.status.blocked')
-          : String(goal.status || '').replace(/_/g, ' ')
+  const startMs = (goal.created_at ?? 0) * 1000
+  const hasTimes = startMs > 0
+  const endMs = isActive ? nowMs : (goal.updated_at ?? 0) * 1000
+  const elapsedSec = hasTimes ? Math.max(0, Math.floor((endMs - startMs) / 1000)) : 0
+  const elapsedLabel = hasTimes ? formatElapsed(elapsedSec, t) : ''
 
   const used = goal.tokens_used ?? 0
   const tokensLabel =
-    used <= 0
-      ? ''
-      : used < 1000
-        ? t('goal.tokens', { used })
-        : t('goal.tokensK', { k: (used / 1000).toFixed(1) })
+    used <= 0 ? '' : used < 1000 ? t('goal.tokens', { used }) : t('goal.tokensK', { k: (used / 1000).toFixed(1) })
 
   async function clear() {
     try {
@@ -50,39 +105,312 @@ export function GoalBanner() {
     dispatch(chatActions.setGoal(null))
   }
 
+  const showProgress = isActive && totalCount > 0
+  const statusColor =
+    goal.status === 'complete'
+      ? 'var(--color-success-fg)'
+      : goal.status === 'blocked'
+        ? 'var(--color-error-fg)'
+        : 'var(--color-foreground)'
+
   return (
     <div
-      className="mt-2 flex items-start gap-2 rounded-md border px-3 py-2"
-      style={{ borderColor: 'var(--color-border)', backgroundColor: 'var(--color-secondary)' }}
+      className={`goal-pill relative mx-auto -mb-3.5 w-[calc(100%-12px)] rounded-2xl border px-3.5 py-3 pb-3.5 transition-[box-shadow,transform,z-index] hover:-translate-y-px ${expanded ? 'z-[3]' : 'z-[1]'}`}
+      style={{
+        background: 'var(--color-surface)',
+        borderColor: 'color-mix(in srgb, var(--color-border) 55%, transparent)',
+        boxShadow: '0 4px 14px -4px rgba(24, 20, 16, 0.12)',
+      }}
     >
-      <ViewfinderCircleIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" style={{ color: statusColor }} />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span
-            className="text-[10px] font-semibold uppercase tracking-wide"
-            style={{ color: statusColor }}
-          >
+      {/* Collapsed row */}
+      <div
+        className="flex cursor-pointer items-center gap-2"
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setExpanded((v) => !v)
+          }
+        }}
+      >
+        {/* Leading icon + active dot */}
+        <span className="relative shrink-0 text-[var(--color-muted-foreground)]">
+          <style.Icon className="h-[15px] w-[15px]" strokeWidth={1.8} />
+          {isActive && (
+            <span
+              aria-hidden="true"
+              className="absolute -right-1 -top-1 h-[6px] w-[6px] animate-pulse rounded-full motion-reduce:animate-none"
+              style={{ background: 'var(--color-primary)', border: '1.5px solid var(--color-surface)' }}
+            />
+          )}
+        </span>
+
+        {/* Status label + objective (single truncated line) */}
+        <span className="min-w-0 flex-1 truncate text-[12.5px] leading-none">
+          <span className="mr-1.5 font-semibold" style={{ color: statusColor }}>
             {statusLabel}
           </span>
-          {tokensLabel && (
-            <span className="text-[10px]" style={{ color: 'var(--color-muted-foreground)' }}>
-              {tokensLabel}
+          <span
+            className={
+              goal.status === 'active'
+                ? 'text-[var(--color-foreground)]'
+                : 'text-[var(--color-muted-foreground)]'
+            }
+          >
+            {goal.objective}
+          </span>
+        </span>
+
+        {/* Inline todo progress */}
+        {showProgress && (
+          <span className="inline-flex shrink-0 items-center gap-1.5">
+            <span className="font-mono text-[10px] tabular-nums text-[var(--color-muted-foreground)]">
+              {doneCount}/{totalCount}
             </span>
-          )}
-        </div>
-        <div className="mt-0.5 break-words text-xs" style={{ color: 'var(--color-foreground)' }}>
-          {goal.objective}
+            <span
+              className="h-[3px] w-11 overflow-hidden rounded-full"
+              style={{ background: 'color-mix(in srgb, var(--color-foreground) 10%, transparent)' }}
+            >
+              <span
+                className="block h-full rounded-full transition-[width] duration-500 ease-out motion-reduce:transition-none"
+                style={{ width: `${progressPct}%`, background: 'var(--color-primary)' }}
+              />
+            </span>
+          </span>
+        )}
+
+        {/* Elapsed */}
+        {elapsedLabel && (
+          <span
+            className="shrink-0 font-mono text-[10px] tabular-nums text-[var(--color-muted-foreground)]"
+            title={t('goal.elapsed')}
+          >
+            {elapsedLabel}
+          </span>
+        )}
+
+        {/* Row actions — stop propagation so they don't toggle the pane */}
+        <span className="flex shrink-0 items-center gap-0.5">
+          <button
+            type="button"
+            title={t('goal.edit')}
+            aria-label={t('goal.edit')}
+            onClick={(e) => {
+              e.stopPropagation()
+              setEditing(true)
+            }}
+            className="grid h-[22px] w-[22px] place-items-center rounded-md border-none bg-transparent text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
+          >
+            <PencilSquareIcon className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            title={t('goal.clearGoal')}
+            aria-label={t('goal.clearGoal')}
+            onClick={(e) => {
+              e.stopPropagation()
+              void clear()
+            }}
+            className="grid h-[22px] w-[22px] place-items-center rounded-md border-none bg-transparent text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-error-fg)]"
+          >
+            <TrashIcon className="h-3.5 w-3.5" />
+          </button>
+          <span
+            className={`grid h-[22px] w-[22px] place-items-center text-[var(--color-muted-foreground)] transition-transform duration-200 ${expanded ? 'rotate-90' : ''}`}
+          >
+            <ChevronRightIcon className="h-3.5 w-3.5" />
+          </span>
+        </span>
+      </div>
+
+      {/* Expanded detail */}
+      <div
+        className={`grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${
+          expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div
+            className="border-t px-0.5 pb-1 pt-2.5"
+            style={{ borderColor: 'color-mix(in srgb, var(--color-border) 60%, transparent)' }}
+          >
+            <div className="max-h-[180px] overflow-y-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--color-foreground)]">
+              {goal.objective}
+            </div>
+
+            {/* Meta line */}
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-[var(--color-muted-foreground)]">
+              {hasTimes && (
+                <>
+                  <span>
+                    {t('goal.started')} {new Date(startMs).toLocaleString()}
+                  </span>
+                  <span>
+                    {t('goal.elapsed')} {elapsedLabel}
+                  </span>
+                </>
+              )}
+              {tokensLabel && <span className="font-mono">{tokensLabel}</span>}
+            </div>
+
+            {/* Labeled actions */}
+            <div className="mt-2.5 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 text-[11px] font-medium text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)]"
+              >
+                <PencilSquareIcon className="h-3.5 w-3.5" />
+                {t('goal.edit')}
+              </button>
+              <button
+                type="button"
+                onClick={() => void clear()}
+                className="inline-flex h-7 items-center gap-1.5 rounded-md border-none bg-transparent px-2.5 text-[11px] font-medium text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-error-fg)]"
+              >
+                <TrashIcon className="h-3.5 w-3.5" />
+                {t('goal.clear')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setExpanded(false)}
+                className="ml-auto inline-flex h-7 items-center gap-1 rounded-md border-none bg-transparent px-2 text-[11px] text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
+              >
+                <ChevronRightIcon className="h-3.5 w-3.5 rotate-90" />
+                {t('goal.collapse')}
+              </button>
+            </div>
+          </div>
         </div>
       </div>
-      <button
-        type="button"
-        className="goal-clear shrink-0 cursor-pointer rounded px-2 py-1 text-[10px] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
-        style={{ backgroundColor: 'var(--color-background)', color: 'var(--color-muted-foreground)' }}
-        title={t('goal.clearGoal')}
-        onClick={() => void clear()}
-      >
-        {t('goal.clear')}
-      </button>
+
+      {editing && <EditGoalDialog initial={goal.objective} onClose={() => setEditing(false)} />}
     </div>
   )
+}
+
+// ─── Edit dialog ────────────────────────────────────────────────────────────
+
+function EditGoalDialog({ initial, onClose }: { initial: string; onClose: () => void }) {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const [text, setText] = useState(initial)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+    textareaRef.current?.setSelectionRange(textareaRef.current.value.length, textareaRef.current.value.length)
+  }, [])
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const canSave = text.trim().length > 0 && !saving
+
+  async function save() {
+    if (!canSave) return
+    setSaving(true)
+    setError('')
+    try {
+      // start=false: editing the objective must not kick off another agent run.
+      const goal = await api.setGoal(text.trim(), false)
+      dispatch(chatActions.setGoal(goal))
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('goal.saveFailed'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[var(--z-modal)] flex items-center justify-center bg-[var(--backdrop)]"
+      style={{ backdropFilter: 'blur(6px)', WebkitBackdropFilter: 'blur(6px)' }}
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('goal.editTitle')}
+        onClick={(e) => e.stopPropagation()}
+        className="m-4 flex min-w-0 flex-col overflow-hidden rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-lg)]"
+        style={{ width: 'min(520px, 94vw)' }}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 border-b border-[var(--color-border)] px-[18px] py-4">
+          <div className="grid h-[30px] w-[30px] shrink-0 place-items-center rounded-[var(--radius-md)] bg-[var(--accent-wash)] text-[var(--color-primary)]">
+            <ViewfinderCircleIcon className="h-4 w-4" />
+          </div>
+          <h3 className="m-0 flex-1 text-sm font-semibold tracking-[-0.01em] text-[var(--color-foreground)]">
+            {t('goal.editTitle')}
+          </h3>
+          <button
+            type="button"
+            aria-label={t('common.close')}
+            onClick={onClose}
+            className="grid h-7 w-7 shrink-0 place-items-center rounded-[var(--radius-md)] border border-transparent bg-transparent text-[var(--color-muted-foreground)] transition-colors hover:border-[var(--color-border)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-[18px] py-4">
+          <textarea
+            ref={textareaRef}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={6}
+            className="w-full resize-y rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-muted)] px-3 py-2.5 text-[13px] leading-relaxed text-[var(--color-foreground)] outline-none transition-colors focus:border-[var(--color-primary)]"
+          />
+          <p className="mt-2 text-[11px] leading-relaxed text-[var(--color-muted-foreground)]">
+            {t('chat.goalHint.replace')}
+          </p>
+          {error && <p className="mt-2 text-[11px] text-[var(--color-error-fg)]">{error}</p>}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t border-[var(--color-border)] bg-[var(--color-muted)] px-[18px] py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-[30px] items-center rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3.5 text-xs font-medium text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)]"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            disabled={!canSave}
+            onClick={() => void save()}
+            className="inline-flex h-[30px] items-center gap-1.5 rounded-[var(--radius-md)] border border-transparent bg-[var(--color-primary)] px-3.5 text-xs font-medium text-[var(--color-on-primary)] transition-colors enabled:hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
+          >
+            {saving ? t('common.loading') : t('common.save')}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function formatElapsed(totalSec: number, t: (key: string, opts?: Record<string, unknown>) => string): string {
+  const s = Math.max(0, totalSec)
+  if (s < 60) return t('chat.durationSeconds', { n: s })
+  const m = Math.floor(s / 60)
+  if (m < 60) return t('chat.durationMinutes', { m, s: s % 60 })
+  const h = Math.floor(m / 60)
+  return t('goal.durationHours', { h, m: m % 60 })
 }

--- a/web/src/components/ProjectHeader.tsx
+++ b/web/src/components/ProjectHeader.tsx
@@ -4,11 +4,13 @@
  */
 
 import { Cog6ToothIcon } from '@heroicons/react/24/outline'
+import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from '../app/hooks'
 import { uiActions } from '../app/store'
 import { ThemeToggle } from './ThemeToggle'
 
 export function ProjectHeader() {
+  const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const projectPath = useAppSelector((s) => s.session.projectPath)
   const provider = useAppSelector((s) => s.model.providerName)
@@ -37,14 +39,14 @@ export function ProjectHeader() {
           type="button"
           onClick={() => dispatch(uiActions.setSettingsOpen(true))}
           className="rounded-[var(--radius-md)] p-1.5 text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--neutral-wash-soft)] hover:text-[var(--color-foreground)]"
-          aria-label="Settings"
-          title="Settings (⌘,)"
+          aria-label={t('nav.settings')}
+          title={t('nav.settingsWithShortcut')}
         >
           <Cog6ToothIcon className="h-4 w-4" />
         </button>
         <span
           className={`h-2 w-2 rounded-full ${wsConnected ? 'bg-[var(--color-success)]' : 'bg-[var(--color-muted-foreground)]'}`}
-          title={wsConnected ? 'connected' : 'disconnected'}
+          title={wsConnected ? t('topbar.status.connected') : t('topbar.status.disconnected')}
         />
       </div>
     </header>

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   ArrowPathIcon,
   CheckCircleIcon,
@@ -37,13 +38,15 @@ interface Props {
   onSwitchTab: (tab: Tab) => void
 }
 
-const TAB_LABELS: Record<Tab, string> = {
-  plan: 'Plan',
-  files: 'Files',
-  changes: 'Changes',
+/** i18n keys for the tab strip (resolved with t() at render). */
+const TAB_KEYS: Record<Tab, string> = {
+  plan: 'rightPanel.plan',
+  files: 'rightPanel.files',
+  changes: 'rightPanel.changes',
 } as const
 
 export function RightPanel({ activeTab, onClose, onSwitchTab }: Props) {
+  const { t } = useTranslation()
   // Panel width with a min/max clamp; resized via the left drag handle.
   const [panelWidth, setPanelWidth] = useState(320)
   const projectPath = useAppSelector((s) => s.session.projectPath)
@@ -80,25 +83,25 @@ export function RightPanel({ activeTab, onClose, onSwitchTab }: Props) {
       {/* Header: tab strip + close. */}
       <div className="flex h-10 shrink-0 items-center justify-between border-b border-[var(--color-border)] pl-3 pr-2">
         <div className="flex items-center gap-0.5">
-          {(['plan', 'files', 'changes'] as const).map((t) => (
+          {(['plan', 'files', 'changes'] as const).map((tab) => (
             <button
-              key={t}
+              key={tab}
               type="button"
-              onClick={() => onSwitchTab(t)}
+              onClick={() => onSwitchTab(tab)}
               className={`rounded-[var(--radius-md)] px-2.5 py-1 text-xs font-medium transition-colors ${
-                activeTab === t
+                activeTab === tab
                   ? 'bg-[var(--color-muted)] text-[var(--color-foreground)]'
                   : 'text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)]'
               }`}
             >
-              {TAB_LABELS[t]}
+              {t(TAB_KEYS[tab])}
             </button>
           ))}
         </div>
         <button
           type="button"
           onClick={onClose}
-          aria-label="Close panel"
+          aria-label={t('terminal.closePanel')}
           className="flex h-6 w-6 items-center justify-center rounded-[var(--radius-sm)] text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"
         >
           <XMarkIcon className="h-3.5 w-3.5" />
@@ -125,6 +128,7 @@ export function RightPanel({ activeTab, onClose, onSwitchTab }: Props) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 function PlanPane() {
+  const { t } = useTranslation()
   const todos = useAppSelector((s) => s.chat.todos)
   const total = todos.length
   const completed = todos.filter((t) => t.status === 'completed').length
@@ -133,7 +137,7 @@ function PlanPane() {
   return (
     <div className="flex h-full flex-col">
       <div className="flex shrink-0 items-center gap-2.5 border-b border-[var(--color-border)] px-3 py-2.5">
-        <span className="text-xs font-medium text-[var(--color-foreground)]">Plan</span>
+        <span className="text-xs font-medium text-[var(--color-foreground)]">{t('rightPanel.plan')}</span>
         <div className="h-[5px] flex-1 overflow-hidden rounded-[var(--radius-pill)] bg-[var(--color-border)]">
           <div
             className="h-full rounded-[var(--radius-pill)] bg-[var(--color-accent-neutral)] transition-[width] duration-[var(--duration-slow)] ease-out"
@@ -145,7 +149,7 @@ function PlanPane() {
         </span>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
-        {total > 0 ? <TaskList todos={todos} /> : <div className="px-2 py-4 text-center text-[13px] text-[var(--color-muted-foreground)]">No tasks yet</div>}
+        {total > 0 ? <TaskList todos={todos} /> : <div className="px-2 py-4 text-center text-[13px] text-[var(--color-muted-foreground)]">{t('rightPanel.noTasks')}</div>}
       </div>
     </div>
   )
@@ -231,6 +235,7 @@ function TaskList({ todos }: { todos: TodoItem[] }) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 function FileTreePanel() {
+  const { t } = useTranslation()
   const [items, setItems] = useState<FileItem[]>([])
   const [currentPath, setCurrentPath] = useState('')
   const [loading, setLoading] = useState(false)
@@ -249,11 +254,11 @@ function FileTreePanel() {
     } catch (err) {
       console.error('Failed to fetch files:', err)
       setItems([])
-      setDirError("Couldn't load this directory.")
+      setDirError(t('rightPanel.dirError'))
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [t])
 
   // Initial load of the workspace root (the parent keys this component on the
   // project path, so a project switch remounts + re-fetches).
@@ -275,7 +280,7 @@ function FileTreePanel() {
         setPreviewFile(result)
       } catch (err) {
         console.error('Failed to fetch file content:', err)
-        setFileError(`Couldn't open ${item.name} (it may be a binary file, too large, or unreadable).`)
+        setFileError(t('rightPanel.fileError', { name: item.name }))
       }
     }
   }
@@ -362,7 +367,7 @@ function FileTreePanel() {
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto py-1">
           {loading ? (
-            <div className="px-3 py-6 text-center text-xs text-[var(--color-muted-foreground)]">Loading…</div>
+            <div className="px-3 py-6 text-center text-xs text-[var(--color-muted-foreground)]">{t('common.loading')}</div>
           ) : dirError ? (
             <div className="px-3 py-6 text-center text-xs text-[var(--color-error-fg)]">{dirError}</div>
           ) : (
@@ -393,7 +398,7 @@ function FileTreePanel() {
                 </button>
               ))}
               {items.length === 0 && (
-                <div className="px-3 py-6 text-center text-xs text-[var(--color-muted-foreground)]">Empty directory</div>
+                <div className="px-3 py-6 text-center text-xs text-[var(--color-muted-foreground)]">{t('rightPanel.emptyDir')}</div>
               )}
             </>
           )}
@@ -410,11 +415,11 @@ function FileTreePanel() {
 
 type DiffMode = 'working' | 'staged' | 'branch' | 'session'
 
-const DIFF_MODES: { value: DiffMode; label: string }[] = [
-  { value: 'session', label: 'Session' },
-  { value: 'working', label: 'Working' },
-  { value: 'staged', label: 'Staged' },
-  { value: 'branch', label: 'Branch' },
+const DIFF_MODES: { value: DiffMode; labelKey: string }[] = [
+  { value: 'session', labelKey: 'diff.modes.session' },
+  { value: 'working', labelKey: 'diff.modes.working' },
+  { value: 'staged', labelKey: 'diff.modes.staged' },
+  { value: 'branch', labelKey: 'diff.modes.branch' },
 ]
 
 interface ParsedLine {
@@ -450,6 +455,7 @@ const LINE_STYLE: Record<ParsedLine['type'], string> = {
 }
 
 function DiffViewer() {
+  const { t } = useTranslation()
   const [entries, setEntries] = useState<DiffResponse['entries']>([])
   const [mode, setMode] = useState<DiffMode>('working')
   const [loading, setLoading] = useState(false)
@@ -471,14 +477,14 @@ function DiffViewer() {
     } catch (err) {
       console.error('Failed to fetch diff:', err)
       setEntries([])
-      setError('Failed to load changes')
+      setError(t('diff.loadError'))
     } finally {
       setLoading(false)
     }
     // selectedFile is intentionally read from state inside the callback rather
     // than captured, so we don't re-run fetch when the selection changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [t])
 
   useEffect(() => {
     void fetchDiff(mode)
@@ -494,7 +500,7 @@ function DiffViewer() {
       <div className="flex shrink-0 items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-sidebar-bg)] px-3 py-1.5">
         <div className="flex items-center gap-2">
           <span className="text-[11px] font-semibold uppercase tracking-wider text-[var(--color-muted-foreground)]">
-            Changes
+            {t('diff.changes')}
           </span>
           <div className="flex gap-0.5">
             {DIFF_MODES.map((m) => (
@@ -508,7 +514,7 @@ function DiffViewer() {
                     : 'text-[var(--color-muted-foreground)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]'
                 }`}
               >
-                {m.label}
+                {t(m.labelKey)}
               </button>
             ))}
           </div>
@@ -526,7 +532,7 @@ function DiffViewer() {
             onClick={() => void fetchDiff(mode)}
             className="cursor-pointer text-[10px] font-medium text-[var(--color-muted-foreground)] transition-colors hover:text-[var(--color-foreground)]"
           >
-            ↻ Refresh
+            {t('diff.refresh')}
           </button>
         </div>
       </div>
@@ -539,11 +545,11 @@ function DiffViewer() {
         {/* File list */}
         <div className="max-h-[30%] shrink-0 overflow-y-auto border-b border-[var(--color-border)]">
           {entries.length === 0 && !loading && (
-            <div className="py-6 text-center text-[11px] text-[var(--color-muted-foreground)]">No changes</div>
+            <div className="py-6 text-center text-[11px] text-[var(--color-muted-foreground)]">{t('diff.noChanges')}</div>
           )}
           {loading && (
             <div className="animate-pulse py-6 text-center text-[11px] text-[var(--color-muted-foreground)]">
-              Loading...
+              {t('common.loading')}
             </div>
           )}
           {entries.map((entry) => {

--- a/web/src/components/SettingsDialog.tsx
+++ b/web/src/components/SettingsDialog.tsx
@@ -1261,10 +1261,10 @@ function ProviderForm({
                       className={INPUT_SM}
                       style={{ width: '8rem' }}
                     >
-                      <option value="">Default</option>
-                      <option value="low">Low</option>
-                      <option value="medium">Medium</option>
-                      <option value="high">High</option>
+                      <option value="">{t('common.default')}</option>
+                      <option value="low">{t('common.low')}</option>
+                      <option value="medium">{t('common.medium')}</option>
+                      <option value="high">{t('common.high')}</option>
                     </select>
                   </div>
                 </div>
@@ -3823,12 +3823,13 @@ function Breakdown({
   compact: (n: number) => string
   project?: boolean
 }) {
+  const { t } = useTranslation()
   const sorted = [...shares].sort((a, b) => b.tokens - a.tokens).slice(0, 8)
   return (
     <section className={US_PANEL}>
       <div className={US_PANEL_TITLE}>{title}</div>
       <div className="space-y-1.5">
-        {sorted.length === 0 && <div className="text-[11px] text-[var(--color-muted-foreground)]">No data.</div>}
+        {sorted.length === 0 && <div className="text-[11px] text-[var(--color-muted-foreground)]">{t('settings.usageStats.noData')}</div>}
         {sorted.map((s) => (
           <div key={s.name}>
             <div className="flex items-center justify-between text-[11px]">

--- a/web/src/components/SetupView.tsx
+++ b/web/src/components/SetupView.tsx
@@ -152,7 +152,7 @@ export function SetupView() {
         onSubmit={complete}
         className="w-full max-w-md rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-[var(--shadow-md)]"
       >
-        <h1 className="text-lg font-semibold">Welcome to jcode</h1>
+        <h1 className="text-lg font-semibold">{t('setup.welcomeTitle')}</h1>
         <p className="mt-1 text-sm text-[var(--color-muted-foreground)]">
           {t('setup.selectProviderDesc')}
         </p>
@@ -169,7 +169,7 @@ export function SetupView() {
           }}
           className="mt-1 w-full rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-muted)] px-3 py-2 text-sm"
         >
-          <option value="">Select…</option>
+          <option value="">{t('setup.selectEllipsis')}</option>
           {providers.map((p) => (
             <option key={p.id} value={p.id}>
               {p.name}
@@ -223,13 +223,13 @@ export function SetupView() {
 
         {models.length > 0 && (
           <>
-            <label className="mt-3 block text-xs font-medium text-[var(--color-muted-foreground)]">Model</label>
+            <label className="mt-3 block text-xs font-medium text-[var(--color-muted-foreground)]">{t('setup.modelLabel')}</label>
             <select
               value={model}
               onChange={(e) => setModel(e.target.value)}
               className="mt-1 w-full rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-muted)] px-3 py-2 text-sm"
             >
-              <option value="">Default</option>
+              <option value="">{t('common.default')}</option>
               {models.map((m) => (
                 <option key={m.id} value={m.id}>
                   {m.name}

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
@@ -28,6 +29,7 @@ interface Props {
 }
 
 export function TerminalPanel({ onClose }: Props) {
+  const { t } = useTranslation()
   const termElRef = useRef<HTMLDivElement | null>(null)
   const onCloseRef = useRef(onClose)
   onCloseRef.current = onClose
@@ -207,21 +209,21 @@ export function TerminalPanel({ onClose }: Props) {
             role="button"
             tabIndex={0}
             aria-pressed="true"
-            aria-label="Shell"
+            aria-label={t('terminal.shell', { n: 1 })}
             className="inline-flex h-[22px] shrink-0 items-center gap-1 rounded-[var(--radius-sm)] px-2 font-mono text-[11px] font-medium text-[var(--color-foreground)] transition-[background,color] duration-100"
             style={{
               fontFamily: 'var(--font-mono)',
               background: 'color-mix(in srgb, var(--color-foreground) 10%, transparent)',
             }}
           >
-            <span className="pointer-events-none">Shell</span>
+            <span className="pointer-events-none">{t('terminal.shell', { n: 1 })}</span>
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-0.5">
           <button
             type="button"
             onClick={onCloseRef.current}
-            title="Close panel"
+            title={t('terminal.closePanel')}
             className="flex h-5 w-5 items-center justify-center rounded-[var(--radius-sm)] text-[var(--color-muted-foreground)] transition-[background,color] duration-100 hover:bg-[color-mix(in_srgb,var(--color-foreground)_8%,transparent)] hover:text-[var(--color-foreground)]"
           >
             <XMarkIcon className="h-3 w-3" />

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -8,10 +8,12 @@
  * without per-theme classes.
  */
 import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { SunIcon, MoonIcon, SwatchIcon } from '@heroicons/react/24/outline'
 import { useTheme, THEME_CHOICES } from '../lib/useTheme'
 
 export function ThemeToggle({ compact = false }: { compact?: boolean }) {
+  const { t } = useTranslation()
   const { theme, resolvedTheme, setTheme, toggleDark } = useTheme()
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement | null>(null)
@@ -43,8 +45,8 @@ export function ThemeToggle({ compact = false }: { compact?: boolean }) {
       <button
         type="button"
         onClick={compact ? toggleDark : () => setOpen((v) => !v)}
-        title={resolvedTheme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-        aria-label={resolvedTheme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+        title={resolvedTheme === 'dark' ? t('nav.switchToLight') : t('nav.switchToDark')}
+        aria-label={resolvedTheme === 'dark' ? t('nav.switchToLight') : t('nav.switchToDark')}
         className={`flex items-center justify-center rounded-[var(--radius-md)] text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--neutral-wash-soft)] hover:text-[var(--color-foreground)] ${compact ? 'h-9 w-9 hover:bg-[var(--color-muted)]' : 'h-[34px] w-[34px] hover:bg-[var(--color-muted)]'}`}
       >
         {resolvedTheme === 'dark' ? (
@@ -59,8 +61,8 @@ export function ThemeToggle({ compact = false }: { compact?: boolean }) {
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          title="Themes"
-          aria-label="Choose theme"
+          title={t('nav.toggleTheme')}
+          aria-label={t('nav.toggleTheme')}
           aria-haspopup="menu"
           aria-expanded={open}
           className="flex h-[34px] w-[34px] items-center justify-center rounded-[var(--radius-md)] text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]"

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -277,6 +277,12 @@ export default {
     },
     // Slash-command placeholder shown when the user types "/".
     command: 'Command',
+    // "/goal" pseudo-command in the slash menu — arms Goal mode.
+    goalSlashDesc: 'Arm Goal mode — your next message becomes the objective',
+    // Badge on slash-menu items backed by a dynamic workflow.
+    workflowBadge: 'workflow',
+    // Fallback message body when only images are attached (no text).
+    attachedImages: '(see attached images)',
     stopped: 'Stopped',
     nextMessageGoal: 'Next message becomes the session goal',
     durationSeconds: '{n}s',
@@ -816,6 +822,9 @@ export default {
 
   setup: {
     step: 'Step {n}: {label}',
+    welcomeTitle: 'Welcome to jcode',
+    selectEllipsis: 'Select…',
+    modelLabel: 'Model',
     chooseProvider: 'Choose a Provider',
     enterApiKey: 'Enter API Key',
     allSet: "You're all set!",
@@ -981,11 +990,26 @@ export default {
     },
   },
 
+  // Computer-use picture-in-picture (floating latest-screenshot card).
+  pip: {
+    computerUse: 'Computer use',
+    shots: '{n} shots',
+    collapse: 'Hide',
+    expand: 'Show',
+    openFull: 'Enlarge',
+    shrink: 'Shrink',
+    unavailable: 'Screenshot expired',
+    latest: 'Latest',
+  },
+
   rightPanel: {
     plan: 'Plan',
     files: 'Files',
     changes: 'Changes',
     noTasks: 'No tasks yet',
+    emptyDir: 'Empty directory',
+    dirError: "Couldn't load this directory.",
+    fileError: "Couldn't open {name} (it may be a binary file, too large, or unreadable).",
   },
 
   diff: {
@@ -1055,6 +1079,13 @@ export default {
   goal: {
     clearGoal: 'Clear goal',
     clear: 'Clear',
+    edit: 'Edit',
+    editTitle: 'Edit goal',
+    collapse: 'Collapse',
+    started: 'Started',
+    elapsed: 'Elapsed',
+    saveFailed: 'Could not save the goal',
+    durationHours: '{h}h {m}m',
     tokens: '{used} tokens',
     tokensK: '{k}k tokens',
     status: {

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -5,6 +5,9 @@ export default {
   common: {
     ok: 'OK',
     default: 'デフォルト',
+    low: '低',
+    medium: '中',
+    high: '高',
     on: 'オン',
     off: 'オフ',
     add: '追加',
@@ -247,6 +250,7 @@ export default {
       filter: 'モデルを絞り込み…',
       toggleVisibility: 'モデルセレクターに表示するモデルを選択',
       noImages: '現在のモデルは画像をサポートしていません',
+      noImageInput: '画像入力非対応',
       reasoning: '推論',
       tools: 'ツール使用',
       images: '画像入力',
@@ -262,6 +266,9 @@ export default {
       remove: '目標を削除',
     },
     command: 'コマンド',
+    goalSlashDesc: '目標モードを有効化 — 次のメッセージが目標になります',
+    workflowBadge: 'ワークフロー',
+    attachedImages: '（添付画像を参照）',
     stopped: '停止しました',
     nextMessageGoal: '次のメッセージがセッションの目標になります',
     durationSeconds: '{n}秒',
@@ -931,17 +938,32 @@ export default {
     },
   },
 
+  pip: {
+    computerUse: 'コンピュータ操作',
+    shots: '{n} 枚',
+    collapse: '隠す',
+    expand: '表示',
+    openFull: '拡大',
+    shrink: '縮小',
+    unavailable: 'スクリーンショットは期限切れです',
+    latest: '最新',
+  },
+
   rightPanel: {
     plan: '計画',
     files: 'ファイル',
     changes: '変更',
     noTasks: 'タスクがまだありません',
+    emptyDir: '空のディレクトリ',
+    dirError: 'このディレクトリを読み込めませんでした。',
+    fileError: '{name} を開けませんでした（バイナリ・サイズ超過・読み取り不可の可能性）。',
   },
 
   diff: {
     changes: '変更',
     refresh: '↻ 更新',
     noChanges: '変更なし',
+    loadError: '変更の読み込みに失敗しました',
     selectFile: '変更を表示するファイルを選択',
     modes: {
       session: 'セッション',
@@ -1005,6 +1027,13 @@ export default {
   goal: {
     clearGoal: '目標をクリア',
     clear: 'クリア',
+    edit: '編集',
+    editTitle: '目標を編集',
+    collapse: '折りたたむ',
+    started: '開始',
+    elapsed: '経過',
+    saveFailed: '目標を保存できませんでした',
+    durationHours: '{h}時間 {m}分',
     tokens: '{used} トークン',
     tokensK: '{k}k トークン',
     status: {

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -5,6 +5,9 @@ export default {
   common: {
     ok: '확인',
     default: '기본값',
+    low: '낮음',
+    medium: '중간',
+    high: '높음',
     on: '켬',
     off: '끔',
     add: '추가',
@@ -247,6 +250,7 @@ export default {
       filter: '모델 필터…',
       toggleVisibility: '모델 선택기에 표시할 모델 선택',
       noImages: '현재 모델은 이미지를 지원하지 않습니다',
+      noImageInput: '이미지 입력 미지원',
       reasoning: '추론',
       tools: '도구 사용',
       images: '이미지 입력',
@@ -262,6 +266,9 @@ export default {
       remove: '목표 제거',
     },
     command: '명령어',
+    goalSlashDesc: '목표 모드 활성화 — 다음 메시지가 목표가 됩니다',
+    workflowBadge: '워크플로',
+    attachedImages: '(첨부 이미지 참조)',
     stopped: '중지됨',
     nextMessageGoal: '다음 메시지가 세션의 목표가 됩니다',
     durationSeconds: '{n}초',
@@ -930,17 +937,32 @@ export default {
     },
   },
 
+  pip: {
+    computerUse: '컴퓨터 제어',
+    shots: '스크린샷 {n}장',
+    collapse: '숨기기',
+    expand: '보기',
+    openFull: '확대',
+    shrink: '축소',
+    unavailable: '스크린샷이 만료되었습니다',
+    latest: '최신',
+  },
+
   rightPanel: {
     plan: '계획',
     files: '파일',
     changes: '변경',
     noTasks: '작업이 아직 없습니다',
+    emptyDir: '빈 디렉터리',
+    dirError: '이 디렉터리를 불러올 수 없습니다.',
+    fileError: '{name}을(를) 열 수 없습니다(바이너리이거나, 너무 크거나, 읽을 수 없을 수 있습니다).',
   },
 
   diff: {
     changes: '변경',
     refresh: '↻ 새로 고침',
     noChanges: '변경 없음',
+    loadError: '변경 사항을 불러오지 못했습니다',
     selectFile: '변경을 표시할 파일 선택',
     modes: {
       session: '세션',
@@ -1004,6 +1026,13 @@ export default {
   goal: {
     clearGoal: '목표 지우기',
     clear: '지우기',
+    edit: '편집',
+    editTitle: '목표 편집',
+    collapse: '접기',
+    started: '시작',
+    elapsed: '경과',
+    saveFailed: '목표를 저장하지 못했습니다',
+    durationHours: '{h}시간 {m}분',
     tokens: '{used} 토큰',
     tokensK: '{k}k 토큰',
     status: {

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -247,6 +247,7 @@ export default {
       filter: '筛选模型…',
       toggleVisibility: '选择哪些模型显示在模型选择器中',
       noImages: '当前模型不支持图片',
+      noImageInput: '不支持图像输入',
       reasoning: '推理',
       tools: '工具调用',
       images: '图片输入',
@@ -262,6 +263,9 @@ export default {
       remove: '移除目标',
     },
     command: '命令',
+    goalSlashDesc: '开启目标模式 —— 下一条消息将成为目标',
+    workflowBadge: '工作流',
+    attachedImages: '（见附图）',
     stopped: '已停止',
     nextMessageGoal: '下一条消息将成为本次会话的目标',
     durationSeconds: '{n}秒',
@@ -794,6 +798,9 @@ export default {
 
   setup: {
     step: '第 {n} 步：{label}',
+    welcomeTitle: '欢迎使用 jcode',
+    selectEllipsis: '请选择…',
+    modelLabel: '模型',
     chooseProvider: '选择服务商',
     enterApiKey: '输入 API Key',
     allSet: '一切就绪！',
@@ -957,17 +964,32 @@ export default {
     },
   },
 
+  pip: {
+    computerUse: '电脑操控',
+    shots: '{n} 张截图',
+    collapse: '隐藏',
+    expand: '显示',
+    openFull: '放大',
+    shrink: '缩小',
+    unavailable: '截图已过期',
+    latest: '最新',
+  },
+
   rightPanel: {
     plan: '计划',
     files: '文件',
     changes: '变更',
     noTasks: '暂无任务',
+    emptyDir: '空目录',
+    dirError: '无法加载该目录。',
+    fileError: '无法打开 {name}（可能是二进制文件、过大或不可读）。',
   },
 
   diff: {
     changes: '变更',
     refresh: '↻ 刷新',
     noChanges: '无变更',
+    loadError: '加载变更失败',
     selectFile: '选择一个文件以查看变更',
     modes: {
       session: '会话',
@@ -1031,6 +1053,13 @@ export default {
   goal: {
     clearGoal: '清除目标',
     clear: '清除',
+    edit: '编辑',
+    editTitle: '编辑目标',
+    collapse: '收起',
+    started: '开始于',
+    elapsed: '已进行',
+    saveFailed: '保存目标失败',
+    durationHours: '{h}小时 {m}分',
     tokens: '{used} tokens',
     tokensK: '{k}k tokens',
     status: {

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -6,6 +6,9 @@ export default {
   common: {
     ok: '確定',
     default: '預設',
+    low: '低',
+    medium: '中',
+    high: '高',
     on: '開啟',
     off: '關閉',
     add: '添加',
@@ -248,6 +251,7 @@ export default {
       filter: '篩選模型…',
       toggleVisibility: '選擇哪些模型顯示在模型選擇器中',
       noImages: '目前模型不支援圖片',
+      noImageInput: '不支援影像輸入',
       reasoning: '推理',
       tools: '工具呼叫',
       images: '圖片輸入',
@@ -263,6 +267,9 @@ export default {
       remove: '移除目標',
     },
     command: '指令',
+    goalSlashDesc: '開啟目標模式 —— 下一則訊息將成為目標',
+    workflowBadge: '工作流程',
+    attachedImages: '（見附圖）',
     stopped: '已停止',
     nextMessageGoal: '下一則訊息將成為本次工作階段的目標',
     durationSeconds: '{n}秒',
@@ -925,17 +932,32 @@ export default {
     },
   },
 
+  pip: {
+    computerUse: '電腦操控',
+    shots: '{n} 張截圖',
+    collapse: '隱藏',
+    expand: '顯示',
+    openFull: '放大',
+    shrink: '縮小',
+    unavailable: '截圖已過期',
+    latest: '最新',
+  },
+
   rightPanel: {
     plan: '計劃',
     files: '檔案',
     changes: '變更',
     noTasks: '暫無工作',
+    emptyDir: '空目錄',
+    dirError: '無法載入該目錄。',
+    fileError: '無法開啟 {name}（可能是二進位檔案、過大或不可讀）。',
   },
 
   diff: {
     changes: '變更',
     refresh: '↻ 重新整理',
     noChanges: '無變更',
+    loadError: '載入變更失敗',
     selectFile: '選擇一個檔案以查看變更',
     modes: {
       session: '對話',
@@ -999,6 +1021,13 @@ export default {
   goal: {
     clearGoal: '清除目標',
     clear: '清除',
+    edit: '編輯',
+    editTitle: '編輯目標',
+    collapse: '收起',
+    started: '開始於',
+    elapsed: '已進行',
+    saveFailed: '儲存目標失敗',
+    durationHours: '{h}小時 {m}分',
     tokens: '{used} tokens',
     tokensK: '{k}k tokens',
     status: {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -69,6 +69,9 @@ export interface SessionEntry {
   // compact fields
   summary?: string
   compacted_n?: number
+
+  // user message attachments (base64, no data: prefix) — mirrors session.EntryImage
+  images?: { media_type: string; data: string }[]
 }
 
 export interface ConfigResponse {


### PR DESCRIPTION
## Summary

Redesigns the active-goal banner as a floating pill that visually sits *behind* the composer input, matching the requested reference design. The composer becomes its own card with a higher z-index so the pill peeks from behind with no extra wrapping borders.

Also ships supporting frontend improvements made in the same pass:
- `/goal` local slash command to arm Goal mode mid-draft.
- Preserve image attachments when replaying sessions.
- Computer-use picture-in-picture component + `ApiBaseProvider` for Tauri-safe image URLs.
- Expanded i18n coverage for auth, setup, theme toggles, right panel, terminal, settings, and goal UI.

And backend/browser changes:
- Unify browser config mapping via `browser.FromConfig()` and `browser.Manager.Enabled()`.
- Rolling browser tools on/off now rebuilds the active agent's tool list immediately.
- Harden browser/computer config endpoints with rollback on save failure.
- Add browser configmap + tests, plus browser-tools tests and doc updates.

## Type of Change

- [x] New feature
- [x] Refactoring / code cleanup
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Test update

## Changes Made

1. `GoalBanner.tsx`: complete rewrite as a floating rounded pill with status icon, objective, inline todo progress, elapsed time, edit/delete/expand actions, and right-pointing chevron.
2. `ChatInput.tsx`: docked composer is now its own bordered card (`z-[2]`), no inner border in docked mode; `/goal` slash command toggles Goal mode without inserting text.
3. `ChatView.tsx`: removed shared wrapper card around banner + composer so they stack as siblings.
4. `store.ts` + `types.ts`: preserve image attachments during session replay.
5. `App.tsx` + `ComputerShotPiP.tsx` + `apiBase`: add floating latest-screenshot PiP for computer use.
6. i18n files: harden strings across auth, setup, theme, right panel, terminal, settings, and goal surfaces.
7. `internal/browser`, `internal/command`, `internal/web`, `internal/tools`, `internal/computer`: browser-use config/tool exposure improvements and tests.
8. `design/goal-banner-composer.html`: design mockup used to align on the visual direction.

## Testing

- `make lint-web` passes.
- `make build-web` + `go build ./...` pass.
- Verified in browser: collapsed pill sits behind composer, expanded panel raises above composer (`z-[3]`), model/mode/effort dropdowns render on top, and content is not clipped.
- Pre-push hook (go build, go vet, golangci-lint, go test) passed twice, covering both the frontend and Go changes.

## Screenshots / Recordings

See `design/goal-banner-composer.html` for the static design reference.

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass.
- [ ] I have added/updated tests as needed.
- [ ] I have updated relevant documentation.

## Additional Notes

The visual direction was validated via the design mockup before implementation. The pill uses inline `background` / `borderColor` / `boxShadow` styles to avoid `color-mix()` transparency quirks in headless Chrome screenshots.
