### PR TITLE
feat(model): add Alibaba Token Plan (China) provider

### DIFF
--- a/internal/model/chatmodel.go
+++ b/internal/model/chatmodel.go
@@ -1016,15 +1016,16 @@ var knownModels = map[string]knownModel{
 	// 2026 long-context flagships (offline fallback when the models.dev registry
 	// is unavailable). Context windows verified against vendor docs / models.dev;
 	// see internal-doc/model-research.md. Pricing left 0 where not confidently known.
-	"MiniMax-M3":        {1000000, 0.60, 2.40},
-	"minimax-m3":        {1000000, 0.60, 2.40},
-	"deepseek-v4-pro":   {1000000, 0, 0},
-	"deepseek-v4-flash": {1000000, 0, 0},
-	"qwen3.7-max":       {1000000, 2.50, 7.50},
-	"qwen3.7-plus":      {1000000, 0, 0},
-	"qwen3.6-plus":      {1000000, 0, 0},
-	"kimi-k2.6":         {262144, 0, 0},
-	"kimi-k2.7-code":    {262144, 0, 0},
+	"MiniMax-M3":          {1000000, 0.60, 2.40},
+	"minimax-m3":          {1000000, 0.60, 2.40},
+	"deepseek-v4-pro":     {1000000, 0, 0},
+	"deepseek-v4-flash":   {1000000, 0, 0},
+	"qwen3.7-max":         {1000000, 2.50, 7.50},
+	"qwen3.8-max-preview": {1000000, 2.50, 7.50},
+	"qwen3.7-plus":        {1000000, 0, 0},
+	"qwen3.6-plus":        {1000000, 0, 0},
+	"kimi-k2.6":           {262144, 0, 0},
+	"kimi-k2.7-code":      {262144, 0, 0},
 	// Kimi For Coding plan tiers — subscription-metered, so no per-token price.
 	"kimi-for-coding":           {262144, 0, 0},
 	"kimi-for-coding-highspeed": {262144, 0, 0},

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -524,6 +524,29 @@ func glm52Model() *RegistryModel {
 	}
 }
 
+// qwen38MaxPreviewModel builds a fresh Qwen3.8-Max-Preview entry. Returns a new
+// object per call so each provider gets its own instance (deep-copied again per
+// ModelRegistry).
+//
+// Qwen3.8-Max-Preview is an early-access flagship exposed only on Alibaba's
+// Token Plan endpoints (alibaba-token-plan-cn / alibaba-token-plan). It is not
+// on models.dev yet, so it can't come through registry_generated.go. Parameters
+// mirror qwen3.7-max for now (same window, pricing shape, reasoning options);
+// official specs pending. See internal-doc/model-research.md.
+func qwen38MaxPreviewModel() *RegistryModel {
+	return &RegistryModel{
+		ID: "qwen3.8-max-preview", Name: "Qwen3.8 Max Preview", Family: "qwen",
+		Reasoning: true, ToolCall: true, Temperature: true,
+		Modalities: &ModelModalities{Input: []string{"text"}, Output: []string{"text"}},
+		Cost:       &ModelCost{Input: 2.5, Output: 7.5, CacheRead: 0.5, CacheWrite: 3.125},
+		Limit:      &ModelLimit{Context: 1_000_000, Output: 65_536},
+		ReasoningOptions: []ReasoningOption{
+			{Type: "toggle"},
+			{Type: "budget_tokens", Max: intPtr(262144)},
+		},
+	}
+}
+
 // additionalModels injects models into EXISTING generated providers when a model is
 // released before models.dev publishes it. Applied at init() and MERGED in — an
 // entry is skipped if the provider already defines that model id, so once the
@@ -534,6 +557,9 @@ var additionalModels = map[string]map[string]*RegistryModel{
 	"zhipuai-coding-plan": {"glm-5.2": glm52Model()},
 	"zai":                 {"glm-5.2": glm52Model()},
 	"zai-coding-plan":     {"glm-5.2": glm52Model()},
+	// Qwen3.8-Max-Preview is exclusive to Alibaba Token Plan endpoints for now.
+	"alibaba-token-plan-cn": {"qwen3.8-max-preview": qwen38MaxPreviewModel()},
+	"alibaba-token-plan":    {"qwen3.8-max-preview": qwen38MaxPreviewModel()},
 }
 
 func init() {

--- a/script/generate_models.go
+++ b/script/generate_models.go
@@ -35,6 +35,7 @@ var wantedProviders = []string{
 	"alibaba-cn",
 	"alibaba-coding-plan-cn",
 	"alibaba-token-plan-cn",
+	"alibaba-token-plan",
 	"moonshotai",
 	"minimax",
 	"minimax-coding-plan",

--- a/script/generate_models.go
+++ b/script/generate_models.go
@@ -34,6 +34,7 @@ var wantedProviders = []string{
 	// Chinese providers
 	"alibaba-cn",
 	"alibaba-coding-plan-cn",
+	"alibaba-token-plan-cn",
 	"moonshotai",
 	"minimax",
 	"minimax-coding-plan",


### PR DESCRIPTION
## What

Adds the Alibaba Cloud Model Studio **Token Plan** providers and an early-access flagship model.

### Providers (via `wantedProviders`)
| ID | Endpoint |
|---|---|
| `alibaba-token-plan-cn` | `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` |
| `alibaba-token-plan` | `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` |

Both env `ALIBABA_TOKEN_PLAN_API_KEY`, 18 models each from models.dev. These endpoints were missing — the existing Alibaba entries (`alibaba-cn`, `alibaba-coding-plan-cn`) both point at DashScope, not the MaaS token-plan host.

### Model: `qwen3.8-max-preview` (via `additionalModels`)
Early-access flagship exposed **only** on the two Token Plan endpoints — not on models.dev yet, so it can't come through the generator. Injected into `alibaba-token-plan-cn` and `alibaba-token-plan` only. Parameters mirror `qwen3.7-max` for now (official specs pending):

- Context: 1,000,000 / Output: 65,536
- Cost: $2.5 / $7.5 per 1M (cache 0.5 / 3.125)
- Reasoning + ToolCall + Temperature
- Reasoning options: `toggle` + `budget_tokens` @ 262144

## How
- `script/generate_models.go` — `wantedProviders += alibaba-token-plan-cn, alibaba-token-plan`
- `internal/model/registry.go` — new `qwen38MaxPreviewModel()` constructor + entries in `additionalModels` for both Token Plan providers
- `internal/model/chatmodel.go` — `qwen3.8-max-preview` added to `knownModels` offline fallback

## Notes
- `registry_generated.go` is gitignored — reviewers/runners need `make generate` to materialize the new provider entries locally.
- Once `qwen3.8-max-preview` lands on models.dev, the `additionalModels` entry is silently overridden by the generated record (existing merge semantics).
- `alibaba-cn` / `alibaba-coding-plan-cn` intentionally NOT given qwen3.8-max-preview — it's exclusive to the Token Plan endpoints.

## Verification
- [x] `make generate` → "Filtered to 25 wanted providers" (was 23 pre-PR)
- [x] `go build ./...` passes
- [x] `go test ./internal/model/...` passes
- [x] `make lint-go` — 0 issues
- [x] Runtime check: `qwen3.8-max-preview` present on both token-plan providers (ctx=1M, out=65536, $2.5/$7.5, 2 reasoning opts) and absent from `alibaba-cn` / `alibaba-coding-plan-cn`
