### PR TITLE
feat(jcode-ui): live tool info in running activity header + breathing ring pending indicator

### DIFF
--- a/design/running-thinking-indicator.html
+++ b/design/running-thinking-indicator.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>jcode · Running / Thinking 状态指示器设计稿</title>
+<style>
+:root {
+  --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --radius-xs: 3px; --radius-sm: 4px; --radius-md: 6px;
+  --radius-lg: 8px; --radius-xl: 12px; --radius-2xl: 16px; --radius-pill: 9999px;
+  --shadow-sm: 0 1px 2px rgba(24,20,16,.06);
+  --shadow-md: 0 4px 14px -4px rgba(24,20,16,.12);
+  --ease-out: cubic-bezier(.16,1,.3,1);
+  --duration-fast:100ms; --duration-normal:150ms;
+  --gutter: 2.25rem;
+  --color-primary:#FF8400; --color-background:#F2F3F0; --color-surface:#FFFFFF;
+  --color-foreground:#111111; --color-muted-foreground:#666666; --color-border:#CBCCC9;
+  --color-muted:#F2F3F0; --color-secondary:#E7E8E5; --color-secondary-foreground:#111111;
+  --neutral-wash-soft: color-mix(in srgb, var(--color-foreground) 8%, transparent);
+}
+.dark {
+  --color-primary:#FF8400; --color-background:#111111; --color-surface:#1A1A1A;
+  --color-foreground:#FFFFFF; --color-muted-foreground:#B8B9B6; --color-border:#2E2E2E;
+  --color-muted:#2E2E2E; --color-secondary:#2E2E2E; --color-secondary-foreground:#FFFFFF;
+  --neutral-wash-soft: color-mix(in srgb, var(--color-foreground) 8%, transparent);
+}
+
+* { box-sizing: border-box; }
+html { background: var(--color-background); }
+body {
+  margin: 0; font-family: var(--font-sans); color: var(--color-foreground);
+  -webkit-font-smoothing: antialiased; min-height: 100vh;
+  display: flex; flex-direction: column; align-items: center;
+  padding: 18px 14px 90px;
+}
+.toolbar { width: 100%; max-width: 720px; display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+.toolbar h1 { font-size: 14px; font-weight: 600; margin: 0; }
+.toolbar .spacer { flex: 1; }
+button.theme { font-size: 12px; color: var(--color-muted-foreground); background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: 5px 10px; cursor: pointer; }
+
+.stage { width: 100%; max-width: 720px; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-xl); box-shadow: var(--shadow-md); overflow: hidden; }
+
+.message-row { display: flex; align-items: flex-start; gap: .75rem; padding: 1rem 1rem .5rem; }
+.avatar { width: 28px; height: 28px; border-radius: 50%; flex-shrink: 0; background: var(--color-foreground); color: var(--color-background); display: grid; place-items: center; font-size: 12px; font-weight: 600; }
+.bubble { background: var(--color-secondary); color: var(--color-secondary-foreground); padding: .55rem .85rem; border-radius: var(--radius-lg); font-size: 15px; line-height: 1.45; border: 1px solid var(--color-border); }
+
+.variant { border-top: 1px solid var(--color-border); padding: 1.25rem 1rem 1.5rem; }
+.variant-label { display: inline-block; font-size: 11px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--color-muted-foreground); background: var(--color-muted); padding: .2rem .55rem; border-radius: var(--radius-sm); margin-bottom: .75rem; }
+.variant-title { font-size: 13px; font-weight: 600; margin: 0 0 .35rem; }
+.variant-desc { font-size: 12px; color: var(--color-muted-foreground); margin: 0 0 1rem; line-height: 1.5; }
+.gutter { margin-left: var(--gutter); }
+
+/* ═══ E: tool icon + command + white scan — NO border, compact ═══ */
+.tool-row {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 2px 6px 2px 4px;
+  border-radius: var(--radius-md);
+  background: transparent;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  font-size: 12px; line-height: 1; font-weight: 500;
+  color: var(--color-muted-foreground);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+}
+.tool-row:hover { background: var(--neutral-wash-soft); }
+.tool-row .tool-icon {
+  width: 12px; height: 12px; flex-shrink: 0;
+  color: var(--color-muted-foreground); opacity: .8;
+}
+.tool-row .command-name {
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--color-foreground);
+}
+.tool-row .chevron {
+  width: 10px; height: 10px; flex-shrink: 0;
+  color: var(--color-muted-foreground); opacity: .6;
+}
+
+/* white scan overlay */
+.tool-row::after {
+  content: "";
+  position: absolute; inset: 0;
+  background: linear-gradient(105deg,
+    transparent 30%,
+    rgba(255,255,255,0.28) 48%,
+    rgba(255,255,255,0.42) 52%,
+    transparent 70%);
+  background-size: 220% 100%;
+  animation: scan-sweep 2.2s ease-in-out infinite;
+  pointer-events: none;
+  border-radius: inherit;
+}
+@keyframes scan-sweep {
+  0% { background-position: 130% 0; }
+  100% { background-position: -30% 0; }
+}
+
+/* thinking row — compact */
+.thinking-row {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 0 8px;
+  font-size: 12px; font-weight: 500;
+  color: var(--color-muted-foreground);
+}
+/* thinking indicator — breathing ring (matches conversation sidebar's .sb-ring) */
+.think-ring {
+  display: inline-block; width: 9px; height: 9px; flex-shrink: 0;
+  border: 1.6px solid var(--color-primary); border-radius: var(--radius-pill);
+  background: transparent;
+  animation: think-ring-breathe 1.6s ease-in-out infinite;
+}
+@keyframes think-ring-breathe {
+  0%, 100% { opacity: .35; transform: scale(.78); }
+  50%      { opacity: 1;   transform: scale(1); }
+}
+
+/* ═══ A: current baseline (for comparison) ═══ */
+.activity-header {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12px; line-height: 1; font-weight: 500;
+  color: var(--color-muted-foreground);
+  padding: 2px 6px 2px 4px; border-radius: var(--radius-md);
+  background: transparent; border: none; cursor: pointer;
+}
+.activity-header .status-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-primary); }
+.activity-header .chevron { width: 10px; height: 10px; color: var(--color-muted-foreground); opacity: .6; }
+.shimmer-running {
+  background: linear-gradient(90deg, var(--color-muted-foreground) 20%, var(--color-foreground) 50%, var(--color-muted-foreground) 80%);
+  background-size: 200% auto; background-clip: text; -webkit-background-clip: text;
+  color: transparent !important; -webkit-text-fill-color: transparent;
+  animation: shimmer-sweep 2s linear infinite;
+}
+@keyframes shimmer-sweep { 0% { background-position: -200% center; } 100% { background-position: 200% center; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .tool-row::after, .think-ring, .shimmer-running { animation: none; }
+  .think-ring { opacity: 1; transform: none; }
+}
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <h1>Running / Thinking 指示器</h1>
+  <span class="spacer"></span>
+  <button class="theme" onclick="document.documentElement.classList.toggle('dark')">切换 dark</button>
+</div>
+
+<div class="stage">
+  <div class="message-row">
+    <div class="avatar">U</div>
+    <div class="bubble">帮我提交 pr</div>
+  </div>
+
+  <!-- A. 现状 -->
+  <section class="variant">
+    <div class="variant-label">A · 现状</div>
+    <h2 class="variant-title">Running… + Thinking 点阵</h2>
+    <p class="variant-desc">固定文字 "Running…"，没有当前动作信息。</p>
+    <div class="gutter">
+      <button class="activity-header">
+        <span class="status-dot"></span>
+        <span class="shimmer-running">Running…</span>
+        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="thinking-row">
+        <span class="think-ring" aria-hidden="true"></span>
+        <span>Thinking</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- E. 推荐：tool icon + command + white scan -->
+  <section class="variant">
+    <div class="variant-label">E · 推荐</div>
+    <h2 class="variant-title">tool icon + 当前命令 + 纯白扫光</h2>
+    <p class="variant-desc">无边框、无背景色。12px icon + mono 命令名 + 10px chevron。纯白色光带从左到右扫过。Thinking 保持三点但更紧凑。</p>
+    <div class="gutter">
+      <button class="tool-row">
+        <svg class="tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>
+        <span class="command-name">Read</span>
+        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="thinking-row">
+        <span class="think-ring" aria-hidden="true"></span>
+        <span>Thinking</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- E2: 另一个工具示例 -->
+  <section class="variant">
+    <div class="variant-label">E2 · 同方案不同工具</div>
+    <h2 class="variant-title">Execute / Edit 等工具</h2>
+    <p class="variant-desc">同样的紧凑行，只是 icon 和命令名不同。</p>
+    <div class="gutter">
+      <button class="tool-row">
+        <svg class="tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" x2="20" y1="19" y2="19"/></svg>
+        <span class="command-name">git status</span>
+        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="thinking-row">
+        <span class="think-ring" aria-hidden="true"></span>
+        <span>Thinking</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- E3: 合并 running + thinking 为一行 -->
+  <section class="variant">
+    <div class="variant-label">E3 · 合并为一行</div>
+    <h2 class="variant-title">command + thinking 同一行</h2>
+    <p class="variant-desc">如果不想占两行，可以把 thinking 合并到命令行尾部。</p>
+    <div class="gutter">
+      <button class="tool-row">
+        <svg class="tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>
+        <span class="command-name">Read</span>
+        <span style="opacity:.4">·</span>
+        <span class="think-ring" aria-hidden="true"></span>
+        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+    </div>
+  </section>
+</div>
+
+<script>
+if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  document.documentElement.classList.add('dark');
+}
+</script>
+</body>
+</html>

