### PR TITLE
feat(desktop): add task context titlebar

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1589,6 +1589,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "icns"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467efeb2c1e570cebb9863f9173447f8fe92303d66adc97cb89ac824b60e7a0f"
+dependencies = [
+ "byteorder",
+ "png 0.18.1",
+]
+
+[[package]]
 name = "ico"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1820,11 @@ dependencies = [
 name = "jcode-desktop"
 version = "0.5.3"
 dependencies = [
+ "base64 0.22.1",
+ "icns",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "plist",
  "serde",
  "serde_json",
  "tauri",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -28,6 +28,13 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-global-shortcut = "2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+base64 = "0.22"
+icns = { version = "0.4", default-features = false, features = ["pngio"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSWorkspace"] }
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSArray", "NSString", "NSURL"] }
+plist = "1"
+
 [profile.release]
 panic = "abort"
 codegen-units = 1

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -20,6 +20,33 @@
     "notification:default",
     "opener:default",
     {
+      "identifier": "opener:allow-open-path",
+      "allow": [
+        { "path": "$HOME/**", "app": "Finder" },
+        { "path": "$HOME/**", "app": "Visual Studio Code" },
+        { "path": "$HOME/**", "app": "Cursor" },
+        { "path": "$HOME/**", "app": "Zed" },
+        { "path": "$HOME/**", "app": "Antigravity" },
+        { "path": "$HOME/**", "app": "Terminal" },
+        { "path": "$HOME/**", "app": "iTerm" },
+        { "path": "$HOME/**", "app": "Ghostty" },
+        { "path": "$HOME/**", "app": "Warp" },
+        { "path": "$HOME/**", "app": "Xcode" },
+        { "path": "$HOME/**", "app": "GoLand" },
+        { "path": "/Volumes/**", "app": "Finder" },
+        { "path": "/Volumes/**", "app": "Visual Studio Code" },
+        { "path": "/Volumes/**", "app": "Cursor" },
+        { "path": "/Volumes/**", "app": "Zed" },
+        { "path": "/Volumes/**", "app": "Antigravity" },
+        { "path": "/Volumes/**", "app": "Terminal" },
+        { "path": "/Volumes/**", "app": "iTerm" },
+        { "path": "/Volumes/**", "app": "Ghostty" },
+        { "path": "/Volumes/**", "app": "Warp" },
+        { "path": "/Volumes/**", "app": "Xcode" },
+        { "path": "/Volumes/**", "app": "GoLand" }
+      ]
+    },
+    {
       "identifier": "opener:allow-open-url",
       "allow": [
         {

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -20,33 +20,6 @@
     "notification:default",
     "opener:default",
     {
-      "identifier": "opener:allow-open-path",
-      "allow": [
-        { "path": "$HOME/**", "app": "Finder" },
-        { "path": "$HOME/**", "app": "Visual Studio Code" },
-        { "path": "$HOME/**", "app": "Cursor" },
-        { "path": "$HOME/**", "app": "Zed" },
-        { "path": "$HOME/**", "app": "Antigravity" },
-        { "path": "$HOME/**", "app": "Terminal" },
-        { "path": "$HOME/**", "app": "iTerm" },
-        { "path": "$HOME/**", "app": "Ghostty" },
-        { "path": "$HOME/**", "app": "Warp" },
-        { "path": "$HOME/**", "app": "Xcode" },
-        { "path": "$HOME/**", "app": "GoLand" },
-        { "path": "/Volumes/**", "app": "Finder" },
-        { "path": "/Volumes/**", "app": "Visual Studio Code" },
-        { "path": "/Volumes/**", "app": "Cursor" },
-        { "path": "/Volumes/**", "app": "Zed" },
-        { "path": "/Volumes/**", "app": "Antigravity" },
-        { "path": "/Volumes/**", "app": "Terminal" },
-        { "path": "/Volumes/**", "app": "iTerm" },
-        { "path": "/Volumes/**", "app": "Ghostty" },
-        { "path": "/Volumes/**", "app": "Warp" },
-        { "path": "/Volumes/**", "app": "Xcode" },
-        { "path": "/Volumes/**", "app": "GoLand" }
-      ]
-    },
-    {
       "identifier": "opener:allow-open-url",
       "allow": [
         {

--- a/desktop/src-tauri/src/desktop_apps.rs
+++ b/desktop/src-tauri/src/desktop_apps.rs
@@ -1,0 +1,357 @@
+//! Native macOS application discovery for the title-bar "Open in" menu.
+//!
+//! The frontend never guesses whether an editor is installed and never sends
+//! an executable path. This module resolves a curated set of developer apps by
+//! bundle identifier through Launch Services, extracts each installed app's
+//! own icon, and accepts only the opaque IDs declared below when opening a
+//! workspace.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy)]
+struct WorkspaceAppCandidate {
+    id: &'static str,
+    label: &'static str,
+    bundle_ids: &'static [&'static str],
+    group: &'static str,
+    reveal_in_finder: bool,
+}
+
+const WORKSPACE_APP_CANDIDATES: &[WorkspaceAppCandidate] = &[
+    WorkspaceAppCandidate {
+        id: "vscode",
+        label: "VS Code",
+        bundle_ids: &["com.microsoft.VSCode"],
+        group: "editor",
+        reveal_in_finder: false,
+    },
+    WorkspaceAppCandidate {
+        id: "cursor",
+        label: "Cursor",
+        bundle_ids: &["com.todesktop.230313mzl4w4u92"],
+        group: "editor",
+        reveal_in_finder: false,
+    },
+    WorkspaceAppCandidate {
+        id: "zed",
+        label: "Zed",
+        bundle_ids: &["dev.zed.Zed", "dev.zed.Zed-Preview"],
+        group: "editor",
+        reveal_in_finder: false,
+    },
+    WorkspaceAppCandidate {
+        id: "antigravity",
+        label: "Antigravity",
+        bundle_ids: &["com.google.antigravity"],
+        group: "editor",
+        reveal_in_finder: false,
+    },
+    WorkspaceAppCandidate {
+        id: "finder",
+        label: "Finder",
+        bundle_ids: &["com.apple.finder"],
+        group: "system",
+        reveal_in_finder: true,
+    },
+    WorkspaceAppCandidate {
+        id: "terminal",
+        label: "Terminal",
+        bundle_ids: &["com.apple.Terminal"],
+        group: "system",
+        reveal_in_finder: false,
+    },
+    WorkspaceAppCandidate {
+        id: "iterm",
+        label: "iTerm2",
+        bundle_ids: &["com.googlecode.iterm2"],
+        group: "system",
+        reveal_in_finder: false,
+    },
+    WorkspaceAppCandidate {
+        id: "ghostty",
+        label: "Ghostty",
+        bundle_ids: &["com.mitchellh.ghostty"],
+        group: "system",
+        reveal_in_finder: false,
+    },
+    WorkspaceAppCandidate {
+        id: "warp",
+        label: "Warp",
+        bundle_ids: &["dev.warp.Warp-Stable", "dev.warp.Warp"],
+        group: "system",
+        reveal_in_finder: false,
+    },
+    WorkspaceAppCandidate {
+        id: "xcode",
+        label: "Xcode",
+        bundle_ids: &["com.apple.dt.Xcode"],
+        group: "system",
+        reveal_in_finder: false,
+    },
+    WorkspaceAppCandidate {
+        id: "goland",
+        label: "GoLand",
+        bundle_ids: &["com.jetbrains.goland"],
+        group: "system",
+        reveal_in_finder: false,
+    },
+];
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceApplication {
+    id: &'static str,
+    label: &'static str,
+    group: &'static str,
+    icon_data_url: Option<String>,
+}
+
+#[tauri::command]
+pub fn list_workspace_applications() -> Vec<WorkspaceApplication> {
+    imp::list_workspace_applications()
+}
+
+#[tauri::command]
+pub fn open_workspace_in_application(path: String, app_id: String) -> Result<(), String> {
+    let workspace = validate_workspace_path(&path)?;
+    let candidate = candidate_by_id(&app_id)
+        .ok_or_else(|| format!("unsupported workspace application: {app_id}"))?;
+    imp::open_workspace(&workspace, candidate)
+}
+
+fn candidate_by_id(id: &str) -> Option<&'static WorkspaceAppCandidate> {
+    WORKSPACE_APP_CANDIDATES
+        .iter()
+        .find(|candidate| candidate.id == id)
+}
+
+fn validate_workspace_path(path: &str) -> Result<PathBuf, String> {
+    let requested = PathBuf::from(path);
+    if !requested.is_absolute() {
+        return Err("workspace path must be absolute".to_string());
+    }
+
+    let canonical = requested
+        .canonicalize()
+        .map_err(|error| format!("workspace path is unavailable: {error}"))?;
+    if !canonical.is_dir() {
+        return Err("workspace path must be a directory".to_string());
+    }
+
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| "HOME is unavailable".to_string())?;
+    let canonical_home = home.canonicalize().unwrap_or(home);
+    if !is_allowed_workspace_root(&canonical, &canonical_home) {
+        return Err("workspace path is outside the allowed local roots".to_string());
+    }
+
+    Ok(canonical)
+}
+
+fn is_allowed_workspace_root(path: &Path, home: &Path) -> bool {
+    path.starts_with(home) || path.starts_with("/Volumes")
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use super::{WorkspaceAppCandidate, WorkspaceApplication, WORKSPACE_APP_CANDIDATES};
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use icns::IconFamily;
+    use objc2_app_kit::NSWorkspace;
+    use objc2_foundation::{NSArray, NSString, NSURL};
+    use plist::Value;
+    use std::fs::File;
+    use std::io::BufReader;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
+
+    pub fn list_workspace_applications() -> Vec<WorkspaceApplication> {
+        WORKSPACE_APP_CANDIDATES
+            .iter()
+            .filter_map(|candidate| {
+                let app_path = resolve_application(candidate)?;
+                Some(WorkspaceApplication {
+                    id: candidate.id,
+                    label: candidate.label,
+                    group: candidate.group,
+                    icon_data_url: app_icon_data_url(&app_path),
+                })
+            })
+            .collect()
+    }
+
+    pub fn open_workspace(
+        workspace_path: &Path,
+        candidate: &WorkspaceAppCandidate,
+    ) -> Result<(), String> {
+        let app_path = resolve_application(candidate)
+            .ok_or_else(|| format!("{} is not installed", candidate.label))?;
+
+        if candidate.reveal_in_finder {
+            reveal_in_finder(workspace_path);
+            return Ok(());
+        }
+
+        let output = Command::new("/usr/bin/open")
+            .arg("-a")
+            .arg(&app_path)
+            .arg("--")
+            .arg(workspace_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|error| format!("could not start {}: {error}", candidate.label))?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        if detail.is_empty() {
+            Err(format!(
+                "{} exited with status {}",
+                candidate.label, output.status
+            ))
+        } else {
+            Err(format!("could not open {}: {detail}", candidate.label))
+        }
+    }
+
+    fn resolve_application(candidate: &WorkspaceAppCandidate) -> Option<PathBuf> {
+        let workspace = NSWorkspace::sharedWorkspace();
+        for bundle_id in candidate.bundle_ids {
+            let identifier = NSString::from_str(bundle_id);
+            let Some(url) = workspace.URLForApplicationWithBundleIdentifier(&identifier) else {
+                continue;
+            };
+            let Some(path) = url.path() else {
+                continue;
+            };
+            let app_path = PathBuf::from(path.to_string());
+            if app_path.is_dir() {
+                return Some(app_path);
+            }
+        }
+        None
+    }
+
+    fn reveal_in_finder(path: &Path) {
+        let workspace = NSWorkspace::sharedWorkspace();
+        let path = NSString::from_str(&path.to_string_lossy());
+        let url = NSURL::fileURLWithPath(&path);
+        let urls = NSArray::from_retained_slice(&[url]);
+        workspace.activateFileViewerSelectingURLs(&urls);
+    }
+
+    fn app_icon_data_url(app_path: &Path) -> Option<String> {
+        let icon_path = app_icon_path(app_path)?;
+        let file = BufReader::new(File::open(icon_path).ok()?);
+        let family = IconFamily::read(file).ok()?;
+        let mut icon_types = family.available_icons().to_vec();
+        icon_types.sort_by_key(|icon_type| {
+            let width = icon_type.pixel_width();
+            if width >= 64 {
+                width - 64
+            } else {
+                10_000 + 64 - width
+            }
+        });
+
+        for icon_type in icon_types {
+            let Ok(image) = family.get_icon_with_type(icon_type) else {
+                continue;
+            };
+            let mut png = Vec::new();
+            if image.write_png(&mut png).is_ok() {
+                return Some(format!("data:image/png;base64,{}", STANDARD.encode(png)));
+            }
+        }
+        None
+    }
+
+    fn app_icon_path(app_path: &Path) -> Option<PathBuf> {
+        let info = Value::from_file(app_path.join("Contents/Info.plist")).ok()?;
+        let dictionary = info.as_dictionary()?;
+        let icon_name = dictionary
+            .get("CFBundleIconFile")
+            .and_then(Value::as_string)
+            .or_else(|| {
+                dictionary
+                    .get("CFBundleIconName")
+                    .and_then(Value::as_string)
+            })?;
+
+        let mut icon_path = app_path.join("Contents/Resources").join(icon_name);
+        if icon_path.extension().is_none() {
+            icon_path.set_extension("icns");
+        }
+        icon_path.is_file().then_some(icon_path)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod imp {
+    use super::{WorkspaceAppCandidate, WorkspaceApplication};
+    use std::path::Path;
+
+    pub fn list_workspace_applications() -> Vec<WorkspaceApplication> {
+        Vec::new()
+    }
+
+    pub fn open_workspace(
+        _workspace_path: &Path,
+        _candidate: &WorkspaceAppCandidate,
+    ) -> Result<(), String> {
+        Err("workspace applications are only available on macOS".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{candidate_by_id, is_allowed_workspace_root};
+    use std::path::Path;
+
+    #[test]
+    fn candidate_lookup_accepts_only_declared_ids() {
+        assert_eq!(
+            candidate_by_id("vscode").map(|app| app.label),
+            Some("VS Code")
+        );
+        assert!(candidate_by_id("../../Applications/Calculator.app").is_none());
+    }
+
+    #[test]
+    fn workspace_roots_are_scoped_to_home_and_volumes() {
+        let home = Path::new("/Users/tester");
+        assert!(is_allowed_workspace_root(
+            Path::new("/Users/tester/work/jcode"),
+            home
+        ));
+        assert!(is_allowed_workspace_root(
+            Path::new("/Volumes/Workspace/jcode"),
+            home
+        ));
+        assert!(!is_allowed_workspace_root(Path::new("/tmp/jcode"), home));
+        assert!(!is_allowed_workspace_root(
+            Path::new("/Users/another/jcode"),
+            home
+        ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_discovery_returns_finder_with_its_native_icon() {
+        let applications = super::imp::list_workspace_applications();
+        let finder = applications
+            .iter()
+            .find(|application| application.id == "finder")
+            .expect("Finder should be registered with Launch Services");
+        assert!(finder
+            .icon_data_url
+            .as_deref()
+            .is_some_and(|icon| icon.starts_with("data:image/png;base64,")));
+    }
+}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents a stray console window on Windows in release builds.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod desktop_apps;
 mod shell_env;
 mod sidecar;
 mod tray;
@@ -105,7 +106,11 @@ fn main() {
         .manage(SidecarHandle::default())
         .manage(sidecar::SidecarPort::default())
         .manage(DesktopState::default())
-        .invoke_handler(tauri::generate_handler![get_sidecar_port])
+        .invoke_handler(tauri::generate_handler![
+            get_sidecar_port,
+            desktop_apps::list_workspace_applications,
+            desktop_apps::open_workspace_in_application
+        ])
         .setup(|app| {
             // Start the backend FIRST so a (possibly cosmetic) tray failure can
             // never prevent the server — and thus the whole app — from coming up.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -685,22 +685,36 @@ func (s *Server) currentModelContextLimit(eng *Engine) int {
 }
 
 // handleWorkspace returns lightweight git workspace info (branch + dirty) for
-// the current project so the web UI can show the real branch name. Diff stats
+// the requested task, or the foreground project for legacy callers. Diff stats
 // are fetched separately via /api/diff. Empty branch = not a git repo.
 func (s *Server) handleWorkspace(w http.ResponseWriter, r *http.Request) {
+	pwd := s.activePwd()
+	if taskID := r.URL.Query().Get("task_id"); taskID != "" {
+		var err error
+		pwd, err = s.workspacePwdForTask(taskID)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if pwd == "" {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "task workspace not found"})
+			return
+		}
+	}
+
 	// Use the request context so the git commands are cancelled if the client
 	// disconnects (CodeRabbit review feedback on PR #82).
 	// `branch --show-current` (not `rev-parse --abbrev-ref HEAD`) so a freshly
 	// initialised repo with no commits still reports its unborn branch (e.g.
 	// "main") instead of the literal "HEAD".
 	branchCmd := exec.CommandContext(r.Context(), "git", "branch", "--show-current")
-	branchCmd.Dir = s.activePwd()
+	branchCmd.Dir = pwd
 	branchCmd.Env = utils.ScrubbedGitEnv()
 	branchOut, _ := branchCmd.Output()
 	branch := strings.TrimSpace(string(branchOut))
 
 	statusCmd := exec.CommandContext(r.Context(), "git", "status", "--porcelain")
-	statusCmd.Dir = s.activePwd()
+	statusCmd.Dir = pwd
 	statusCmd.Env = utils.ScrubbedGitEnv()
 	statusOut, _ := statusCmd.Output()
 	dirty := strings.TrimSpace(string(statusOut)) != ""
@@ -709,6 +723,24 @@ func (s *Server) handleWorkspace(w http.ResponseWriter, r *http.Request) {
 		"branch": branch,
 		"dirty":  dirty,
 	})
+}
+
+func (s *Server) workspacePwdForTask(taskID string) (string, error) {
+	if eng := s.resolveEngine(taskID); eng != nil {
+		return eng.pwd, nil
+	}
+	all, err := session.ListAllSessions()
+	if err != nil {
+		return "", fmt.Errorf("list task workspaces: %w", err)
+	}
+	for project, metas := range all {
+		for i := range metas {
+			if metas[i].UUID == taskID {
+				return project, nil
+			}
+		}
+	}
+	return "", nil
 }
 
 // --- Helpers ---

--- a/internal/web/tasks_test.go
+++ b/internal/web/tasks_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -53,6 +54,43 @@ func TestWorkspaceNonGit(t *testing.T) {
 	if ws.Branch != "" || ws.Dirty {
 		t.Fatalf("non-git dir: want empty branch + not dirty, got %+v", ws)
 	}
+}
+
+func TestWorkspaceUsesRequestedTaskProject(t *testing.T) {
+	activeDir := initGitWorkspace(t, "active-branch")
+	taskDir := initGitWorkspace(t, "task-branch")
+	seedIndex(t, map[string][]session.SessionMeta{
+		taskDir: {{UUID: "requested-task", Project: taskDir}},
+	})
+	s := &Server{
+		Engine: &Engine{pwd: activeDir, taskID: "active-task"},
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/workspace?task_id=requested-task", nil)
+	s.handleWorkspace(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%q", rec.Code, rec.Body.String())
+	}
+	var ws struct {
+		Branch string `json:"branch"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &ws); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	if ws.Branch != "task-branch" {
+		t.Fatalf("branch=%q, want requested task branch", ws.Branch)
+	}
+}
+
+func initGitWorkspace(t *testing.T, branch string) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "-b", branch)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	return dir
 }
 
 // P0-2: GET /api/tasks with no index returns an empty array (not null).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -54,11 +54,13 @@ import { SetupView } from './components/SetupView'
 import { SettingsView } from './components/SettingsView'
 import { TopBar } from './components/TopBar'
 import { CloudSyncToggle } from './components/CloudSyncToggle'
+import { DesktopTitlebar } from './components/DesktopTitlebar'
 import { ComputerShotPiP } from './components/ComputerShotPiP'
 import { RightPanel } from './components/RightPanel'
 import { TerminalPanel } from './components/TerminalPanel'
 import { RemoteConnectWizard } from './components/RemoteConnectWizard'
 import type { RemotePrefill } from './lib/remote'
+import { isMacOSDesktop } from './lib/useDesktop'
 
 export default function App() {
   const dispatch = useAppDispatch()
@@ -275,8 +277,19 @@ function Shell({ activeView }: { activeView: 'chat' | 'automations' | 'cloud-mob
         <div className="app-shell relative flex h-[100dvh] overflow-hidden bg-[var(--color-background)] text-[var(--color-foreground)]">
           {/* Native title-bar drag strip — hidden in browser, shown in Tauri (CSS). */}
           <div className="titlebar-drag" data-tauri-drag-region aria-hidden="true" />
-          {/* TopBar — floated top-right (only on chat view, like Vue). */}
-          {activeView === 'chat' && (
+          {/* macOS Desktop uses the native overlay band for task context and
+              controls. Browser + other desktop platforms keep the established
+              floating TopBar and cloud button unchanged. */}
+          {activeView === 'chat' && isMacOSDesktop && (
+            <DesktopTitlebar
+              isRunning={isRunning}
+              wsConnected={wsConnected}
+              activePanel={rightPanelOpen ? rightPanelTab : 'none'}
+              terminalOpen={bottomPanel === 'terminal'}
+              onTogglePanel={togglePanel}
+            />
+          )}
+          {activeView === 'chat' && !isMacOSDesktop && (
             <TopBar
               isRunning={isRunning}
               wsConnected={wsConnected}
@@ -285,8 +298,8 @@ function Shell({ activeView }: { activeView: 'chat' | 'automations' | 'cloud-mob
               onTogglePanel={togglePanel}
             />
           )}
-          {/* Per-session cloud sync switch (M19) — floated left of the TopBar. */}
-          {activeView === 'chat' && <CloudSyncToggle />}
+          {/* Browser/non-mac fallback: retain the standalone per-session switch. */}
+          {activeView === 'chat' && !isMacOSDesktop && <CloudSyncToggle />}
           {/* Codex-style computer-use PiP — floats under the TopBar, shows the
               latest screenshot from the session's computer_screenshot calls. */}
           {activeView === 'chat' && <ComputerShotPiP />}

--- a/web/src/components/CloudSyncToggle.tsx
+++ b/web/src/components/CloudSyncToggle.tsx
@@ -17,7 +17,7 @@
  * (no backfill).
  */
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { CloudIcon } from '@heroicons/react/24/outline'
 import { useTranslation } from 'react-i18next'
 import { api } from '../lib/api'
@@ -25,22 +25,42 @@ import { useAppSelector } from '../app/hooks'
 
 const POLL_MS = 5000
 
-export function CloudSyncToggle() {
-  const { t } = useTranslation()
-  const sessionId = useAppSelector((s) => s.session.currentSessionId)
+export interface CloudSessionSyncState {
+  loggedIn: boolean
+  synced: boolean
+  busy: boolean
+  toggle: () => Promise<void>
+}
+
+/** Shared per-session cloud state used by both browser chrome and Desktop. */
+export function useCloudSessionSync(sessionId: string): CloudSessionSyncState {
   const [loggedIn, setLoggedIn] = useState(false)
   const [synced, setSynced] = useState(false)
   const [busy, setBusy] = useState(false)
+  const refreshSequence = useRef(0)
+  const busyRef = useRef(false)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const refresh = useCallback(async () => {
+    if (busyRef.current) return
+    const sequence = ++refreshSequence.current
     try {
       const st = await api.cloudStatus()
+      if (sequence !== refreshSequence.current) return
       setLoggedIn(st.logged_in)
       if (!st.logged_in) {
         setSynced(false)
         return
       }
       const sync = await api.cloudSync()
+      if (sequence !== refreshSequence.current) return
       setSynced(sessionId ? !!sync.sessions[sessionId] : false)
     } catch {
       // Tolerate failure (older backend / transient): keep the last state.
@@ -48,24 +68,43 @@ export function CloudSyncToggle() {
   }, [sessionId])
 
   useEffect(() => {
+    refreshSequence.current++
+    setSynced(false)
     void refresh()
     const id = window.setInterval(() => void refresh(), POLL_MS)
-    return () => window.clearInterval(id)
+    return () => {
+      refreshSequence.current++
+      window.clearInterval(id)
+    }
   }, [refresh])
 
   async function toggle() {
-    if (!sessionId || !loggedIn || busy) return
+    if (!sessionId || !loggedIn || busyRef.current) return
+    busyRef.current = true
+    const sequence = ++refreshSequence.current
     setBusy(true)
     const next = !synced
     setSynced(next) // optimistic; the next poll reconciles
     try {
       await api.cloudSetSessionSync(sessionId, next)
     } catch {
-      setSynced(!next)
+      if (mountedRef.current && sequence === refreshSequence.current) setSynced(!next)
     } finally {
-      setBusy(false)
+      busyRef.current = false
+      if (mountedRef.current) {
+        setBusy(false)
+        if (sequence === refreshSequence.current) void refresh()
+      }
     }
   }
+
+  return { loggedIn, synced, busy, toggle }
+}
+
+export function CloudSyncToggle() {
+  const { t } = useTranslation()
+  const sessionId = useAppSelector((s) => s.session.currentSessionId)
+  const { loggedIn, synced, busy, toggle } = useCloudSessionSync(sessionId)
 
   if (!sessionId) return null
 

--- a/web/src/components/DesktopTitlebar.test.tsx
+++ b/web/src/components/DesktopTitlebar.test.tsx
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { i18n } from '../i18n'
+import { sessionActions, store } from '../app/store'
+import { DesktopTitlebar } from './DesktopTitlebar'
+
+const mocks = vi.hoisted(() => ({
+  openWorkspacePath: vi.fn<() => Promise<void>>(),
+  updateTask: vi.fn(),
+  workspace: vi.fn(),
+  cloudSetSessionSync: vi.fn(),
+}))
+
+vi.mock('../lib/useDesktop', () => ({
+  openWorkspacePath: mocks.openWorkspacePath,
+}))
+
+vi.mock('../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/api')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      workspace: mocks.workspace,
+      cloudStatus: vi.fn().mockResolvedValue({ logged_in: true }),
+      cloudSync: vi.fn().mockResolvedValue({
+        sync_default: false,
+        sessions: { 'titlebar-test': true },
+      }),
+      cloudSetSessionSync: mocks.cloudSetSessionSync,
+      diff: vi.fn().mockResolvedValue({ mode: 'working', entries: [] }),
+      updateTask: mocks.updateTask,
+    },
+  }
+})
+
+function renderTitlebar() {
+  return render(
+    <Provider store={store}>
+      <DesktopTitlebar
+        isRunning={false}
+        wsConnected
+        activePanel="none"
+        terminalOpen={false}
+        onTogglePanel={() => {}}
+      />
+    </Provider>,
+  )
+}
+
+beforeEach(async () => {
+  cleanup()
+  vi.clearAllMocks()
+  mocks.openWorkspacePath.mockResolvedValue()
+  mocks.updateTask.mockResolvedValue({})
+  mocks.workspace.mockResolvedValue({ branch: 'codex/desktop-task-titlebar', dirty: true })
+  mocks.cloudSetSessionSync.mockResolvedValue({ enabled: true })
+  await i18n.changeLanguage('en')
+  store.dispatch(sessionActions.setProjectPath('/Users/test/work/jcode'))
+  store.dispatch(sessionActions.setCurrentSession('titlebar-test'))
+  store.dispatch(sessionActions.upsertTask({
+    uuid: 'titlebar-test',
+    project: '/Users/test/work/jcode',
+    created_at: '2026-07-30T00:00:00Z',
+    updated_at: '2026-07-30T00:00:00Z',
+    provider: 'openai',
+    model: 'gpt-5',
+    title: 'Design the Desktop titlebar',
+    pinned: false,
+    archived: false,
+    unread: false,
+  }))
+})
+
+describe('DesktopTitlebar', () => {
+  it('shows task, branch, cloud, and actions without an ellipsis menu', async () => {
+    renderTitlebar()
+
+    const details = screen.getByRole('button', { name: 'Task details' })
+    fireEvent.click(details)
+
+    const dialog = screen.getByRole('dialog', { name: 'Task details' })
+    expect(dialog).toBeTruthy()
+    await waitFor(() => expect(screen.getByText('codex/desktop-task-titlebar')).toBeTruthy())
+    expect(mocks.workspace).toHaveBeenCalledWith('titlebar-test')
+    expect(screen.getByRole('switch', { name: 'Cloud sync for this session' }).getAttribute('aria-checked')).toBe('true')
+    expect(screen.getByRole('button', { name: 'Pin' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Rename' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Task actions' })).toBeNull()
+  })
+
+  it('renames through the task API and updates the active title', async () => {
+    renderTitlebar()
+    fireEvent.click(screen.getByRole('button', { name: 'Task details' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+
+    const input = screen.getByRole('textbox', { name: 'Rename' })
+    fireEvent.change(input, { target: { value: 'Desktop context controls' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(mocks.updateTask).toHaveBeenCalledWith('titlebar-test', { title: 'Desktop context controls' })
+    })
+    expect(store.getState().session.tasks.find((task) => task.uuid === 'titlebar-test')?.title).toBe('Desktop context controls')
+  })
+
+  it('keeps the rename editor open when the task update fails', async () => {
+    mocks.updateTask.mockRejectedValueOnce(new Error('network down'))
+    renderTitlebar()
+    fireEvent.click(screen.getByRole('button', { name: 'Task details' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+
+    const input = screen.getByRole('textbox', { name: 'Rename' })
+    fireEvent.change(input, { target: { value: 'Keep this draft' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toBe('Could not update this task.'))
+    expect(screen.getByRole('textbox', { name: 'Rename' }).getAttribute('value')).toBe('Keep this draft')
+  })
+
+  it('opens the local workspace in the selected application', async () => {
+    renderTitlebar()
+    fireEvent.click(screen.getByRole('button', { name: 'Open workspace' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'VS Code' }))
+
+    await waitFor(() => {
+      expect(mocks.openWorkspacePath).toHaveBeenCalledWith('/Users/test/work/jcode', 'Visual Studio Code')
+    })
+  })
+
+  it('prevents duplicate cloud updates while a toggle is in flight', async () => {
+    let finishToggle: (() => void) | undefined
+    mocks.cloudSetSessionSync.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      finishToggle = resolve
+    }))
+    renderTitlebar()
+    fireEvent.click(screen.getByRole('button', { name: 'Task details' }))
+    const cloudSwitch = await screen.findByRole('switch', { name: 'Cloud sync for this session' })
+    await waitFor(() => expect(cloudSwitch.getAttribute('aria-checked')).toBe('true'))
+
+    fireEvent.click(cloudSwitch)
+    fireEvent.click(cloudSwitch)
+    expect(mocks.cloudSetSessionSync).toHaveBeenCalledTimes(1)
+    expect(mocks.cloudSetSessionSync).toHaveBeenCalledWith('titlebar-test', false)
+    finishToggle?.()
+  })
+
+  it('supports keyboard navigation and returns focus from the app menu', async () => {
+    renderTitlebar()
+    const trigger = screen.getByRole('button', { name: 'Open workspace' })
+    fireEvent.click(trigger)
+    const vscode = await screen.findByRole('menuitem', { name: 'VS Code' })
+    await waitFor(() => expect(document.activeElement).toBe(vscode))
+
+    fireEvent.keyDown(vscode, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Cursor' }))
+    fireEvent.keyDown(document.activeElement!, { key: 'Escape' })
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/web/src/components/DesktopTitlebar.test.tsx
+++ b/web/src/components/DesktopTitlebar.test.tsx
@@ -6,14 +6,16 @@ import { sessionActions, store } from '../app/store'
 import { DesktopTitlebar } from './DesktopTitlebar'
 
 const mocks = vi.hoisted(() => ({
-  openWorkspacePath: vi.fn<() => Promise<void>>(),
+  listWorkspaceApplications: vi.fn(),
+  openWorkspaceInApplication: vi.fn<() => Promise<void>>(),
   updateTask: vi.fn(),
   workspace: vi.fn(),
   cloudSetSessionSync: vi.fn(),
 }))
 
 vi.mock('../lib/useDesktop', () => ({
-  openWorkspacePath: mocks.openWorkspacePath,
+  listWorkspaceApplications: mocks.listWorkspaceApplications,
+  openWorkspaceInApplication: mocks.openWorkspaceInApplication,
 }))
 
 vi.mock('../lib/api', async (importOriginal) => {
@@ -52,7 +54,12 @@ function renderTitlebar() {
 beforeEach(async () => {
   cleanup()
   vi.clearAllMocks()
-  mocks.openWorkspacePath.mockResolvedValue()
+  mocks.listWorkspaceApplications.mockResolvedValue([
+    { id: 'vscode', label: 'VS Code', group: 'editor', iconDataUrl: 'data:image/png;base64,icon' },
+    { id: 'cursor', label: 'Cursor', group: 'editor' },
+    { id: 'finder', label: 'Finder', group: 'system' },
+  ])
+  mocks.openWorkspaceInApplication.mockResolvedValue()
   mocks.updateTask.mockResolvedValue({})
   mocks.workspace.mockResolvedValue({ branch: 'codex/desktop-task-titlebar', dirty: true })
   mocks.cloudSetSessionSync.mockResolvedValue({ enabled: true })
@@ -76,6 +83,9 @@ beforeEach(async () => {
 describe('DesktopTitlebar', () => {
   it('shows task, branch, cloud, and actions without an ellipsis menu', async () => {
     renderTitlebar()
+    expect(screen.getByTestId('desktop-titlebar').style.left).toBe(
+      'calc(var(--sidebar-width, 20rem) + 10px)',
+    )
 
     const details = screen.getByRole('button', { name: 'Task details' })
     fireEvent.click(details)
@@ -123,11 +133,20 @@ describe('DesktopTitlebar', () => {
   it('opens the local workspace in the selected application', async () => {
     renderTitlebar()
     fireEvent.click(screen.getByRole('button', { name: 'Open workspace' }))
-    fireEvent.click(screen.getByRole('menuitem', { name: 'VS Code' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'VS Code' }))
 
     await waitFor(() => {
-      expect(mocks.openWorkspacePath).toHaveBeenCalledWith('/Users/test/work/jcode', 'Visual Studio Code')
+      expect(mocks.openWorkspaceInApplication).toHaveBeenCalledWith('/Users/test/work/jcode', 'vscode')
     })
+  })
+
+  it('uses discovered native icons and hides applications the system did not return', async () => {
+    renderTitlebar()
+    fireEvent.click(screen.getByRole('button', { name: 'Open workspace' }))
+
+    const vscode = await screen.findByRole('menuitem', { name: 'VS Code' })
+    expect(vscode.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,icon')
+    expect(screen.queryByRole('menuitem', { name: 'GoLand' })).toBeNull()
   })
 
   it('prevents duplicate cloud updates while a toggle is in flight', async () => {

--- a/web/src/components/DesktopTitlebar.tsx
+++ b/web/src/components/DesktopTitlebar.tsx
@@ -11,21 +11,13 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import {
   ArchiveBoxIcon,
-  BoltIcon,
   BookmarkIcon,
   ChevronDownIcon,
   CloudIcon,
   CodeBracketSquareIcon,
   CommandLineIcon,
-  CubeTransparentIcon,
-  CursorArrowRaysIcon,
   FolderOpenIcon,
-  ForwardIcon,
   PencilSquareIcon,
-  RectangleGroupIcon,
-  RocketLaunchIcon,
-  SparklesIcon,
-  WrenchScrewdriverIcon,
 } from '@heroicons/react/24/outline'
 import type { ComponentType, RefObject, SVGProps } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -33,7 +25,11 @@ import { useAppDispatch, useAppSelector } from '../app/hooks'
 import { sessionActions } from '../app/store'
 import { api } from '../lib/api'
 import { isRemotePath } from '../lib/remote'
-import { openWorkspacePath } from '../lib/useDesktop'
+import {
+  listWorkspaceApplications,
+  openWorkspaceInApplication,
+  type WorkspaceApplication,
+} from '../lib/useDesktop'
 import { useCloudSessionSync } from './CloudSyncToggle'
 import { TopBar } from './TopBar'
 
@@ -47,28 +43,6 @@ interface Props {
   terminalOpen: boolean
   onTogglePanel: (panel: PanelType) => void
 }
-
-interface WorkspaceOpener {
-  id: string
-  label: string
-  application?: string
-  icon: OutlineIcon
-  group: 'editor' | 'system'
-}
-
-const WORKSPACE_OPENERS: WorkspaceOpener[] = [
-  { id: 'vscode', label: 'VS Code', application: 'Visual Studio Code', icon: CodeBracketSquareIcon, group: 'editor' },
-  { id: 'cursor', label: 'Cursor', application: 'Cursor', icon: CursorArrowRaysIcon, group: 'editor' },
-  { id: 'zed', label: 'Zed', application: 'Zed', icon: BoltIcon, group: 'editor' },
-  { id: 'antigravity', label: 'Antigravity', application: 'Antigravity', icon: RocketLaunchIcon, group: 'editor' },
-  { id: 'finder', label: 'Finder', application: 'Finder', icon: FolderOpenIcon, group: 'system' },
-  { id: 'terminal', label: 'Terminal', application: 'Terminal', icon: CommandLineIcon, group: 'system' },
-  { id: 'iterm', label: 'iTerm2', application: 'iTerm', icon: RectangleGroupIcon, group: 'system' },
-  { id: 'ghostty', label: 'Ghostty', application: 'Ghostty', icon: SparklesIcon, group: 'system' },
-  { id: 'warp', label: 'Warp', application: 'Warp', icon: ForwardIcon, group: 'system' },
-  { id: 'xcode', label: 'Xcode', application: 'Xcode', icon: WrenchScrewdriverIcon, group: 'system' },
-  { id: 'goland', label: 'GoLand', application: 'GoLand', icon: CubeTransparentIcon, group: 'system' },
-]
 
 export function DesktopTitlebar(props: Props) {
   const { t } = useTranslation()
@@ -125,7 +99,11 @@ export function DesktopTitlebar(props: Props) {
   }, [props.isRunning, refreshBranch])
 
   return (
-    <div className="pointer-events-none absolute left-[88px] right-[14px] top-[6px] z-[46] flex h-[34px] min-w-0 items-center gap-2">
+    <div
+      data-testid="desktop-titlebar"
+      style={{ left: 'calc(var(--sidebar-width, 20rem) + 10px)' }}
+      className="pointer-events-none absolute right-[14px] top-[6px] z-[46] flex h-[34px] min-w-0 items-center gap-2"
+    >
       <TaskDetails
         sessionId={currentSessionId}
         title={taskTitle}
@@ -399,27 +377,52 @@ function WorkspaceOpenMenu({ projectPath }: { projectPath: string }) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [error, setError] = useState('')
+  const [applications, setApplications] = useState<WorkspaceApplication[]>([])
+  const [loading, setLoading] = useState(true)
+  const [discoveryFailed, setDiscoveryFailed] = useState(false)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([])
   const menuId = useId()
   const disabled = !projectPath || isRemotePath(projectPath)
 
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    setDiscoveryFailed(false)
+    void listWorkspaceApplications()
+      .then((items) => {
+        if (active) setApplications(items)
+      })
+      .catch(() => {
+        if (active) {
+          setApplications([])
+          setDiscoveryFailed(true)
+        }
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [])
+
   useDismissableMenu(open, setOpen, rootRef, triggerRef)
   useEffect(() => {
     if (!open) return
     const frame = window.requestAnimationFrame(() => itemRefs.current[0]?.focus())
     return () => window.cancelAnimationFrame(frame)
-  }, [open])
+  }, [applications.length, open])
 
-  async function openIn(opener: WorkspaceOpener) {
+  async function openIn(application: WorkspaceApplication) {
     if (disabled) return
     setError('')
     try {
-      await openWorkspacePath(projectPath, opener.application)
+      await openWorkspaceInApplication(projectPath, application.id)
       setOpen(false)
     } catch {
-      setError(t('desktopTitlebar.openFailed', { app: opener.label }))
+      setError(t('desktopTitlebar.openFailed', { app: application.label }))
     }
   }
 
@@ -469,13 +472,27 @@ function WorkspaceOpenMenu({ projectPath }: { projectPath: string }) {
           role="menu"
           aria-label={t('desktopTitlebar.openWorkspace')}
           onKeyDown={onMenuKeyDown}
-          className="absolute right-0 top-[calc(100%+6px)] z-[var(--z-dropdown)] max-h-[calc(100vh-58px)] w-[224px] overflow-y-auto rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] p-1.5 shadow-[var(--shadow-lg)]"
+          className="absolute right-0 top-[calc(100%+6px)] z-[var(--z-dropdown)] max-h-[calc(100vh-58px)] w-[232px] overflow-y-auto rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] p-1.5 shadow-[var(--shadow-lg)]"
         >
-          {WORKSPACE_OPENERS.map((opener, index) => {
-            const Icon = opener.icon
-            const startsGroup = index > 0 && WORKSPACE_OPENERS[index - 1].group !== opener.group
+          {loading && (
+            <div className="px-2.5 py-2 text-[11px] text-[var(--color-muted-foreground)]">
+              {t('common.loading')}
+            </div>
+          )}
+          {!loading && discoveryFailed && (
+            <p role="alert" className="px-2.5 py-2 text-[11px] leading-relaxed text-[var(--color-error-fg)]">
+              {t('desktopTitlebar.discoveryFailed')}
+            </p>
+          )}
+          {!loading && !discoveryFailed && applications.length === 0 && (
+            <div className="px-2.5 py-2 text-[11px] text-[var(--color-muted-foreground)]">
+              {t('desktopTitlebar.noApplications')}
+            </div>
+          )}
+          {applications.map((application, index) => {
+            const startsGroup = index > 0 && applications[index - 1].group !== application.group
             return (
-              <div key={opener.id}>
+              <div key={application.id}>
                 {startsGroup && <div className="my-1 h-px bg-[var(--color-border)]" />}
                 <button
                   ref={(element) => {
@@ -483,13 +500,11 @@ function WorkspaceOpenMenu({ projectPath }: { projectPath: string }) {
                   }}
                   type="button"
                   role="menuitem"
-                  onClick={() => void openIn(opener)}
-                  className="flex w-full items-center gap-2.5 rounded-[var(--radius-md)] px-2.5 py-2 text-left text-[13px] text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)]"
+                  onClick={() => void openIn(application)}
+                  className="flex w-full items-center gap-2.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-left text-[13px] text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)] focus:bg-[var(--color-muted)] focus:outline-none"
                 >
-                  <span className="grid h-6 w-6 shrink-0 place-items-center rounded-[var(--radius-md)] bg-[var(--color-muted)]">
-                    <Icon className="h-4 w-4 text-[var(--color-muted-foreground)]" />
-                  </span>
-                  {opener.label}
+                  <WorkspaceApplicationIcon application={application} />
+                  {application.label}
                 </button>
               </div>
             )
@@ -502,6 +517,25 @@ function WorkspaceOpenMenu({ projectPath }: { projectPath: string }) {
         </div>
       )}
     </div>
+  )
+}
+
+function WorkspaceApplicationIcon({ application }: { application: WorkspaceApplication }) {
+  if (application.iconDataUrl) {
+    return (
+      <img
+        src={application.iconDataUrl}
+        alt=""
+        aria-hidden="true"
+        className="h-[22px] w-[22px] shrink-0 object-contain"
+      />
+    )
+  }
+  const Icon = application.id === 'finder' ? FolderOpenIcon : CommandLineIcon
+  return (
+    <span className="grid h-[22px] w-[22px] shrink-0 place-items-center rounded-[var(--radius-sm)] bg-[var(--color-muted)]">
+      <Icon className="h-3.5 w-3.5 text-[var(--color-muted-foreground)]" />
+    </span>
   )
 }
 

--- a/web/src/components/DesktopTitlebar.tsx
+++ b/web/src/components/DesktopTitlebar.tsx
@@ -1,0 +1,542 @@
+/**
+ * DesktopTitlebar — macOS overlay titlebar for the active task.
+ *
+ * The browser keeps its existing floating controls. In the Tauri macOS shell,
+ * this component uses the otherwise-empty titlebar band for task identity,
+ * branch/workspace context, per-session cloud sync, task actions, app launchers,
+ * and the existing panel picker. Worktree/branch mutation deliberately stays
+ * out of scope: the branch is informational only.
+ */
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import {
+  ArchiveBoxIcon,
+  BoltIcon,
+  BookmarkIcon,
+  ChevronDownIcon,
+  CloudIcon,
+  CodeBracketSquareIcon,
+  CommandLineIcon,
+  CubeTransparentIcon,
+  CursorArrowRaysIcon,
+  FolderOpenIcon,
+  ForwardIcon,
+  PencilSquareIcon,
+  RectangleGroupIcon,
+  RocketLaunchIcon,
+  SparklesIcon,
+  WrenchScrewdriverIcon,
+} from '@heroicons/react/24/outline'
+import type { ComponentType, RefObject, SVGProps } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useAppDispatch, useAppSelector } from '../app/hooks'
+import { sessionActions } from '../app/store'
+import { api } from '../lib/api'
+import { isRemotePath } from '../lib/remote'
+import { openWorkspacePath } from '../lib/useDesktop'
+import { useCloudSessionSync } from './CloudSyncToggle'
+import { TopBar } from './TopBar'
+
+type PanelType = 'plan' | 'files' | 'changes' | 'terminal'
+type OutlineIcon = ComponentType<SVGProps<SVGSVGElement>>
+
+interface Props {
+  isRunning: boolean
+  wsConnected: boolean
+  activePanel: 'none' | 'plan' | 'files' | 'changes' | 'terminal'
+  terminalOpen: boolean
+  onTogglePanel: (panel: PanelType) => void
+}
+
+interface WorkspaceOpener {
+  id: string
+  label: string
+  application?: string
+  icon: OutlineIcon
+  group: 'editor' | 'system'
+}
+
+const WORKSPACE_OPENERS: WorkspaceOpener[] = [
+  { id: 'vscode', label: 'VS Code', application: 'Visual Studio Code', icon: CodeBracketSquareIcon, group: 'editor' },
+  { id: 'cursor', label: 'Cursor', application: 'Cursor', icon: CursorArrowRaysIcon, group: 'editor' },
+  { id: 'zed', label: 'Zed', application: 'Zed', icon: BoltIcon, group: 'editor' },
+  { id: 'antigravity', label: 'Antigravity', application: 'Antigravity', icon: RocketLaunchIcon, group: 'editor' },
+  { id: 'finder', label: 'Finder', application: 'Finder', icon: FolderOpenIcon, group: 'system' },
+  { id: 'terminal', label: 'Terminal', application: 'Terminal', icon: CommandLineIcon, group: 'system' },
+  { id: 'iterm', label: 'iTerm2', application: 'iTerm', icon: RectangleGroupIcon, group: 'system' },
+  { id: 'ghostty', label: 'Ghostty', application: 'Ghostty', icon: SparklesIcon, group: 'system' },
+  { id: 'warp', label: 'Warp', application: 'Warp', icon: ForwardIcon, group: 'system' },
+  { id: 'xcode', label: 'Xcode', application: 'Xcode', icon: WrenchScrewdriverIcon, group: 'system' },
+  { id: 'goland', label: 'GoLand', application: 'GoLand', icon: CubeTransparentIcon, group: 'system' },
+]
+
+export function DesktopTitlebar(props: Props) {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const currentSessionId = useAppSelector((s) => s.session.currentSessionId)
+  const tasks = useAppSelector((s) => s.session.tasks)
+  const sessions = useAppSelector((s) => s.session.sessions)
+  const projectPath = useAppSelector((s) => s.session.projectPath)
+  const currentProvider = useAppSelector((s) => s.model.providerName)
+  const currentModel = useAppSelector((s) => s.model.modelName)
+
+  const activeTask = useMemo(
+    () => tasks.find((task) => task.uuid === currentSessionId),
+    [currentSessionId, tasks],
+  )
+  const activeSession = useMemo(
+    () => sessions.find((session) => session.uuid === currentSessionId),
+    [currentSessionId, sessions],
+  )
+  const taskTitle = activeTask?.title?.trim() || activeSession?.title?.trim() || t('sidebar.untitled')
+  const activeProject = activeTask?.project || projectPath
+  const projectLabel = workspaceName(activeProject)
+  const modelLabel = [activeTask?.provider || currentProvider, activeTask?.model || currentModel]
+    .filter(Boolean)
+    .join(' / ')
+
+  const [branch, setBranch] = useState('')
+  const branchRequest = useRef(0)
+  const refreshBranch = useCallback(async () => {
+    const request = ++branchRequest.current
+    if (!activeProject) {
+      setBranch('')
+      return
+    }
+    try {
+      const workspace = await api.workspace(currentSessionId)
+      if (request === branchRequest.current) setBranch(workspace.branch)
+    } catch {
+      if (request === branchRequest.current) setBranch('')
+    }
+  }, [activeProject, currentSessionId])
+
+  useEffect(() => {
+    void refreshBranch()
+    return () => {
+      branchRequest.current++
+    }
+  }, [refreshBranch, currentSessionId])
+
+  const wasRunning = useRef(props.isRunning)
+  useEffect(() => {
+    if (wasRunning.current && !props.isRunning) void refreshBranch()
+    wasRunning.current = props.isRunning
+  }, [props.isRunning, refreshBranch])
+
+  return (
+    <div className="pointer-events-none absolute left-[88px] right-[14px] top-[6px] z-[46] flex h-[34px] min-w-0 items-center gap-2">
+      <TaskDetails
+        sessionId={currentSessionId}
+        title={taskTitle}
+        project={activeProject}
+        projectLabel={projectLabel}
+        branch={branch}
+        model={modelLabel}
+        pinned={!!activeTask?.pinned}
+        archived={!!activeTask?.archived}
+        running={props.isRunning}
+        canEdit={!!activeTask}
+        onPatch={async (patch) => {
+          if (!currentSessionId) return
+          await api.updateTask(currentSessionId, patch)
+          dispatch(sessionActions.patchTask({ uuid: currentSessionId, ...patch }))
+        }}
+      />
+
+      <div className="pointer-events-auto ml-auto flex shrink-0 items-center gap-1">
+        <WorkspaceOpenMenu projectPath={activeProject} />
+        <TopBar embedded {...props} />
+      </div>
+    </div>
+  )
+}
+
+interface TaskDetailsProps {
+  sessionId: string
+  title: string
+  project: string
+  projectLabel: string
+  branch: string
+  model: string
+  pinned: boolean
+  archived: boolean
+  running: boolean
+  canEdit: boolean
+  onPatch: (patch: { title?: string; pinned?: boolean; archived?: boolean }) => Promise<void>
+}
+
+function TaskDetails({
+  sessionId,
+  title,
+  project,
+  projectLabel,
+  branch,
+  model,
+  pinned,
+  archived,
+  running,
+  canEdit,
+  onPatch,
+}: TaskDetailsProps) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [draftTitle, setDraftTitle] = useState(title)
+  const [error, setError] = useState('')
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const popoverId = useId()
+  const cloudLabelId = useId()
+  const cloudDescriptionId = useId()
+  const cloud = useCloudSessionSync(sessionId)
+
+  useEffect(() => setDraftTitle(title), [title])
+  useEffect(() => {
+    if (open) return
+    setEditing(false)
+    setDraftTitle(title)
+    setError('')
+  }, [open, title])
+  useDismissableMenu(open, setOpen, rootRef, triggerRef)
+
+  async function patch(patchValue: Parameters<TaskDetailsProps['onPatch']>[0]): Promise<boolean> {
+    setError('')
+    try {
+      await onPatch(patchValue)
+      return true
+    } catch {
+      setError(t('desktopTitlebar.updateFailed'))
+      return false
+    }
+  }
+
+  async function saveTitle() {
+    const next = draftTitle.trim()
+    if (!next || next === title) {
+      setDraftTitle(title)
+      setEditing(false)
+      return
+    }
+    if (await patch({ title: next })) setEditing(false)
+  }
+
+  const branchLabel = branch || t('desktopTitlebar.noBranch')
+  const cloudDescription = !cloud.loggedIn
+    ? t('cloud.syncNeedLogin')
+    : cloud.synced
+      ? t('cloud.syncOn')
+      : t('cloud.syncOff')
+
+  return (
+    <div ref={rootRef} className="pointer-events-auto relative min-w-0 max-w-[48vw]">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-controls={open ? popoverId : undefined}
+        aria-label={t('desktopTitlebar.taskDetails')}
+        onClick={() => {
+          setError('')
+          setOpen((value) => !value)
+        }}
+        className={`flex h-[34px] min-w-0 max-w-full items-center gap-2 rounded-[var(--radius-lg)] px-2.5 text-left transition-colors ${
+          open
+            ? 'bg-[var(--color-muted)] text-[var(--color-foreground)]'
+            : 'text-[var(--color-foreground)] hover:bg-[var(--color-muted)]'
+        }`}
+      >
+        <span className="min-w-0 truncate text-[13px] font-semibold">{title}</span>
+        <span className="shrink-0 text-[var(--color-muted-foreground)]">·</span>
+        <span className="min-w-0 truncate font-mono text-[11px] text-[var(--color-muted-foreground)]">
+          {projectLabel} / {branchLabel}
+        </span>
+        <ChevronDownIcon className={`h-3 w-3 shrink-0 text-[var(--color-muted-foreground)] transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div
+          id={popoverId}
+          role="dialog"
+          aria-label={t('desktopTitlebar.taskDetails')}
+          className="absolute left-0 top-[calc(100%+6px)] z-[var(--z-dropdown)] w-[420px] overflow-hidden rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-lg)]"
+        >
+          <div className="border-b border-[var(--color-border)] px-4 py-3.5">
+            {editing ? (
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void saveTitle()
+                }}
+                className="flex items-center gap-2"
+              >
+                <input
+                  autoFocus
+                  value={draftTitle}
+                  onChange={(event) => setDraftTitle(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      event.stopPropagation()
+                      setDraftTitle(title)
+                      setEditing(false)
+                    }
+                  }}
+                  aria-label={t('sidebar.actions.rename')}
+                  className="h-8 min-w-0 flex-1 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-background)] px-2.5 text-[13px] text-[var(--color-foreground)]"
+                />
+                <button
+                  type="submit"
+                  className="h-8 rounded-[var(--radius-md)] bg-[var(--color-primary)] px-3 text-[12px] font-medium text-[var(--color-on-primary)]"
+                >
+                  {t('common.save')}
+                </button>
+              </form>
+            ) : (
+              <div className="flex min-w-0 items-center gap-2">
+                <h2 className="min-w-0 flex-1 truncate text-[14px] font-semibold text-[var(--color-foreground)]">{title}</h2>
+                <span className={`inline-flex shrink-0 items-center gap-1.5 rounded-[var(--radius-pill)] px-2 py-1 text-[10px] font-medium ${
+                  running
+                    ? 'bg-[var(--neutral-wash)] text-[var(--color-accent-neutral)]'
+                    : 'bg-[var(--color-muted)] text-[var(--color-muted-foreground)]'
+                }`}>
+                  <span className={`h-1.5 w-1.5 rounded-full ${running ? 'bg-[var(--color-accent-neutral)]' : 'bg-[var(--color-muted-foreground)]'}`} />
+                  {running ? t('topbar.status.running') : t('desktopTitlebar.ready')}
+                </span>
+              </div>
+            )}
+          </div>
+
+          <dl className="grid grid-cols-[92px_minmax(0,1fr)] gap-x-3 gap-y-2.5 border-b border-[var(--color-border)] px-4 py-3.5 text-[12px]">
+            <dt className="text-[var(--color-muted-foreground)]">{t('desktopTitlebar.workspace')}</dt>
+            <dd className="truncate font-medium text-[var(--color-foreground)]">{projectLabel}</dd>
+            <dt className="text-[var(--color-muted-foreground)]">{t('desktopTitlebar.branch')}</dt>
+            <dd className="truncate font-mono text-[var(--color-foreground)]">{branchLabel}</dd>
+            <dt className="text-[var(--color-muted-foreground)]">{t('desktopTitlebar.path')}</dt>
+            <dd className="truncate font-mono text-[11px] text-[var(--color-foreground)]" title={project}>{project || '—'}</dd>
+            {model && (
+              <>
+                <dt className="text-[var(--color-muted-foreground)]">{t('desktopTitlebar.model')}</dt>
+                <dd className="truncate font-mono text-[11px] text-[var(--color-foreground)]">{model}</dd>
+              </>
+            )}
+          </dl>
+
+          <div className="border-b border-[var(--color-border)] p-2">
+            <button
+              type="button"
+              role="switch"
+              aria-checked={cloud.synced}
+              aria-labelledby={cloudLabelId}
+              aria-describedby={cloudDescriptionId}
+              disabled={!sessionId || !cloud.loggedIn || cloud.busy}
+              onClick={() => void cloud.toggle()}
+              className="flex w-full items-center gap-3 rounded-[var(--radius-lg)] px-2.5 py-2 text-left transition-colors hover:bg-[var(--color-muted)] disabled:cursor-not-allowed disabled:opacity-55"
+            >
+              <CloudIcon className={`h-4 w-4 shrink-0 ${cloud.synced ? 'text-[var(--color-accent-neutral)]' : 'text-[var(--color-muted-foreground)]'}`} />
+              <span className="min-w-0 flex-1">
+                <span id={cloudLabelId} className="block text-[12.5px] font-medium text-[var(--color-foreground)]">{t('cloud.syncSession')}</span>
+                <span id={cloudDescriptionId} className="block truncate text-[10.5px] text-[var(--color-muted-foreground)]">{cloudDescription}</span>
+              </span>
+              <span
+                aria-hidden="true"
+                className={`relative h-5 w-9 shrink-0 rounded-[var(--radius-pill)] transition-colors ${
+                  cloud.synced ? 'bg-[var(--color-accent-neutral)]' : 'bg-[var(--color-border)]'
+                }`}
+              >
+                <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-[var(--color-background)] shadow-[var(--shadow-sm)] transition-transform ${
+                  cloud.synced ? 'translate-x-[18px]' : 'translate-x-0.5'
+                }`} />
+              </span>
+            </button>
+          </div>
+
+          {canEdit && (
+            <div className="p-2">
+              <TaskAction
+                icon={BookmarkIcon}
+                label={pinned ? t('sidebar.actions.unpin') : t('sidebar.actions.pin')}
+                onClick={() => void patch({ pinned: !pinned })}
+              />
+              <TaskAction
+                icon={PencilSquareIcon}
+                label={t('sidebar.actions.rename')}
+                onClick={() => setEditing(true)}
+              />
+              <TaskAction
+                icon={ArchiveBoxIcon}
+                label={archived ? t('sidebar.actions.unarchive') : t('sidebar.actions.archive')}
+                onClick={() => void patch({ archived: !archived })}
+              />
+            </div>
+          )}
+
+          {error && (
+            <p role="alert" className="border-t border-[var(--color-border)] px-4 py-2 text-[11px] text-[var(--color-error-fg)]">
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function TaskAction({ icon: Icon, label, onClick }: { icon: OutlineIcon; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-2.5 rounded-[var(--radius-md)] px-2.5 py-2 text-left text-[12.5px] text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)]"
+    >
+      <Icon className="h-4 w-4 shrink-0 text-[var(--color-muted-foreground)]" />
+      {label}
+    </button>
+  )
+}
+
+function WorkspaceOpenMenu({ projectPath }: { projectPath: string }) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [error, setError] = useState('')
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const menuId = useId()
+  const disabled = !projectPath || isRemotePath(projectPath)
+
+  useDismissableMenu(open, setOpen, rootRef, triggerRef)
+  useEffect(() => {
+    if (!open) return
+    const frame = window.requestAnimationFrame(() => itemRefs.current[0]?.focus())
+    return () => window.cancelAnimationFrame(frame)
+  }, [open])
+
+  async function openIn(opener: WorkspaceOpener) {
+    if (disabled) return
+    setError('')
+    try {
+      await openWorkspacePath(projectPath, opener.application)
+      setOpen(false)
+    } catch {
+      setError(t('desktopTitlebar.openFailed', { app: opener.label }))
+    }
+  }
+
+  function onMenuKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    const items = itemRefs.current.filter((item): item is HTMLButtonElement => item !== null)
+    if (items.length === 0) return
+    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement)
+    let nextIndex: number | null = null
+    if (event.key === 'ArrowDown') nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
+    else if (event.key === 'ArrowUp') nextIndex = currentIndex < 0 ? items.length - 1 : (currentIndex - 1 + items.length) % items.length
+    else if (event.key === 'Home') nextIndex = 0
+    else if (event.key === 'End') nextIndex = items.length - 1
+    if (nextIndex === null) return
+    event.preventDefault()
+    items[nextIndex].focus()
+  }
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-controls={open ? menuId : undefined}
+        aria-label={t('desktopTitlebar.openWorkspace')}
+        title={disabled ? t('desktopTitlebar.localOnly') : t('desktopTitlebar.openWorkspace')}
+        onClick={() => {
+          setError('')
+          setOpen((value) => !value)
+        }}
+        className={`inline-flex h-[34px] items-center gap-1.5 rounded-[var(--radius-lg)] px-2.5 text-[12px] transition-colors disabled:cursor-not-allowed disabled:opacity-45 ${
+          open
+            ? 'bg-[var(--color-muted)] text-[var(--color-foreground)]'
+            : 'text-[var(--color-muted-foreground)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]'
+        }`}
+      >
+        <CodeBracketSquareIcon className="h-4 w-4" />
+        <span>{t('desktopTitlebar.open')}</span>
+        <ChevronDownIcon className="h-3 w-3 opacity-60" />
+      </button>
+
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label={t('desktopTitlebar.openWorkspace')}
+          onKeyDown={onMenuKeyDown}
+          className="absolute right-0 top-[calc(100%+6px)] z-[var(--z-dropdown)] max-h-[calc(100vh-58px)] w-[224px] overflow-y-auto rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] p-1.5 shadow-[var(--shadow-lg)]"
+        >
+          {WORKSPACE_OPENERS.map((opener, index) => {
+            const Icon = opener.icon
+            const startsGroup = index > 0 && WORKSPACE_OPENERS[index - 1].group !== opener.group
+            return (
+              <div key={opener.id}>
+                {startsGroup && <div className="my-1 h-px bg-[var(--color-border)]" />}
+                <button
+                  ref={(element) => {
+                    itemRefs.current[index] = element
+                  }}
+                  type="button"
+                  role="menuitem"
+                  onClick={() => void openIn(opener)}
+                  className="flex w-full items-center gap-2.5 rounded-[var(--radius-md)] px-2.5 py-2 text-left text-[13px] text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)]"
+                >
+                  <span className="grid h-6 w-6 shrink-0 place-items-center rounded-[var(--radius-md)] bg-[var(--color-muted)]">
+                    <Icon className="h-4 w-4 text-[var(--color-muted-foreground)]" />
+                  </span>
+                  {opener.label}
+                </button>
+              </div>
+            )
+          })}
+          {error && (
+            <p role="alert" className="mt-1 border-t border-[var(--color-border)] px-2.5 py-2 text-[10.5px] text-[var(--color-error-fg)]">
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function useDismissableMenu(
+  open: boolean,
+  setOpen: (open: boolean) => void,
+  rootRef: RefObject<HTMLElement | null>,
+  triggerRef?: RefObject<HTMLElement | null>,
+) {
+  useEffect(() => {
+    if (!open) return
+    function onMouseDown(event: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) setOpen(false)
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        triggerRef?.current?.focus()
+      }
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open, rootRef, setOpen, triggerRef])
+}
+
+function workspaceName(path: string): string {
+  if (!path) return '—'
+  if (isRemotePath(path)) {
+    const parts = path.replace(/\/+$/, '').split('/')
+    return parts[parts.length - 1] || path
+  }
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '')
+  return normalized.split('/').pop() || path
+}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -33,6 +33,8 @@ interface Props {
   activePanel: 'none' | 'plan' | 'files' | 'changes' | 'terminal'
   terminalOpen: boolean
   onTogglePanel: (panel: PanelType) => void
+  /** Render inside the native Desktop titlebar instead of floating standalone. */
+  embedded?: boolean
 }
 
 const PANEL_BUTTONS: { panel: PanelType; shortcut: string }[] = [
@@ -49,7 +51,7 @@ const PANEL_ICONS: Record<PanelType, typeof RectangleStackIcon> = {
   terminal: CommandLineIcon,
 }
 
-export function TopBar({ isRunning, wsConnected, activePanel, terminalOpen, onTogglePanel }: Props) {
+export function TopBar({ isRunning, wsConnected, activePanel, terminalOpen, onTogglePanel, embedded = false }: Props) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   // Working-tree diff stat shown inline on the Changes item. null on failure /
@@ -141,7 +143,7 @@ export function TopBar({ isRunning, wsConnected, activePanel, terminalOpen, onTo
   return (
     <div
       ref={controlRef}
-      className="absolute right-[14px] top-[6px] z-[46]"
+      className={embedded ? 'relative' : 'absolute right-[14px] top-[6px] z-[46]'}
       style={{ fontFamily: 'var(--font-sans)' }}
     >
       {/* position:relative wrapper so the absolute menu anchors to it, not to the

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -1038,6 +1038,22 @@ export default {
     },
   },
 
+  // macOS Desktop task titlebar.
+  desktopTitlebar: {
+    taskDetails: 'Task details',
+    ready: 'Ready',
+    workspace: 'Workspace',
+    branch: 'Branch',
+    path: 'Path',
+    model: 'Model',
+    noBranch: 'No branch',
+    updateFailed: 'Could not update this task.',
+    open: 'Open',
+    openWorkspace: 'Open workspace',
+    localOnly: 'Opening apps is available for local workspaces only.',
+    openFailed: 'Could not open {app}. Check that it is installed and this workspace location is allowed.',
+  },
+
   // Cloud relay status badge + popover (Sidebar footer).
   cloud: {
     mobileHubTitle: 'Remote Access',

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -1051,6 +1051,8 @@ export default {
     open: 'Open',
     openWorkspace: 'Open workspace',
     localOnly: 'Opening apps is available for local workspaces only.',
+    discoveryFailed: 'Could not read the applications installed on this Mac.',
+    noApplications: 'No supported applications were found.',
     openFailed: 'Could not open {app}. Check that it is installed and this workspace location is allowed.',
   },
 

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -989,6 +989,22 @@ export default {
     },
   },
 
+  // macOS Desktop のタスクタイトルバー。
+  desktopTitlebar: {
+    taskDetails: 'タスクの詳細',
+    ready: '準備完了',
+    workspace: 'ワークスペース',
+    branch: 'ブランチ',
+    path: 'パス',
+    model: 'モデル',
+    noBranch: 'ブランチなし',
+    updateFailed: 'このタスクを更新できませんでした。',
+    open: '開く',
+    openWorkspace: 'ワークスペースを開く',
+    localOnly: 'アプリで開けるのはローカルワークスペースのみです。',
+    openFailed: '{app} を開けませんでした。インストール済みで、ワークスペースの場所が許可されているか確認してください。',
+  },
+
   // クラウドリレーのステータスバッジ + ポップオーバー（サイドバー下部）。
   cloud: {
     mobileHubTitle: 'リモートアクセス',

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -1002,6 +1002,8 @@ export default {
     open: '開く',
     openWorkspace: 'ワークスペースを開く',
     localOnly: 'アプリで開けるのはローカルワークスペースのみです。',
+    discoveryFailed: 'この Mac にインストール済みのアプリを読み取れませんでした。',
+    noApplications: '対応するアプリが見つかりませんでした。',
     openFailed: '{app} を開けませんでした。インストール済みで、ワークスペースの場所が許可されているか確認してください。',
   },
 

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -988,6 +988,22 @@ export default {
     },
   },
 
+  // macOS Desktop 작업 제목 표시줄.
+  desktopTitlebar: {
+    taskDetails: '작업 세부 정보',
+    ready: '준비됨',
+    workspace: '워크스페이스',
+    branch: '브랜치',
+    path: '경로',
+    model: '모델',
+    noBranch: '브랜치 없음',
+    updateFailed: '이 작업을 업데이트할 수 없습니다.',
+    open: '열기',
+    openWorkspace: '워크스페이스 열기',
+    localOnly: '로컬 워크스페이스만 앱에서 열 수 있습니다.',
+    openFailed: '{app}을(를) 열 수 없습니다. 앱이 설치되어 있고 워크스페이스 위치가 허용되어 있는지 확인하세요.',
+  },
+
   // 클라우드 릴리 상태 배지 + 팝오버 (사이드바 하단).
   cloud: {
     mobileHubTitle: '원격 액세스',

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -1001,6 +1001,8 @@ export default {
     open: '열기',
     openWorkspace: '워크스페이스 열기',
     localOnly: '로컬 워크스페이스만 앱에서 열 수 있습니다.',
+    discoveryFailed: '이 Mac에 설치된 앱을 읽을 수 없습니다.',
+    noApplications: '지원되는 앱을 찾지 못했습니다.',
     openFailed: '{app}을(를) 열 수 없습니다. 앱이 설치되어 있고 워크스페이스 위치가 허용되어 있는지 확인하세요.',
   },
 

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -1028,6 +1028,8 @@ export default {
     open: '打开',
     openWorkspace: '打开工作区',
     localOnly: '只有本地工作区可以在应用中打开。',
+    discoveryFailed: '无法读取这台 Mac 上已安装的应用。',
+    noApplications: '未找到支持的应用。',
     openFailed: '无法打开 {app}，请确认应用已安装且工作区路径在允许范围内。',
   },
 

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -1015,6 +1015,22 @@ export default {
     },
   },
 
+  // macOS Desktop 任务标题栏。
+  desktopTitlebar: {
+    taskDetails: '任务详情',
+    ready: '就绪',
+    workspace: '工作区',
+    branch: '分支',
+    path: '路径',
+    model: '模型',
+    noBranch: '无分支',
+    updateFailed: '无法更新此任务。',
+    open: '打开',
+    openWorkspace: '打开工作区',
+    localOnly: '只有本地工作区可以在应用中打开。',
+    openFailed: '无法打开 {app}，请确认应用已安装且工作区路径在允许范围内。',
+  },
+
   // 云中继状态徽标 + 弹层（侧边栏底部）。
   cloud: {
     mobileHubTitle: '远程访问',

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -983,6 +983,22 @@ export default {
     },
   },
 
+  // macOS Desktop 任務標題列。
+  desktopTitlebar: {
+    taskDetails: '任務詳情',
+    ready: '就緒',
+    workspace: '工作區',
+    branch: '分支',
+    path: '路徑',
+    model: '模型',
+    noBranch: '無分支',
+    updateFailed: '無法更新此任務。',
+    open: '開啟',
+    openWorkspace: '開啟工作區',
+    localOnly: '只有本機工作區可以在應用程式中開啟。',
+    openFailed: '無法開啟 {app}，請確認應用程式已安裝且工作區路徑在允許範圍內。',
+  },
+
   // 雲端中繼狀態徽章 + 彈出面板（側邊欄底部）。
   cloud: {
     mobileHubTitle: '遠端存取',

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -996,6 +996,8 @@ export default {
     open: '開啟',
     openWorkspace: '開啟工作區',
     localOnly: '只有本機工作區可以在應用程式中開啟。',
+    discoveryFailed: '無法讀取這台 Mac 上已安裝的應用程式。',
+    noApplications: '找不到支援的應用程式。',
     openFailed: '無法開啟 {app}，請確認應用程式已安裝且工作區路徑在允許範圍內。',
   },
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -170,7 +170,10 @@ export const api = {
     const q = mode ? `?mode=${encodeURIComponent(mode)}` : ''
     return request<DiffResponse>(`/api/diff${q}`)
   },
-  workspace: () => request<WorkspaceInfo>('/api/workspace'),
+  workspace: (taskId?: string) => {
+    const q = taskId ? `?task_id=${encodeURIComponent(taskId)}` : ''
+    return request<WorkspaceInfo>(`/api/workspace${q}`)
+  },
   gitBranches: () => request<GitBranchesResponse>('/api/git/branches'),
   gitCheckout: (branch: string, create = false, strategy: '' | 'stash' | 'force' = '') =>
     request<GitCheckoutResponse>('/api/git/checkout', {

--- a/web/src/lib/useDesktop.test.ts
+++ b/web/src/lib/useDesktop.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { isAbsoluteLocalWorkspacePath } from './useDesktop'
+
+describe('isAbsoluteLocalWorkspacePath', () => {
+  it('accepts absolute macOS paths and rejects relative or remote workspaces', () => {
+    expect(isAbsoluteLocalWorkspacePath('/Users/test/work/jcode')).toBe(true)
+    expect(isAbsoluteLocalWorkspacePath('/Volumes/source/jcode')).toBe(true)
+    expect(isAbsoluteLocalWorkspacePath('work/jcode')).toBe(false)
+    expect(isAbsoluteLocalWorkspacePath('ssh://host/work/jcode')).toBe(false)
+    expect(isAbsoluteLocalWorkspacePath('docker://container/work/jcode')).toBe(false)
+  })
+})

--- a/web/src/lib/useDesktop.ts
+++ b/web/src/lib/useDesktop.ts
@@ -44,18 +44,42 @@ export async function openUrl(url: string): Promise<void> {
   }
 }
 
+export interface WorkspaceApplication {
+  id: string
+  label: string
+  group: 'editor' | 'system'
+  iconDataUrl?: string
+}
+
+let workspaceApplicationsPromise: Promise<WorkspaceApplication[]> | null = null
+
 /**
- * Open a local workspace in a specific desktop application. The Tauri
- * capability file scopes this bridge to an explicit app allowlist and local
- * workspace roots; browser callers are rejected.
+ * Ask the native shell which supported applications Launch Services can
+ * actually resolve. Each result carries the installed app's own icon. Cache
+ * the in-flight/result promise so React StrictMode does not decode every icon
+ * twice during its development remount.
  */
-export async function openWorkspacePath(path: string, application?: string): Promise<void> {
-  if (!isTauri) throw new Error('openWorkspacePath() called outside Tauri')
-  if (!isAbsoluteLocalWorkspacePath(path)) {
-    throw new Error('openWorkspacePath() requires an absolute local path')
+export function listWorkspaceApplications(): Promise<WorkspaceApplication[]> {
+  if (!workspaceApplicationsPromise) {
+    workspaceApplicationsPromise = invoke<WorkspaceApplication[]>('list_workspace_applications').catch((error) => {
+      workspaceApplicationsPromise = null
+      throw error
+    })
   }
-  const { openPath } = await import('@tauri-apps/plugin-opener')
-  await openPath(path, application)
+  return workspaceApplicationsPromise
+}
+
+/**
+ * Open a local workspace with an opaque application ID returned by
+ * listWorkspaceApplications(). The backend resolves the bundle and validates
+ * the canonical path again; the webview cannot supply an executable.
+ */
+export async function openWorkspaceInApplication(path: string, appId: string): Promise<void> {
+  if (!isTauri) throw new Error('openWorkspaceInApplication() called outside Tauri')
+  if (!isAbsoluteLocalWorkspacePath(path)) {
+    throw new Error('openWorkspaceInApplication() requires an absolute local path')
+  }
+  await invoke<void>('open_workspace_in_application', { path, appId })
 }
 
 export function isAbsoluteLocalWorkspacePath(path: string): boolean {

--- a/web/src/lib/useDesktop.ts
+++ b/web/src/lib/useDesktop.ts
@@ -8,6 +8,10 @@
 export const isTauri: boolean =
   typeof window !== 'undefined' && !!(window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
 
+/** True only for the macOS desktop shell that uses an overlay title bar. */
+export const isMacOSDesktop: boolean =
+  isTauri && typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform || '')
+
 /**
  * Tag the root document for native desktop shell styling. The macOS Tauri
  * window uses an overlay title bar, so CSS needs an `is-tauri-macos` hook to
@@ -38,6 +42,24 @@ export async function openUrl(url: string): Promise<void> {
   } else {
     window.open(url, '_blank', 'noopener,noreferrer')
   }
+}
+
+/**
+ * Open a local workspace in a specific desktop application. The Tauri
+ * capability file scopes this bridge to an explicit app allowlist and local
+ * workspace roots; browser callers are rejected.
+ */
+export async function openWorkspacePath(path: string, application?: string): Promise<void> {
+  if (!isTauri) throw new Error('openWorkspacePath() called outside Tauri')
+  if (!isAbsoluteLocalWorkspacePath(path)) {
+    throw new Error('openWorkspacePath() requires an absolute local path')
+  }
+  const { openPath } = await import('@tauri-apps/plugin-opener')
+  await openPath(path, application)
+}
+
+export function isAbsoluteLocalWorkspacePath(path: string): boolean {
+  return path.startsWith('/') && !path.startsWith('ssh://') && !path.startsWith('docker://')
 }
 
 /**


### PR DESCRIPTION
## Summary

- Use the macOS Desktop overlay titlebar for the active task title, workspace, and branch context, aligned with the main workspace column rather than the sidebar.
- Add a task-details popover with workspace/path/model information, per-session cloud sync, and pin/rename/archive actions—without an ellipsis menu.
- Discover supported editors, terminals, and Finder through macOS Launch Services by bundle ID; show only applications actually installed on the Mac.
- Render each discovered app's native `.icns` artwork in the “Open” menu, use Finder's native reveal API, and resolve all other apps inside the Tauri backend.
- Validate canonical workspace paths and opaque app IDs in Rust, removing the broader frontend opener allowlist.
- Keep browser and non-macOS surfaces on the existing standalone TopBar and cloud control.
- Make branch lookup task-scoped and harden cloud sync against stale refreshes, rapid task switching, duplicate toggles, and unmount races.
- Add keyboard navigation, ARIA relationships, localized copy, and focused Go/React/Rust tests.

## Why

The macOS Desktop titlebar was visually empty even though task identity and environment context are frequently needed. The first pass also guessed at installed applications and represented them with generic symbols. This revision follows the model used by GitHub Desktop and Raycast: identify installed apps through their bundle IDs, then let the operating system supply the real app identity and icon.

## User impact

Desktop users can identify the active task and branch at a glance, manage task metadata and cloud sync from one place, and open the current local workspace only in tools present on their Mac. Finder now uses the system reveal path. Browser behavior is unchanged.

## Validation

- `make build-web`
- `make lint-web`
- `go test ./...`
- `pnpm --dir web test` (19 tests)
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml` (3 tests, including native Finder discovery/icon extraction on macOS)
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`
- Prior titlebar visual QA at 1280 px and the 760 px minimum width
- Adversarial audit plus read-only Kimi CLI and Grok CLI reviews; final Kimi review: APPROVE

`make lint` is currently blocked by 44 pre-existing `SA5011` findings in untouched Go test files; none are in this PR's diff. The web lint/typecheck and all Go, React, and Rust tests above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS desktop title bar with task details, workspace information, task actions, and cloud sync controls.
  * Open local workspaces directly in supported applications, including Finder, with app icons and keyboard navigation.
  * Added localized title bar text in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

* **Bug Fixes**
  * Workspace details and Git status now reflect the selected task’s project.
  * Improved cloud sync reliability, preventing stale updates and duplicate toggle requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->