### PR TITLE
Simplify cloud sync toolbar controls

### DIFF
--- a/web/src/components/CloudSyncToggle.tsx
+++ b/web/src/components/CloudSyncToggle.tsx
@@ -84,18 +84,15 @@ export function CloudSyncToggle() {
         aria-label={t('cloud.syncSession')}
         aria-pressed={synced}
         title={title}
-        className="inline-flex h-[34px] items-center justify-center gap-1.5 rounded-[var(--radius-lg)] border px-2.5 text-[11px] font-medium transition-[background,color,border-color,transform] duration-150 active:translate-y-px disabled:cursor-not-allowed disabled:opacity-50"
+        className="inline-flex h-[34px] w-[34px] items-center justify-center rounded-[var(--radius-lg)] bg-transparent transition-[color,transform] duration-150 active:translate-y-px disabled:cursor-not-allowed disabled:opacity-50"
         style={{
           color: synced ? 'var(--color-accent-neutral)' : 'var(--color-muted-foreground)',
-          borderColor: 'var(--color-border)',
-          backgroundColor: synced ? 'var(--accent-wash)' : 'var(--color-background)',
         }}
       >
         <span className="relative">
           <CloudIcon className="h-4 w-4" />
           {!synced && loggedIn && <span aria-hidden="true" className="absolute left-0 top-1/2 h-px w-4 -rotate-45 bg-current" />}
         </span>
-        <span>{synced ? t('cloud.syncing') : t('cloud.syncDisabled')}</span>
       </button>
     </div>
   )

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -157,10 +157,10 @@ export function TopBar({ isRunning, wsConnected, activePanel, terminalOpen, onTo
             void loadDiffStat()
             setOpen((v) => !v)
           }}
-          className={`inline-flex h-[34px] items-center gap-[3px] rounded-[var(--radius-lg)] border px-[9px] transition-[background,color,border-color] duration-150 ${
+          className={`inline-flex h-[34px] items-center gap-[3px] rounded-[var(--radius-lg)] px-[9px] transition-[background,color] duration-150 ${
             open
-              ? 'bg-[var(--color-muted)] text-[var(--color-foreground)] border-[var(--color-foreground)]'
-              : 'bg-[var(--color-background)] text-[var(--color-muted-foreground)] border-[var(--color-border)] hover:text-[var(--color-foreground)] hover:border-[var(--color-foreground)]'
+              ? 'bg-[var(--color-muted)] text-[var(--color-foreground)]'
+              : 'bg-[var(--color-background)] text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)]'
           }`}
         >
           <RectangleStackIcon className="h-4 w-4" />


### PR DESCRIPTION
## Summary

- remove the borders around the cloud-sync and panels toolbar controls
- render cloud sync as an icon-only button
- keep the active cloud-sync state transparent and communicate state through icon color

## Why

The bordered controls and persistent sync label added unnecessary visual weight to the compact top-right toolbar. The cloud control should remain lightweight while preserving its existing behavior and accessible labels.

## Impact

The toolbar is more compact and visually quieter. Cloud sync behavior, disabled state, tooltip, `aria-label`, and `aria-pressed` semantics remain unchanged.

## Root cause

The cloud-sync button rendered state text, a border, and an active wash background, while the adjacent panels button also rendered a border.

## Validation

- `pnpm --dir web typecheck`
- pre-push hook: `go build ./...`
- pre-push hook: `go vet ./...`
- pre-push hook: golangci-lint (new issues vs `origin/main`)
- pre-push hook: `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the cloud sync control to display only its icon while preserving accessibility labels and sync behavior.
  * Refined button interactions with transparent styling and clearer active/disabled transitions.
  * Removed border changes from the floating panels menu’s open and closed states for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->