### PR TITLE
fix(release): build jcode-computerd.app bundle before tauri build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,20 @@ jobs:
             done
           fi
 
+      # Assemble the jcode-computerd.app bundle (macOS resource declared in
+      # tauri.macos.conf.json). The script compiles the Swift helpers + Rust
+      # onboarding UI into a signed .app at desktop/src-tauri/bundles/.
+      - name: Build computerd bundle
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          case "${{ matrix.triple }}" in
+            aarch64-apple-darwin) SWIFT_TARGET="arm64-apple-macos14.0" ;;
+            x86_64-apple-darwin) SWIFT_TARGET="x86_64-apple-macos14.0" ;;
+          esac
+          mkdir -p desktop/src-tauri/bundles
+          script/build_computerd_bundle.sh "$SWIFT_TARGET" "desktop/src-tauri/bundles" "${{ matrix.triple }}"
+
       # macOS signing + notarization. Everything here is optional: with no secrets
       # the build still succeeds and produces an UNSIGNED bundle (Gatekeeper warns
       # on first launch). When the secrets are present, the Tauri CLI imports the


### PR DESCRIPTION
## 问题

Release workflow 的两个 macOS desktop job 在 v0.10.1 构建时失败（[run 29684575654](https://github.com/cnjack/jcode/actions/runs/29684575654/job/88186593659)）：

```
resource path `bundles/jcode-computerd.app` doesn't exist
Error failed to build app: failed to build app
```

## 原因

`desktop/src-tauri/tauri.macos.conf.json` 把 `bundles/jcode-computerd.app` 声明为 bundle resource，但 release workflow 从未组装这个 .app。于是 `pnpm tauri build` 的 cargo build script 在检查资源时找不到文件而失败。

## 修复

在 `Build desktop bundle`（`pnpm tauri build`）之前新增 `Build computerd bundle` 步骤，按 matrix triple 选择 Swift target，调用 `script/build_computerd_bundle.sh` 把 bundle 产出到 `desktop/src-tauri/bundles/`，路径与 tauri.macos.conf.json 声明的 resource 一致。仅在 `runner.os == 'macOS'` 时运行。

## 验证

- 步骤顺序正确：先 build computerd bundle，再 tauri build。
- 脚本输出 `<output-dir>/jcode-computerd.app` = `desktop/src-tauri/bundles/jcode-computerd.app`，与 resource 路径匹配。
- 本地 pre-push 检查（go build/vet/lint/test）通过。
- 真正的端到端验证需要在下次 Release tag 时由 CI 的 macOS job 确认。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated macOS builds for the signed `jcode-computerd.app` bundle.
  * macOS release packages now include the required Swift helpers and onboarding interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->