### PR TITLE
Honor persisted model visibility in model picker

### DIFF
--- a/internal/web/models_test.go
+++ b/internal/web/models_test.go
@@ -1,10 +1,16 @@
 package web
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cnjack/jcode/internal/config"
+	"github.com/cnjack/jcode/internal/model"
 )
 
 func TestWebSwitchModelSameValueIsNoOp(t *testing.T) {
@@ -17,5 +23,62 @@ func TestWebSwitchModelSameValueIsNoOp(t *testing.T) {
 		strings.NewReader(`{"provider":"openai","model":"gpt-5"}`)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("same model: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProviderCatalogUsesPersistedModelVisibility(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := filepath.Join(home, ".jcode")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(configDir, "config.json"),
+		[]byte(`{"providers":{"zhipuai-coding-plan":{"api_key":"test"}}}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	state := &config.ModelState{
+		EnabledModels: []config.ModelRef{{
+			Provider: "zhipuai-coding-plan",
+			Model:    "glm-4.5-air",
+		}},
+		DisabledModels: []config.ModelRef{{
+			Provider: "zhipuai-coding-plan",
+			Model:    "glm-5.2",
+		}},
+	}
+	if err := config.SaveModelState(state); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := model.NewModelRegistry()
+	s := &Server{registry: registry}
+	req := httptest.NewRequest(http.MethodGet, "/api/providers/zhipuai-coding-plan/models", nil)
+	req.SetPathValue("id", "zhipuai-coding-plan")
+	rec := httptest.NewRecorder()
+	s.handleProviderCatalog(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("catalog: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+
+	var got []struct {
+		ID    string `json:"id"`
+		Added bool   `json:"added"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	addedByID := make(map[string]bool, len(got))
+	for _, item := range got {
+		addedByID[item.ID] = item.Added
+	}
+	if !addedByID["glm-4.5-air"] {
+		t.Error("explicitly enabled glm-4.5-air was reported disabled")
+	}
+	if addedByID["glm-5.2"] {
+		t.Error("explicitly disabled default glm-5.2 was reported enabled")
 	}
 }

--- a/internal/web/providers.go
+++ b/internal/web/providers.go
@@ -57,6 +57,7 @@ func (s *Server) handleProviderCatalog(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	modelState, _ := config.LoadModelState()
 
 	// customEntry builds a catalogEntry from a user-defined CustomModelConfig.
 	customEntry := func(id string) catalogEntry {
@@ -130,9 +131,12 @@ func (s *Server) handleProviderCatalog(w http.ResponseWriter, r *http.Request) {
 				ctx = m.Limit.Context
 			}
 			result = append(result, catalogEntry{
-				ID:         m.ID,
-				Name:       m.Name,
-				Added:      configured[m.ID] || m.DefaultEnabled,
+				ID:   m.ID,
+				Name: m.Name,
+				Added: modelState.IsModelEnabled(
+					config.ModelRef{Provider: providerID, Model: m.ID},
+					m.DefaultEnabled,
+				),
 				Context:    ctx,
 				Reasoning:  m.Reasoning,
 				Attachment: m.Attachment,

--- a/packages/jcode-ui/src/product/ChatInput.test.tsx
+++ b/packages/jcode-ui/src/product/ChatInput.test.tsx
@@ -21,15 +21,15 @@ const PROVIDERS: ProviderInfo[] = [
     id: 'openai',
     name: 'OpenAI',
     models: [
-      { id: 'gpt-4o', name: 'GPT-4o', tool_call: true, image_support: true, context_limit: 128000 },
-      { id: 'gpt-4o-mini', name: 'GPT-4o mini', tool_call: true, context_limit: 128000 },
+      { id: 'gpt-4o', name: 'GPT-4o', tool_call: true, enabled: true, image_support: true, context_limit: 128000 },
+      { id: 'gpt-4o-mini', name: 'GPT-4o mini', tool_call: true, enabled: true, context_limit: 128000 },
     ],
   },
   {
     id: 'anthropic',
     name: 'Anthropic',
     models: [
-      { id: 'claude-sonnet', name: 'Claude Sonnet', tool_call: true, reasoning: true },
+      { id: 'claude-sonnet', name: 'Claude Sonnet', tool_call: true, enabled: true, reasoning: true },
       { id: 'claude-hidden', name: 'Claude Hidden', tool_call: true, enabled: false },
     ],
   },
@@ -222,6 +222,41 @@ describe('model picker', () => {
     fireEvent.change(screen.getByPlaceholderText('Filter models…'), { target: { value: 'mini' } })
     await waitFor(() => expect(screen.getByText('GPT-4o mini')).toBeTruthy())
     expect(screen.queryByText('Claude Sonnet')).toBeNull()
+  })
+
+  it('fails closed when a model has no enabled flag', async () => {
+    const providers = [
+      ...PROVIDERS,
+      {
+        id: 'legacy',
+        name: 'Legacy Provider',
+        models: [
+          {
+            id: 'builtin-without-state',
+            name: 'Built-in Without State',
+            tool_call: true,
+          },
+        ],
+      },
+    ]
+    renderComposer(makeHost({ providers }))
+
+    fireEvent.click(screen.getByText('GPT-4o'))
+    await waitFor(() => expect(screen.getByPlaceholderText('Filter models…')).toBeTruthy())
+
+    expect(screen.queryByText('Built-in Without State')).toBeNull()
+  })
+
+  it('does not surface a disabled favorite', async () => {
+    renderComposer(makeHost({
+      favoriteModels: ['anthropic/claude-hidden'],
+      recentModels: [{ provider: 'anthropic', model: 'claude-hidden' }],
+    }))
+
+    fireEvent.click(screen.getByText('GPT-4o'))
+    await waitFor(() => expect(screen.getByPlaceholderText('Filter models…')).toBeTruthy())
+
+    expect(screen.queryByText('Claude Hidden')).toBeNull()
   })
 
   it('selecting a model calls host.selectModel', async () => {

--- a/packages/jcode-ui/src/product/ChatInput.tsx
+++ b/packages/jcode-ui/src/product/ChatInput.tsx
@@ -316,7 +316,7 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
   const pickerProviders = useMemo(
     () =>
       filteredProviders
-        .map((p) => ({ ...p, models: p.models.filter((m) => m.enabled !== false) }))
+        .map((p) => ({ ...p, models: p.models.filter((m) => m.enabled === true) }))
         .filter((p) => p.models.length > 0),
     [filteredProviders],
   )
@@ -327,6 +327,7 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
     return recentModels.filter((r) => {
       if (!favSet.has(`${r.provider}/${r.model}`)) return false
       if (providerName === r.provider && modelName === r.model) return false
+      if (modelInfoFor(r.provider, r.model)?.enabled !== true) return false
       if (!q) return true
       const name = getModelDisplayName(r.provider, r.model).toLowerCase()
       return name.includes(q) || r.provider.toLowerCase().includes(q)
@@ -362,7 +363,10 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
   }, [currentEffort, currentModelInfo])
   const showEffortControl = currentEffortOptions.length > 0
 
-  const manageVisibleCount = filteredProviders.reduce((n, p) => n + p.models.length, 0)
+  const manageVisibleCount = filteredProviders.reduce(
+    (n, p) => n + p.models.filter((m) => m.enabled === true).length,
+    0,
+  )
   const manageTotalCount = providers.reduce((n, p) => n + p.models.length, 0)
 
   // Local pseudo-command: "/goal" arms Goal mode (same as the "+" menu entry)
@@ -1566,7 +1570,7 @@ function ManageModelsDialog({
                 <span className="ml-auto font-mono text-[10px] text-[var(--color-muted-foreground)]">{p.models.length}</span>
               </div>
               {p.models.map((m) => {
-                const off = m.enabled === false
+                const off = m.enabled !== true
                 return (
                   <div
                     key={`mgr-${p.id}-${m.id}`}

--- a/packages/jcode-ui/src/product/types.ts
+++ b/packages/jcode-ui/src/product/types.ts
@@ -26,6 +26,7 @@ export interface ModelInfo {
   reasoning?: boolean
   recommended?: boolean
   default_enabled?: boolean
+  /** Whether this model is available in the chat picker. Omitted is treated as disabled. */
   enabled?: boolean
   image_support?: boolean
   /** How this model exposes its reasoning/thinking controls. */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -116,7 +116,8 @@ export interface ModelInfo {
   reasoning?: boolean
   recommended?: boolean
   default_enabled?: boolean
-  enabled?: boolean
+  // Always supplied by GET /api/models; only true entries belong in pickers.
+  enabled: boolean
   image_support?: boolean
   // How this model exposes its reasoning/thinking controls (from models.dev).
   // Absent/empty ⇒ no reasoning controls to render.


### PR DESCRIPTION
## Summary

- derive provider catalog `added` state from the persisted model visibility state
- require models to be explicitly enabled before showing them in the chat picker or model manager counts
- hide disabled models from favorites and recent-model shortcuts
- make the web model contract require the backend-provided `enabled` field
- add backend and component coverage for enabled, disabled, omitted, favorite, and recent model states

## Why

The model picker could surface models that users had explicitly disabled. Missing `enabled` fields were also treated as visible, which made stale or incomplete provider data fail open.

## Impact

Model availability now consistently follows the persisted enable/disable state across the provider catalog, picker, manager counts, favorites, and recent models. Missing visibility state fails closed.

## Root cause

The provider catalog combined configured/default state without consulting `ModelState`, while the UI filtered with `enabled !== false`. Together, those behaviors allowed disabled or unspecified models to remain selectable.

## Validation

- `go test ./internal/web -run 'TestProviderCatalogUsesPersistedModelVisibility|TestWebSwitchModelSameValueIsNoOp'`
- `pnpm --dir packages/jcode-ui test -- ChatInput.test.tsx` (15 tests)
- `pnpm --dir packages/jcode-ui typecheck`
- `pnpm --dir web typecheck`
- pre-push hook: `go build ./...`
- pre-push hook: `go vet ./...`
- pre-push hook: golangci-lint (new issues vs `origin/main`)
- pre-push hook: `go test ./...`