### PR TITLE
fix: route Desktop loopback links and modifier-clicks to system browser

### DIFF
--- a/web/src/lib/useDesktop.test.ts
+++ b/web/src/lib/useDesktop.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { isAbsoluteLocalWorkspacePath } from './useDesktop'
+
+const mocks = vi.hoisted(() => ({
+  openUrl: vi.fn<() => Promise<void>>(),
+}))
+
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: mocks.openUrl }))
+
+afterEach(() => {
+  delete (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+  document.body.replaceChildren()
+  vi.clearAllMocks()
+  vi.resetModules()
+})
 
 describe('isAbsoluteLocalWorkspacePath', () => {
   it('accepts absolute macOS paths and rejects relative or remote workspaces', () => {
@@ -12,5 +25,57 @@ describe('isAbsoluteLocalWorkspacePath', () => {
     expect(isAbsoluteLocalWorkspacePath('\\\\server\\share\\jcode')).toBe(false)
     expect(isAbsoluteLocalWorkspacePath('ssh://host/work/jcode')).toBe(false)
     expect(isAbsoluteLocalWorkspacePath('docker://container/work/jcode')).toBe(false)
+  })
+})
+
+describe('initExternalLinks', () => {
+  it.each([
+    ['ordinary click', {}],
+    ['Command-click', { metaKey: true }],
+    ['Ctrl-click', { ctrlKey: true }],
+  ])('opens a localhost preview in the system browser on Desktop: %s', async (_label, modifiers) => {
+    ;(window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {}
+    const { initExternalLinks } = await import('./useDesktop')
+    const cleanup = initExternalLinks()
+    const anchor = document.createElement('a')
+    anchor.href = 'http://localhost:3721/'
+    document.body.append(anchor)
+
+    const followedInWebview = anchor.dispatchEvent(new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      ...modifiers,
+    }))
+
+    expect(followedInWebview).toBe(false)
+    await vi.waitFor(() => expect(mocks.openUrl).toHaveBeenCalledWith('http://localhost:3721/'))
+    cleanup()
+  })
+
+  it('keeps Browser Web Command-click behavior native', async () => {
+    const { initExternalLinks } = await import('./useDesktop')
+    const cleanup = initExternalLinks()
+    const anchor = document.createElement('a')
+    anchor.href = 'https://example.com/'
+    document.body.append(anchor)
+    let preventedByRouter = false
+    anchor.addEventListener('click', (event) => {
+      preventedByRouter = event.defaultPrevented
+      // Stop jsdom from attempting an actual navigation after observing the
+      // capture-phase router's decision.
+      event.preventDefault()
+    })
+
+    anchor.dispatchEvent(new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      metaKey: true,
+    }))
+
+    expect(preventedByRouter).toBe(false)
+    expect(mocks.openUrl).not.toHaveBeenCalled()
+    cleanup()
   })
 })

--- a/web/src/lib/useDesktop.ts
+++ b/web/src/lib/useDesktop.ts
@@ -99,32 +99,37 @@ export function isAbsoluteLocalWorkspacePath(path: string): boolean {
  * `target="_blank"` clicks are dead (new-window creation is denied). One
  * delegated capture-phase listener covers every current and future anchor:
  * external http(s) links are opened in the system browser (Tauri) or a new
- * tab (browser); same-origin and loopback (sidecar API, Bearer-auth'd) links
- * are left alone.
+ * tab (browser). Desktop also routes loopback links and Command/Ctrl-clicks
+ * through the system browser; API traffic uses fetch/WebSocket rather than
+ * anchor navigation. Same-origin application links are left alone.
  */
-export function initExternalLinks(): void {
-  if (typeof document === 'undefined') return
-  document.addEventListener(
-    'click',
-    (e) => {
-      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
-      const anchor = (e.target as Element | null)?.closest?.('a[href]')
-      if (!anchor) return
-      const href = anchor.getAttribute('href') ?? ''
-      let url: URL
-      try {
-        url = new URL(href, window.location.href)
-      } catch {
-        return
-      }
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') return
-      if (url.origin === window.location.origin) return
-      if (isLoopback(url.hostname)) return
-      e.preventDefault()
-      void openUrl(url.href)
-    },
-    true,
-  )
+export function initExternalLinks(): () => void {
+  if (typeof document === 'undefined') return () => {}
+  const onClick = (e: MouseEvent) => {
+    if (e.defaultPrevented || e.button !== 0 || e.shiftKey || e.altKey) return
+    // Browser Web keeps native Command/Ctrl-click new-tab behavior. Tauri's
+    // webview cannot create that tab, so Desktop must route the gesture too.
+    if (!isTauri && (e.metaKey || e.ctrlKey)) return
+    const anchor = (e.target as Element | null)?.closest?.('a[href]')
+    if (!anchor) return
+    const href = anchor.getAttribute('href') ?? ''
+    let url: URL
+    try {
+      url = new URL(href, window.location.href)
+    } catch {
+      return
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return
+    if (url.origin === window.location.origin) return
+    // In Browser Web, preserve the existing loopback navigation behavior. In
+    // Desktop, localhost links are user-facing previews and belong outside the
+    // app; sidecar API requests never rely on anchor clicks.
+    if (!isTauri && isLoopback(url.hostname)) return
+    e.preventDefault()
+    void openUrl(url.href)
+  }
+  document.addEventListener('click', onClick, true)
+  return () => document.removeEventListener('click', onClick, true)
 }
 
 function isLoopback(hostname: string): boolean {


### PR DESCRIPTION
## What

- `initExternalLinks` now returns a cleanup function that removes the delegated click listener.
- On Tauri Desktop, loopback (localhost preview) links and Command/Ctrl-clicks are routed through the system browser — the webview cannot open new tabs, so these gestures were previously dead.
- Browser Web keeps its native behavior: Command/Ctrl-click new-tab and loopback navigation are untouched.
- Adds unit tests covering Desktop (ordinary click / Command-click / Ctrl-click on localhost) and Browser Web modifier-click behavior.

## Why

In the Desktop app, localhost preview links and modifier-clicks did nothing because Tauri's webview denies new-window creation, and the old listener skipped both modifier-clicks and loopback URLs entirely. API traffic uses fetch/WebSocket rather than anchor navigation, so routing loopback anchors externally is safe.

## Testing

- `npx vitest run src/lib/useDesktop.test.ts` — 5/5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved external-link handling in the desktop app.
  - Command-click and Ctrl-click now open loopback links in the system browser as expected.
  - Preserved native modifier-click behavior for HTTPS links in browser mode.
  - Improved link navigation reliability while maintaining existing URL validation and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->