--- a/packages/jcode-ui/src/components/ActivityGroupCard.tsx
+++ b/packages/jcode-ui/src/components/ActivityGroupCard.tsx
@@ -22,6 +22,7 @@ import { ChevronDownIcon } from '@heroicons/react/24/outline'
 import type { ActivityGroup } from 'jcode-ui-core'
 import { summarizeActivityCounts, countActivityFlags } from 'jcode-ui-core'
 import { ToolRow } from './ToolRow.js'
+import { ToolIcon } from './toolIcons.js'
 
 export interface ActivityGroupCardProps {
   group: ActivityGroup
@@ -40,6 +41,10 @@ export const ActivityGroupCard = memo(function ActivityGroupCard({
   const counts = useMemo(() => summarizeActivityCounts(group.tools), [group.tools])
   const { failed, denied } = useMemo(() => countActivityFlags(group.tools), [group.tools])
   const hasError = failed > 0
+  // Latest tool drives the running header line (icon + title + subtitle).
+  // group.tools is append-ordered, so the last entry is the currently-running
+  // step (or, once settled, the most recent one).
+  const latest = running ? group.tools[group.tools.length - 1] : undefined
 
   return (
     <div
@@ -55,50 +60,85 @@ export const ActivityGroupCard = memo(function ActivityGroupCard({
         onClick={() => setUserOverride(!expanded)}
         className="jcode-activity__header flex w-full max-w-full cursor-pointer items-center gap-1.5 bg-transparent text-left"
       >
-        <span
-          className={`jcode-toolbatch__status shrink-0 text-[10px] ${running ? 'animate-pulse' : ''}`}
-          style={{
-            color: running
-              ? 'var(--jcode-color-primary)'
-              : hasError
-                ? 'var(--jcode-color-error-fg)'
-                : 'var(--jcode-color-success-fg)',
-          }}
-          aria-hidden
-        >
-          {running ? '●' : hasError ? '✗' : '✓'}
-        </span>
         {running ? (
-          <span
-            className="shimmer-running shrink-0 text-xs font-medium tracking-wide"
-            style={{ color: 'var(--jcode-color-muted-foreground)' }}
-          >
-            Running…
-          </span>
-        ) : group.explorative ? (
+          // Running: tool icon + latest tool name (+ subtitle) + scan-line
+          // shimmer on the title. The live status dot is pushed to the right
+          // (ml-auto) so settled groups keep their ✗/✓ on the left.
           <>
+            {latest && (
+              <ToolIcon
+                kind={latest.displayInfo?.kind}
+                name={latest.name}
+                className="h-3 w-3 shrink-0"
+                style={{ color: 'var(--jcode-color-muted-foreground)', opacity: 0.8 }}
+                aria-hidden
+              />
+            )}
             <span
-              className="shrink-0 text-xs font-medium tracking-wide"
+              className="shimmer-running min-w-0 shrink-0 truncate font-mono text-[0.78rem] font-medium tracking-wide"
               style={{ color: 'var(--jcode-color-muted-foreground)' }}
             >
-              Explored
+              {latest ? (latest.displayInfo?.title ?? latest.name) : 'Running…'}
             </span>
-            {counts && (
+            {latest?.displayInfo?.subtitle && (
               <span
-                className="min-w-0 truncate font-mono text-[0.72rem]"
+                className="jcode-toolcall__subtitle min-w-0 truncate font-mono text-[0.72rem]"
                 style={{ color: 'var(--jcode-color-foreground)', opacity: 0.88 }}
               >
-                {counts}
+                · {latest.displayInfo.subtitle}
+              </span>
+            )}
+            <span
+              className="ml-auto flex shrink-0 items-center"
+              aria-hidden
+            >
+              <span
+                className="animate-pulse text-[10px]"
+                style={{ color: 'var(--jcode-color-primary)' }}
+              >
+                ●
+              </span>
+            </span>
+          </>
+        ) : (
+          <>
+            <span
+              className="jcode-toolbatch__status shrink-0 text-[10px]"
+              style={{
+                color: hasError
+                  ? 'var(--jcode-color-error-fg)'
+                  : 'var(--jcode-color-success-fg)',
+              }}
+              aria-hidden
+            >
+              {hasError ? '✗' : '✓'}
+            </span>
+            {group.explorative ? (
+              <>
+                <span
+                  className="shrink-0 text-xs font-medium tracking-wide"
+                  style={{ color: 'var(--jcode-color-muted-foreground)' }}
+                >
+                  Explored
+                </span>
+                {counts && (
+                  <span
+                    className="min-w-0 truncate font-mono text-[0.72rem]"
+                    style={{ color: 'var(--jcode-color-foreground)', opacity: 0.88 }}
+                  >
+                    {counts}
+                  </span>
+                )}
+              </>
+            ) : (
+              <span
+                className="min-w-0 truncate text-xs font-medium tracking-wide"
+                style={{ color: 'var(--jcode-color-muted-foreground)' }}
+              >
+                {counts || `${group.tools.length} tool calls`}
               </span>
             )}
           </>
-        ) : (
-          <span
-            className="min-w-0 truncate text-xs font-medium tracking-wide"
-            style={{ color: 'var(--jcode-color-muted-foreground)' }}
-          >
-            {counts || `${group.tools.length} tool calls`}
-          </span>
         )}
         {failed > 0 && (
           <span

--- a/packages/jcode-ui/src/components/Thread.tsx
+++ b/packages/jcode-ui/src/components/Thread.tsx
@@ -41,6 +41,10 @@ export interface ThreadProps {
   suggestions?: ReactNode
   /** Override the pending ("Thinking…") indicator. */
   renderPending?: () => ReactNode
+  /** Label for the default pending indicator ("Thinking"). Ignored when
+   *  renderPending is set. The library has no i18n; hosts pass a translated
+   *  string here. */
+  pendingLabel?: string
   /** className passthrough for the scroll container. */
   className?: string
   /** Extra bottom padding (px) to clear a sticky composer. */
@@ -52,6 +56,7 @@ export function Thread({
   emptyState,
   suggestions,
   renderPending,
+  pendingLabel,
   className,
   overscanBottom,
 }: ThreadProps): ReactNode {
@@ -71,7 +76,7 @@ export function Thread({
       overscanBottom={overscanBottom ?? 24}
       mapItems={mapItems}
       renderItem={(item) => renderItem(item, isRunning)}
-      renderPending={renderPending ?? DefaultPending}
+      renderPending={renderPending ?? (() => <DefaultPending label={pendingLabel} />)}
       renderEmpty={emptyState ? () => emptyState : undefined}
       renderFooter={
         suggestions
@@ -143,21 +148,20 @@ function renderItem(item: ThreadItem, isRunning: boolean): ReactNode {
   return null
 }
 
-function DefaultPending(): ReactNode {
+function DefaultPending({ label }: { label?: string }): ReactNode {
+  const text = label ?? 'Thinking'
   return (
     <div
       className="jcode-pending jcode-chat-col"
       role="status"
       aria-live="polite"
-      aria-label="Thinking…"
+      aria-label={text}
     >
       <div className="jcode-pending__inner jcode-gutter">
-        <span className="jcode-pending__dots" aria-hidden="true">
-          <span className="jcode-pending-dot" />
-          <span className="jcode-pending-dot" />
-          <span className="jcode-pending-dot" />
+        <span className="jcode-pending__ring" aria-hidden="true">
+          <span className="jcode-pending-ring" />
         </span>
-        <span className="jcode-pending__label">Thinking</span>
+        <span className="jcode-pending__label">{text}</span>
       </div>
     </div>
   )

--- a/packages/jcode-ui/src/components/toolIcons.tsx
+++ b/packages/jcode-ui/src/components/toolIcons.tsx
@@ -1,0 +1,75 @@
+/**
+ * toolIcons — map a tool's displayInfo.kind (or name) to a Heroicon.
+ *
+ * Used by compact activity rows (e.g. ActivityGroupCard's running header) to
+ * show a 12px icon that matches the tool category. Mirrors the kind taxonomy
+ * documented in jcode-ui-core's ToolDisplayInfo:
+ *   read | search | list | shell | edit | agent | other
+ * plus name-based fallbacks for tools that don't set `kind` (execute / bash /
+ * grep / glob / write / multi_edit / webfetch / todo / browser…).
+ */
+
+import {
+  CheckCircleIcon,
+  CommandLineIcon,
+  ComputerDesktopIcon,
+  DocumentPlusIcon,
+  DocumentTextIcon,
+  GlobeAltIcon,
+  ListBulletIcon,
+  MagnifyingGlassIcon,
+  PencilSquareIcon,
+  UserCircleIcon,
+  WrenchScrewdriverIcon,
+} from '@heroicons/react/24/outline'
+import type { ComponentType, SVGProps } from 'react'
+
+export type ToolIconProps = SVGProps<SVGSVGElement> & {
+  /** Presentation kind from ToolDisplayInfo (read | search | list | shell | edit | agent | other). */
+  kind?: string
+  /** Raw tool name; used as fallback when kind is absent. */
+  name?: string
+}
+
+type Icon = ComponentType<SVGProps<SVGSVGElement>>
+
+const BY_KIND: Record<string, Icon> = {
+  read: DocumentTextIcon,
+  search: MagnifyingGlassIcon,
+  list: ListBulletIcon,
+  shell: CommandLineIcon,
+  edit: PencilSquareIcon,
+  write: DocumentPlusIcon,
+  agent: UserCircleIcon,
+  web: GlobeAltIcon,
+  browser: ComputerDesktopIcon,
+  todo: CheckCircleIcon,
+}
+
+const BY_NAME: Record<string, Icon> = {
+  read: DocumentTextIcon,
+  grep: MagnifyingGlassIcon,
+  glob: MagnifyingGlassIcon,
+  list_dir: ListBulletIcon,
+  execute: CommandLineIcon,
+  bash: CommandLineIcon,
+  edit: PencilSquareIcon,
+  multi_edit: PencilSquareIcon,
+  write: DocumentPlusIcon,
+  subagent: UserCircleIcon,
+  team: UserCircleIcon,
+  webfetch: GlobeAltIcon,
+  websearch: GlobeAltIcon,
+  todoread: CheckCircleIcon,
+  todowrite: CheckCircleIcon,
+  todo: CheckCircleIcon,
+  browser: ComputerDesktopIcon,
+}
+
+const FALLBACK_ICON = WrenchScrewdriverIcon
+
+/** Resolve a Heroicon for a tool by kind (preferred) then name. */
+export function ToolIcon({ kind, name, ...rest }: ToolIconProps) {
+  const Icon = (kind && BY_KIND[kind]) || (name && BY_NAME[name]) || FALLBACK_ICON
+  return <Icon {...rest} />
+}

--- a/packages/jcode-ui/src/styles/components.css
+++ b/packages/jcode-ui/src/styles/components.css
@@ -1182,7 +1182,8 @@
 }
 
 /* ─── Thread pending ("Thinking") ───
- * Align under message body gutter; neutral dots (not brand orange). */
+ * Align under message body gutter; breathing ring in brand color (matches
+ * the conversation sidebar's running indicator). */
 .jcode-pending {
   padding-top: 0.35rem;
   padding-bottom: 0.85rem;
@@ -1193,24 +1194,21 @@
   gap: 0.55rem;
   min-height: 1.5rem;
 }
-.jcode-pending__dots {
+.jcode-pending__ring {
   display: inline-flex;
   align-items: center;
-  gap: 0.28rem;
+  justify-content: center;
+  width: 11px;
+  height: 11px;
 }
-.jcode-pending-dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: var(--jcode-color-muted-foreground);
-  opacity: 0.45;
-  animation: jcode-think-dot 1.2s ease-in-out infinite both;
-}
-.jcode-pending-dot:nth-child(2) {
-  animation-delay: 0.15s;
-}
-.jcode-pending-dot:nth-child(3) {
-  animation-delay: 0.3s;
+.jcode-pending-ring {
+  display: block;
+  width: 9px;
+  height: 9px;
+  border: 1.6px solid var(--jcode-color-primary);
+  border-radius: 9999px;
+  background: transparent;
+  animation: jcode-think-ring 1.6s ease-in-out infinite;
 }
 .jcode-pending__label {
   font-size: 0.8rem;
@@ -1220,16 +1218,15 @@
   opacity: 0.9;
 }
 
-@keyframes jcode-think-dot {
+@keyframes jcode-think-ring {
   0%,
-  80%,
   100% {
-    opacity: 0.3;
-    transform: translateY(0);
+    opacity: 0.35;
+    transform: scale(0.78);
   }
-  40% {
-    opacity: 0.95;
-    transform: translateY(-1.5px);
+  50% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 
@@ -1238,9 +1235,10 @@
   .jcode-ask-user .jcode-interactive-card {
     animation: none;
   }
-  .jcode-pending-dot {
+  .jcode-pending-ring {
     animation: none;
-    opacity: 0.6;
+    opacity: 1;
+    transform: none;
   }
 }
 

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -30,6 +30,34 @@ export interface ChatViewProps {
   readOnly?: boolean
 }
 
+/** Pending ("Thinking…") row — breathing ring + i18n label. The library's
+ *  default is English-only; we override it here so the label follows the
+ *  active locale (chat.thinking). Ring style lives in jcode-ui's CSS.
+ *
+ *  Rendered as `<PendingIndicator />` (NOT called as a render function) so
+ *  its useTranslation hook stays on its own fiber — calling it directly as
+ *  renderPending() would attach the hook to VirtualizedThread and trip the
+ *  Rules of Hooks when the pending slot mounts/unmounts. */
+function PendingIndicator() {
+  const { t } = useTranslation()
+  const label = t('chat.thinking')
+  return (
+    <div
+      className="jcode-pending jcode-chat-col"
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+    >
+      <div className="jcode-pending__inner jcode-gutter">
+        <span className="jcode-pending__ring" aria-hidden="true">
+          <span className="jcode-pending-ring" />
+        </span>
+        <span className="jcode-pending__label">{label}</span>
+      </div>
+    </div>
+  )
+}
+
 export function ChatView({ readOnly }: ChatViewProps) {
   const { t } = useTranslation()
   const hasMessages = useAppSelector((s) => s.chat.timeline.length > 0)
@@ -45,7 +73,7 @@ export function ChatView({ readOnly }: ChatViewProps) {
     return (
       <div className="chat-panel flex min-h-0 flex-1 flex-col">
         <div className="min-h-0 flex-1">
-          <Thread overscanBottom={8} />
+          <Thread overscanBottom={8} renderPending={() => <PendingIndicator />} />
         </div>
       </div>
     )
@@ -94,7 +122,7 @@ export function ChatView({ readOnly }: ChatViewProps) {
     <div className="chat-panel flex min-h-0 flex-1 flex-col">
       <ModelBackdrop kind={backdropKind} />
       <div className="chat-content-layer min-h-0 flex-1">
-        <Thread overscanBottom={28} />
+        <Thread overscanBottom={28} renderPending={() => <PendingIndicator />} />
       </div>
       {/* z-[2] keeps the composer’s upward-opening menus above the thread layer. */}
       <div className="chat-content-layer chat-col relative z-[2]">


### PR DESCRIPTION
## Summary

Improves the running/thinking indicators in the chat UI so users can see **which tool is currently executing** instead of a generic "Running…" label, and replaces the bouncing-dots pending indicator with a calmer breathing ring.

## Changes

### New: `toolIcons.tsx`
Maps a tool's `displayInfo.kind` (or raw name as fallback) to the appropriate Heroicon — read→document, shell→terminal, edit→pencil, browser→desktop, etc.

### `ActivityGroupCard` running state redesign
- Shows the **latest tool's icon + title + subtitle** (e.g. `📄 Read · src/foo.ts`) with the existing shimmer animation
- Pulse dot moves to the right (`ml-auto`) so settled groups keep their ✗/✓ status on the left
- No visual change to settled (non-running) groups

### Pending ("Thinking") indicator
- Replaced three bouncing dots with a single **breathing ring** (scale + opacity pulse) in brand/primary color
- `Thread` gains a `pendingLabel` prop so hosts can pass a translated string (library has no i18n)
- `web/ChatView` provides a `PendingIndicator` component rendered as an element (own fiber) to respect Rules of Hooks, using `useTranslation` for the label

### Design mockup
`design/running-thinking-indicator.html` — standalone HTML prototype of the new indicators.

## Verification
- `go build ./...`, `go vet`, `golangci-lint` — 0 issues
- `go test ./...` — all pass
- Pre-push hook passed