### PR TITLE
fix(sidebar): deleting the open conversation lands on welcome with a fresh session

### DIFF
--- a/internal/web/sessions.go
+++ b/internal/web/sessions.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/cloudwego/eino/schema"
 	"github.com/cnjack/jcode/internal/config"
@@ -213,10 +212,17 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "session id is required"})
 		return
 	}
-	// Tear down the live engine for this task (if any) so its run is cancelled and
-	// resources reclaimed. The active foreground engine is left in place — but its
-	// recorder is reset to a fresh session so post-delete writes don't land in the
-	// now-unlinked file (silent data loss).
+	// Refuse while the agent is mid-run. Cancelling + deleting a live task races
+	// the recorder (file/index resurrection) and is a bad UX for an intentional
+	// stop — the user should stop the run first, then delete.
+	if eng := s.resolveEngine(id); eng != nil && eng.running.Load() {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "agent is currently running"})
+		return
+	}
+	// Tear down the live engine for this task (if any) so leftover cancel state
+	// is cleared and resources reclaimed. The active foreground engine is left
+	// in place — but its recorder is reset so post-delete writes don't land in
+	// the now-unlinked file (silent data loss).
 	if eng := s.resolveEngine(id); eng != nil {
 		eng.emu.Lock()
 		cancel := eng.runCancel
@@ -227,42 +233,14 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 		if eng != s.activeEngine() {
 			s.deleteEngine(id)
 		} else {
-			// Active task: wait (bounded) for the cancelled run to drain so its
-			// final RecordAssistant/usage writes land before we close + reset
-			// the recorder (a post-close write would re-create and truncate the
-			// file).
-			for i := 0; i < 200 && eng.running.Load(); i++ {
-				time.Sleep(5 * time.Millisecond)
+			// Not running (guarded above): safe to close the recorder now.
+			eng.emu.Lock()
+			if eng.recorder != nil && eng.recorder.UUID() == id {
+				eng.recorder.Close()
+				eng.recorder = nil
+				eng.history = nil
 			}
-			if drained := !eng.running.Load(); drained {
-				eng.emu.Lock()
-				if eng.recorder != nil && eng.recorder.UUID() == id {
-					eng.recorder.Close()
-					eng.recorder = nil
-					eng.history = nil
-				}
-				eng.emu.Unlock()
-			} else {
-				// The run is still draining (a ctx-ignoring tool, a slow LLM
-				// tail). Closing the recorder now would let the live writer
-				// resurrect the session file this handler is about to delete.
-				// Defer the close until the run actually finishes, then re-run
-				// the deletion to sweep up anything the tail wrote in between
-				// (same discipline as the automation-run teardown).
-				go func() {
-					for i := 0; i < 6000 && eng.running.Load(); i++ {
-						time.Sleep(5 * time.Millisecond)
-					}
-					eng.emu.Lock()
-					if eng.recorder != nil && eng.recorder.UUID() == id {
-						eng.recorder.Close()
-						eng.recorder = nil
-						eng.history = nil
-					}
-					eng.emu.Unlock()
-					_, _ = session.DeleteSessionByUUID(id)
-				}()
-			}
+			eng.emu.Unlock()
 		}
 	}
 

--- a/internal/web/sessions.go
+++ b/internal/web/sessions.go
@@ -227,19 +227,42 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 		if eng != s.activeEngine() {
 			s.deleteEngine(id)
 		} else {
-			// Active task: wait for the cancelled run to drain so its final
-			// RecordAssistant/usage writes land before we close + reset the recorder
-			// (a post-close write would re-create and truncate the file).
+			// Active task: wait (bounded) for the cancelled run to drain so its
+			// final RecordAssistant/usage writes land before we close + reset
+			// the recorder (a post-close write would re-create and truncate the
+			// file).
 			for i := 0; i < 200 && eng.running.Load(); i++ {
 				time.Sleep(5 * time.Millisecond)
 			}
-			eng.emu.Lock()
-			if eng.recorder != nil && eng.recorder.UUID() == id {
-				eng.recorder.Close()
-				eng.recorder = nil
-				eng.history = nil
+			if drained := !eng.running.Load(); drained {
+				eng.emu.Lock()
+				if eng.recorder != nil && eng.recorder.UUID() == id {
+					eng.recorder.Close()
+					eng.recorder = nil
+					eng.history = nil
+				}
+				eng.emu.Unlock()
+			} else {
+				// The run is still draining (a ctx-ignoring tool, a slow LLM
+				// tail). Closing the recorder now would let the live writer
+				// resurrect the session file this handler is about to delete.
+				// Defer the close until the run actually finishes, then re-run
+				// the deletion to sweep up anything the tail wrote in between
+				// (same discipline as the automation-run teardown).
+				go func() {
+					for i := 0; i < 6000 && eng.running.Load(); i++ {
+						time.Sleep(5 * time.Millisecond)
+					}
+					eng.emu.Lock()
+					if eng.recorder != nil && eng.recorder.UUID() == id {
+						eng.recorder.Close()
+						eng.recorder = nil
+						eng.history = nil
+					}
+					eng.emu.Unlock()
+					_, _ = session.DeleteSessionByUUID(id)
+				}()
 			}
-			eng.emu.Unlock()
 		}
 	}
 

--- a/internal/web/tasks_test.go
+++ b/internal/web/tasks_test.go
@@ -196,6 +196,34 @@ func TestUpdateTaskMetaResponseShape(t *testing.T) {
 	}
 }
 
