### PR TITLE
fix(release): Developer-ID sign nested computerd bundle before notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,75 @@ jobs:
             echo "notarization: DISABLED (no API key or Apple ID secrets)"
           fi
 
+      # The computerd bundle is a nested .app *resource* inside the Tauri app
+      # (Resources/jcode-computerd.app). Tauri signs the outer app and its
+      # externalBin sidecars with Developer ID, but does NOT re-sign resource
+      # bundles — so the ad-hoc signature applied by build_computerd_bundle.sh
+      # would survive into the notarization upload and Apple rejects it ("not
+      # signed with a valid Developer ID certificate" / "no secure timestamp" /
+      # "hardened runtime not enabled"). Re-sign the nested bundle here, before
+      # `tauri build`, so the outer signature references a properly signed inner
+      # bundle. Skipped when signing is disabled (no APPLE_CERTIFICATE): Tauri
+      # then neither signs nor notarizes, and the ad-hoc bundle is fine for an
+      # unsigned local build.
+      - name: Sign computerd bundle (Developer ID)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLE_CERTIFICATE:-}" ]; then
+            echo "code-signing disabled — leaving ad-hoc signature (no notarization)"
+            exit 0
+          fi
+          BUNDLE="desktop/src-tauri/bundles/jcode-computerd.app"
+
+          # Import the Developer ID certificate into a throwaway keychain so
+          # codesign can use it. Tauri builds its own keychain later for the
+          # outer app; the two coexist.
+          KEYCHAIN="$RUNNER_TEMP/computerd-signing.keychain-db"
+          KEYCHAIN_PW="$(openssl rand -hex 16)"
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          CERT="$RUNNER_TEMP/computerd-cert.p12"
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode > "$CERT"
+          security import "$CERT" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN"
+          security set-key-partition-list -S apple-tool:,apple: \
+            -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
+          # Prepend our keychain so codesign resolves the identity. The
+          # unquoted substitution is intentional: it expands to the list of
+          # existing keychain paths, each a separate argument.
+          # shellcheck disable=SC2046
+          security list-keychains -d user -s "$KEYCHAIN" \
+            $(security list-keychains -d user | tr -d '"')
+
+          # Resolve the signing identity (fall back to the first valid
+          # codesigning identity in the keychain when not explicitly set).
+          IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
+          if [ -z "$IDENTITY" ]; then
+            IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" | awk -F'"' 'NR==1{print $2}')"
+          fi
+          [ -n "$IDENTITY" ] || { echo "no Developer ID signing identity found" >&2; exit 1; }
+
+          # Sign from the inside out: workers first, then the daemon, then the
+          # bundle wrapper. Hardened runtime (--options runtime) + a secure
+          # timestamp are both mandatory for notarization. A shared identifier
+          # keeps the three binaries under one TCC identity (see the bundle
+          # script header). The daemon uses only AX + ScreenCaptureKit, which
+          # work under hardened runtime without extra entitlements.
+          for bin in jcode-computerd-capture jcode-computerd-onboarding jcode-computerd; do
+            [ -x "$BUNDLE/Contents/MacOS/$bin" ] || continue
+            codesign --force --options runtime --timestamp \
+              --sign "$IDENTITY" --identifier com.cnjack.jcode.computerd \
+              "$BUNDLE/Contents/MacOS/$bin"
+          done
+          codesign --force --options runtime --timestamp \
+            --sign "$IDENTITY" "$BUNDLE"
+
+          echo "Signed nested bundle with: $IDENTITY"
+          codesign --verify --deep --strict --verbose=2 "$BUNDLE"
+
       - name: Build desktop bundle
         shell: bash
         working-directory: desktop


### PR DESCRIPTION
## 问题

上一个 PR (#158) 修复后，bundle 能成功构建，但 Release 的两个 macOS desktop job 在**公证（notarization）**阶段失败（[run 29713342361](https://github.com/cnjack/jcode/actions/runs/29713342361/job/88261208224)）：

```
failed to notarize app: ... "Archive contains critical validation errors"
jcode.app/Contents/Resources/jcode-computerd.app/Contents/MacOS/jcode-computerd:
  - The binary is not signed with a valid Developer ID certificate.
  - The signature does not include a secure timestamp.
  - The executable does not have the hardened runtime enabled.
```

## 原因

computerd helpers 以**嵌套 .app resource**（`Resources/jcode-computerd.app`）形式打进 Tauri app。Tauri 只会用 Developer ID 签外层 app 和 `externalBin` sidecar，**不会**重签 resource 里的嵌套 bundle。于是 `build_computerd_bundle.sh` 打的 ad-hoc 签名被原样带入公证上传，被 Apple 拒绝。（设计文档 computer-helper-design.md §11 预留的 "Release wiring" 正是此处。）

## 修复

新增 CI 步骤 `Sign computerd bundle (Developer ID)`，在 `pnpm tauri build` 之前：
- 把 Developer ID 证书导入一次性 keychain；
- 对嵌套 bundle 的三个二进制（capture / onboarding / daemon）及 bundle 本体用 Developer ID 重签，启用 hardened runtime（`--options runtime`）+ secure timestamp，沿用共享 identifier 保持单一 TCC 身份；
- `codesign --verify --deep --strict` 校验。

仅当配置了 `APPLE_CERTIFICATE` 时执行；未配置签名时 Tauri 既不签名也不公证，ad-hoc bundle 对无签名本地构建仍然可用（早退 exit 0）。

daemon 仅使用 AX + ScreenCaptureKit，hardened runtime 下无需额外 entitlements（已 grep 确认无 DYLD/dlopen/JIT 等敏感用法）。

## 验证

- `actionlint` 通过（shellcheck 无告警）。
- YAML 合法（ruby 解析）。
- 脚本 bash 语法检查通过；`APPLE_CERTIFICATE` 未设置时早退 exit 0 已本地验证。
- 本地 pre-push（go build/vet/lint/test）通过。
- 端到端需下次打 Release tag 由 CI 的 macOS job 确认公证通过。