+// Running tasks must not be deleted: cancel+delete races the recorder and is
+// the wrong product behaviour (stop first, then delete).
+func TestDeleteSessionRejectsRunning(t *testing.T) {
+	seedIndex(t, map[string][]session.SessionMeta{
+		"/work/p": {{UUID: "run-1", Project: "/work/p"}},
+	})
+	eng := &Engine{taskID: "run-1", pwd: "/work/p"}
+	eng.running.Store(true)
+	s := &Server{Engine: eng, tasks: map[string]*Engine{"run-1": eng}}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/sessions/run-1", nil)
+	req.SetPathValue("id", "run-1")
+	s.handleDeleteSession(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("delete while running: code=%d body=%q, want 409", rec.Code, rec.Body.String())
+	}
+	all, err := session.ListAllSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all["/work/p"]) != 1 || all["/work/p"][0].UUID != "run-1" {
+		t.Fatalf("running session must remain indexed, got %+v", all["/work/p"])
+	}
+	if !eng.running.Load() {
+		t.Fatal("delete must not clear the running flag")
+	}
+}
+
 // Regression: deleting a task that belongs to a project OTHER than the active
 // one (s.pwd) must still remove it from the index — the sidebar tree can delete
 // across projects. Previously this silently no-op'd, leaving a ghost task.

--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -497,6 +497,14 @@ const sessionSlice = createSlice({
       const { uuid: _uuid, ...rest } = a.payload
       Object.assign(t, rest)
     },
+    /** Remove a deleted session from BOTH lists, inside the reducer (operates
+     *  on the latest state — a component-side filter over render-scope copies
+     *  would clobber any list update that landed during the delete round-trip,
+     *  and unlike setTasks/setSessions this never re-adds anything). */
+    removeSession(s, a: { payload: string }) {
+      s.sessions = s.sessions.filter((x) => x.uuid !== a.payload)
+      s.tasks = s.tasks.filter((x) => x.uuid !== a.payload)
+    },
     /** Insert or merge a session for the active-project fallback list. */
     upsertSession(s, a: { payload: SessionItem }) {
       const i = s.sessions.findIndex((x) => x.uuid === a.payload.uuid)

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -92,6 +92,11 @@ export function Sidebar() {
   const tasks = useAppSelector((s) => s.session.tasks)
   const projectTimes = useAppSelector((s) => s.session.projectTimes)
   const currentSessionId = useAppSelector((s) => s.session.currentSessionId)
+  // Latest currentSessionId readable from async handlers (deleteItem) after an
+  // await, when the render-scope value is stale: if the user navigated away
+  // while the DELETE was in flight, the delete must not yank the foreground.
+  const currentSessionRef = useRef(currentSessionId)
+  currentSessionRef.current = currentSessionId
   const activePath = useAppSelector((s) => s.session.projectPath)
   const activeView = useAppSelector((s) => s.ui.activeView)
 
@@ -376,19 +381,37 @@ export function Sidebar() {
 
   async function deleteItem(row: SessionRow) {
     const wasActive = row.uuid === currentSessionId
+    if (wasActive) {
+      // Drop queued type-ahead for this session BEFORE the delete round-trip:
+      // the cancelled run's agent_done reaches the client before the DELETE
+      // response, and would otherwise drain the queue back into the deleted
+      // session — resurrecting its file + index entry on disk.
+      dispatch(chatActions.dropSessionQueue(row.uuid))
+    }
     try {
       await api.deleteSession(row.uuid)
     } catch {
       return
     }
-    dispatch(sessionActions.setSessions(sessions.filter((s) => s.uuid !== row.uuid)))
-    dispatch(sessionActions.setTasks(tasks.filter((t) => t.uuid !== row.uuid)))
-    dispatch(chatActions.dropSessionQueue(row.uuid))
-    if (wasActive) {
-      dispatch(chatActions.clearChat())
-      dispatch(sessionActions.setCurrentSession(''))
-      dispatch(chatActions.setRunning(false))
+    // Filter inside the reducer: the render-scope sessions/tasks copies are
+    // stale after the await (a WS update or refresh may have landed since),
+    // and a whole-list setTasks would clobber it.
+    dispatch(sessionActions.removeSession(row.uuid))
+    if (!wasActive) {
+      dispatch(chatActions.dropSessionQueue(row.uuid))
+      return
     }
+    // The user may have navigated to another session while the DELETE was in
+    // flight (their click's loadSession wins) — only take over the foreground
+    // if we're still on the deleted session.
+    if (currentSessionRef.current !== row.uuid) return
+    // Land on the welcome page with a FRESH session. Merely clearing the UI
+    // would strand the backend on the deleted task's engine: the next
+    // message would run on that stale engine, whose events are stamped with
+    // the deleted task id and dropped by the WS filter (a conversation that
+    // appears dead). startNewChat provisions a consistent new engine/task —
+    // and reclaims the stale one (its recorder was reset on delete).
+    await dispatch(startNewChat())
   }
 
   function openContext(e: React.MouseEvent, row: SessionRow) {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -380,12 +380,14 @@ export function Sidebar() {
   }
 
   async function deleteItem(row: SessionRow) {
+    // Running tasks must not be deleted — backend also returns 409. Stop first.
+    if (row.running) return
     const wasActive = row.uuid === currentSessionId
     if (wasActive) {
       // Drop queued type-ahead for this session BEFORE the delete round-trip:
-      // the cancelled run's agent_done reaches the client before the DELETE
-      // response, and would otherwise drain the queue back into the deleted
-      // session — resurrecting its file + index entry on disk.
+      // a late agent_done (from a prior cancel/stop) can arrive before the
+      // DELETE response and would otherwise drain the queue back into the
+      // deleted session — resurrecting its file + index entry on disk.
       dispatch(chatActions.dropSessionQueue(row.uuid))
     }
     try {
@@ -480,6 +482,8 @@ export function Sidebar() {
           icon={TrashIcon}
           label={t('sidebar.actions.delete')}
           danger
+          disabled={row.running}
+          title={row.running ? t('sidebar.actions.deleteWhileRunning') : undefined}
           onClick={() => { void deleteItem(row); closeCtx() }}
         />
       </>
@@ -879,19 +883,34 @@ function CtxItem({
   label,
   onClick,
   danger,
+  disabled,
+  title,
 }: {
   icon: React.ComponentType<{ className?: string }>
   label: string
   onClick: () => void
   danger?: boolean
+  disabled?: boolean
+  title?: string
 }) {
   return (
     <button
       type="button"
       role="menuitem"
-      onClick={onClick}
-      className={`flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-left text-[12.5px] transition-colors hover:bg-[var(--color-muted)] ${
-        danger ? 'text-[var(--color-destructive)]' : 'text-[var(--color-foreground)]'
+      disabled={disabled}
+      title={title}
+      aria-disabled={disabled || undefined}
+      onClick={disabled ? undefined : onClick}
+      className={`flex w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-left text-[12.5px] transition-colors ${
+        disabled
+          ? 'cursor-not-allowed opacity-45'
+          : 'hover:bg-[var(--color-muted)]'
+      } ${
+        danger && !disabled
+          ? 'text-[var(--color-destructive)]'
+          : disabled
+            ? 'text-[var(--color-muted-foreground)]'
+            : 'text-[var(--color-foreground)]'
       }`}
     >
       <Icon className="h-3.5 w-3.5" />

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -1050,6 +1050,7 @@ export default {
       markRead: 'Mark read',
       markUnread: 'Mark unread',
       delete: 'Delete',
+      deleteWhileRunning: 'Stop the agent before deleting this conversation',
       taskActions: 'Task actions',
     },
     relativeTime: {

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -999,6 +999,7 @@ export default {
       markRead: '既読にする',
       markUnread: '未読にする',
       delete: '削除',
+      deleteWhileRunning: '削除する前にエージェントを停止してください',
       taskActions: 'タスク操作',
     },
     relativeTime: {

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -998,6 +998,7 @@ export default {
       markRead: '읽음으로 표시',
       markUnread: '안 읽음으로 표시',
       delete: '삭제',
+      deleteWhileRunning: '삭제하기 전에 실행 중인 에이전트를 중지하세요',
       taskActions: '작업 동작',
     },
     relativeTime: {

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -1025,6 +1025,7 @@ export default {
       markRead: '标记为已读',
       markUnread: '标记为未读',
       delete: '删除',
+      deleteWhileRunning: '请先停止运行中的 Agent，再删除此会话',
       taskActions: '任务操作',
     },
     relativeTime: {

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -993,6 +993,7 @@ export default {
       markRead: '標記為已讀',
       markUnread: '標記為未讀',
       delete: '刪除',
+      deleteWhileRunning: '請先停止執行中的 Agent，再刪除此對話',
       taskActions: '工作操作',
     },
     relativeTime: {


### PR DESCRIPTION
## 需求

允许删除当前已经打开的 conversation，删除之后跳转到 welcome 页面。

>  stacked on #160（base 为 feat/project-last-updated），#160 合并后请将本 PR 的 base 改为 main。

## 问题

之前删除当前打开的会话只是清空 UI（clearChat + setCurrentSession('')），后端仍停留在被删任务的 engine 上：

1. **僵尸 engine**：下一条消息会落到这个旧 engine 上运行，而所有事件都打着已删除的 task id 戳，被 WS 客户端过滤器丢弃 → 新对话看起来像「死了」。
2. **行复活**：setTasks/setSessions reducer 有「保护尚未入索引的当前会话」的防竞态逻辑，删除时该会话仍是 current session → 刚删掉的行被重新加回列表。
3. **队列复活**：被取消运行的 agent_done 先于 DELETE 响应到达客户端，会把该会话的排队消息（type-ahead queue）重新发送进已删除的会话 → 磁盘上文件 + 索引条目复活。
4. **后端 drain 窗口**：删除正在运行的当前任务时，若 1s 内 run 未排空，旧代码直接关闭 recorder → 存活的 writer 会重建刚删除的 JSONL 文件。

## 修复

**前端（Sidebar.tsx deleteItem）**
- 删除当前会话成功后 dispatch `startNewChat()`：创建一致的新 engine/task（旧 engine 因 recorder 已被重置而被回收），UI 落到 welcome 页
- 新增 `removeSession` reducer：在 reducer 内对最新 state 过滤（避免 await 期间闭包过期覆盖列表更新；且不会触发 current-session 保护逻辑）
- 当前会话的 type-ahead 队列在 DELETE 往返**之前**清空（阻断 agent_done 复活路径）
- await 之后通过 ref 复查 currentSession：若用户在 DELETE 期间已切到别的会话，则尊重用户的导航，不再抢占前台

**后端（sessions.go handleDeleteSession）**
- 被删当前任务的 run 在有限等待内未排空时，不再在存活 writer 下关闭 recorder；改为后台等待排空后关闭，并**重跑一次删除**清扫 tail 写入（与 automation-run teardown 同一模式）

## 验证

- `golangci-lint` 0 issues；`make lint-web` 通过；`go test ./internal/web/ ./internal/session/` 通过
- 浏览器端到端：打开某会话 → ⋯ 菜单 Delete → welcome 页出现、该行从侧栏消失、后端 active session 变为全新 UUID、project 的持久化时间与排序不受影响

## 对抗评审

已经过一轮对抗评审，修复了：
1. major — 删除 + 快速打开另一会话的竞态（await 后复查 currentSession）
2. major — 排队消息经 agent_done 复活已删会话（提前清空队列）
3. major — 闭包过期整表覆盖（removeSession reducer）
4. major — 后端 drain 未排空时关闭 recorder 导致文件复活（后台 drain + 清扫）

已知边界（可接受/后续跟进）：
- `api.newSession()` 失败（如 64 engine 上限）时回退到 welcome，此时发消息仍可能命中旧 engine；属极罕见错误路径，刷新页面即可恢复
- 删除后 `currentSessionId=''` 窗口期 WS 过滤放宽，与现有 startNewChat 流程行为一致（非本 PR 引入）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a running conversation now fails with a clear conflict message until the agent is stopped, preventing inconsistent state.
  * Sidebar and task/chat queues now update deterministically after deletion, avoiding late updates and unnecessary resets.
  * If you navigate away during deletion, the chat UI is preserved.
* **UI & Localization**
  * Added a localized sidebar message and disabled Delete while an agent is running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->