### PR TITLE
fix: stop recovery and web UX fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,13 +67,13 @@ agent-eval/          # Agent evaluation harness + showcase generation
 
 ### Frontend (React)
 
-The product UI is React 18 (`web/`) and **consumes `jcode-ui` / `jcode-ui-core` from the npm registry** (not `file:` / `workspace:*` links). `packages/` is the source tree used to publish those packages.
+The product UI is React 18 (`web/`). **Internal** consumers — `web/` and `packages/jcode-ui` — link `jcode-ui` / `jcode-ui-core` via the `workspace:*` protocol so the monorepo co-evolves and `make build-web` builds from local source (not the published tarballs). **External** consumers — `site/`, `examples/*` — use registry version ranges.
 
 - `make build-web` typechecks/builds package `dist/` then builds the React app → `internal/web/dist/` (production embed).
 - `make lint-web` typechecks the React app + both packages.
 - Go `//go:embed dist/*` and Tauri `frontendDist` both point at `internal/web/dist/`.
-- Consumers (`web/`, `site/`, `examples/*`) declare registry versions, e.g. `"jcode-ui": "^0.1.1"`, `"jcode-ui-core": "^0.1.0"`.
-- Inside `packages/jcode-ui`, depend on core via a version range (`"jcode-ui-core": "^0.1.0"`) — **never** `file:../jcode-ui-core` (that broke `jcode-ui@0.1.0` on npm; use `0.1.1+`).
+- Internal deps use `workspace:*` (`web/package.json` → `jcode-ui`/`jcode-ui-core`; `packages/jcode-ui` → `jcode-ui-core`). External consumers (`site/`, `examples/*`) declare registry ranges, e.g. `"jcode-ui": "^0.4.1"`, `"jcode-ui-core": "^0.4.0"`.
+- Inside `packages/jcode-ui`, depend on core via `workspace:*` — **never** `file:../jcode-ui-core` (a `file:` link baked into the published `jcode-ui` tarball broke `jcode-ui@0.1.0` on npm).
 
 See `packages/jcode-ui/README.md` and `site/docs/chat-ui/`. Published: [jcode-ui](https://www.npmjs.com/package/jcode-ui) (styled) + [jcode-ui-core](https://www.npmjs.com/package/jcode-ui-core) (headless). The runtime abstraction (`ChatRuntime` + `createExternalStoreRuntime`) is the seam that lets the components render from any Redux-shaped store.
 
@@ -92,11 +92,11 @@ cd packages/jcode-ui-core && npm publish --access public --otp=XXXXXX
 cd ../jcode-ui && npm publish --access public --otp=XXXXXX
 ```
 
-After a successful publish, bump consumer deps (`web/`, `site/`, `examples/*`) to the new range and run `pnpm install` (and `cd site && pnpm install` for the site workspace). Also refresh `minimumReleaseAgeExclude` entries in every `pnpm-workspace.yaml` (root, `site/`, `examples/*`) so the newly published versions are not blocked by release-age checks. Local edits under `packages/` do **not** reach `web`/`site` until a new version is published and the dependency range is updated.
+After a successful publish, bump the **external** consumer deps (`site/`, `examples/*`) to the new range and run `pnpm install` (and `cd site && pnpm install` for the site workspace). Also refresh `minimumReleaseAgeExclude` entries in every `pnpm-workspace.yaml` (root, `site/`, `examples/*`) so the newly published versions are not blocked by release-age checks. `web/` needs no bump — it links local source via `workspace:*` and picks up `packages/` edits on the next `make build-web`.
 
 Checklist before publish:
 
-1. `jcode-ui` → `jcode-ui-core` is a registry range (`^x.y.z`), not `file:`
+1. `jcode-ui` → `jcode-ui-core` uses `workspace:*` locally (never `file:`); only external consumers (`site/`, `examples/*`) carry registry ranges
 2. Both packages have fresh `dist/` (`pnpm build`)
 3. Smoke: `npm install jcode-ui@<ver>` in a temp dir imports both packages and pulls core transitively
 4. After publish: update `minimumReleaseAgeExclude` in all `pnpm-workspace.yaml` files to the new `jcode-ui` / `jcode-ui-core` versions (drop stale entries)
@@ -202,7 +202,7 @@ Checklist before publish:
 - **Don't store mutable state in tool closures.** Use `*Env` or pass state explicitly. Tools may be re-created across mode transitions (normal ↔ plan).
 - **Don't skip `env.ResolvePath()`.** Raw path concatenation can escape the working directory without warning.
 - **Don't import `internal/tui` from non-TUI packages.** The handler interface is the decoupling boundary.
-- **Don't depend on `jcode-ui` / `jcode-ui-core` via `file:` or `workspace:*`.** Consumers and `packages/jcode-ui`→core must use registry version ranges so publish and local installs match.
+- **Don't depend on `jcode-ui` / `jcode-ui-core` via `file:`.** Internal links (`web/`, `packages/jcode-ui`→core) use `workspace:*`; external consumers (`site/`, `examples/*`) use registry version ranges.
 - **Don't let tests read the real HOME.** The pre-push hook runs the full suite; tests must `t.Setenv("HOME", t.TempDir())` whenever code under test resolves `config.ConfigDir()` (a real `~/.jcode/AGENTS.md` breaks `internal/prompts`).
 
 ---
@@ -254,7 +254,7 @@ outbound-only relay; design contract lives in the cloud repo
 - **Output:** builds to `internal/web/dist/`, embedded in the Go binary via `//go:embed`
 - **Lint:** `make lint-web` (tsc for web + packages)
 - Changes to the product UI (`web/`) require rebuilding via `make build-web` for the Go binary to pick them up
-- Changes to the chat library (`packages/jcode-ui*`) require **npm publish + consumer version bump + `pnpm install`** before `web`/`site` see them (registry deps, not workspace links)
+- Changes to the chat library (`packages/jcode-ui*`) are picked up by `web/` immediately via `workspace:*` (rebuild with `make build-web`); only `site/`/`examples/*` need **npm publish + version bump + `pnpm install`**
 - **Don't confuse `web/` with `site/`:** `web/` is the product UI embedded in the binary and reused by the desktop app; `site/` is the public website + docs at www.j-code.net and is deployed separately (`cd site && pnpm build`).
 
 ### Icons & Styling
@@ -263,5 +263,5 @@ outbound-only relay; design contract lives in the cloud repo
 - **Icon sizing:** use Tailwind `h-N w-N` classes (e.g. `className="h-3.5 w-3.5"`).
 - **Colors:** every color must come from a CSS custom property (jcode-ui tokens / `tokens.generated.css`). Never hardcode hex/rgb/`#fff`/`white` in components.
 - **Themes:** edit `internal/theme/palette.go` and run `make generate` — never edit `tokens.generated.css` or `themes.generated.ts` by hand.
-- **Reusable chat UI:** import from the `jcode-ui` package (registry); implement/fix library code under `packages/jcode-ui` and publish.
+- **Reusable chat UI:** import from the `jcode-ui` package (`workspace:*` in `web/`, registry range in `site/`/`examples/*`); implement/fix library code under `packages/jcode-ui` and publish for external consumers.
 - **Product composer:** the desktop input experience (`ChatInput` + `WorkspacePicker` / `BranchPicker` / `GoalBanner`) lives in `packages/jcode-ui/src/product/` and is consumed as `jcode-ui/product`. The components are Redux/fetch/Tauri/i18next-free — hosts inject a `ProductComposerHost` (state + actions + strings + icons); the web adapter is `web/src/app/composerHost.ts`. Package tests: `cd packages/jcode-ui && pnpm test` (vitest).

--- a/internal/model/chatmodel.go
+++ b/internal/model/chatmodel.go
@@ -818,7 +818,15 @@ func toOpenAIMessages(input []*schema.Message, vision bool) []openai.ChatComplet
 			continue
 		}
 		if msg.Role != schema.Tool {
-			msgs = append(msgs, toOpenAIMessage(msg, vision))
+			converted := toOpenAIMessage(msg, vision)
+			// An interrupted reasoning stream can leave a runtime-only assistant
+			// prefix with reasoning_content but no content or tool_calls. DeepSeek
+			// (and other strict OpenAI-compatible APIs) reject that shape. It is
+			// not a completed conversation turn, so omit it at the provider boundary.
+			if converted.Role != string(schema.Assistant) ||
+				converted.Content != "" || len(converted.MultiContent) > 0 || len(converted.ToolCalls) > 0 {
+				msgs = append(msgs, converted)
+			}
 			i++
 			continue
 		}
@@ -839,6 +847,12 @@ func toOpenAIMessages(input []*schema.Message, vision bool) []openai.ChatComplet
 				// synthetic user message below, so this is not an omission and must
 				// not carry the non-vision warning.
 				textResult.Content = collapsedInputText(toolMsg.UserInputMultiContent, false)
+			}
+			// go-openai omits an empty string because content has `omitempty`, but
+			// DeepSeek requires every tool message to carry content. Keep the model
+			// history structurally valid without changing the UI-visible tool result.
+			if textResult.Content == "" {
+				textResult.Content = "[Tool returned no output]"
 			}
 			if !attachVisuals || !hasInputImage(toolMsg) {
 				msgs = append(msgs, textResult)

--- a/internal/model/chatmodel_multimodal_test.go
+++ b/internal/model/chatmodel_multimodal_test.go
@@ -83,6 +83,27 @@ func TestToOpenAIMessagesVisionDisabledKeepsTextOnly(t *testing.T) {
 	}
 }
 
+func TestToOpenAIMessagesDropsReasoningOnlyAssistant(t *testing.T) {
+	got := toOpenAIMessages([]*schema.Message{
+		schema.UserMessage("before stop"),
+		{Role: schema.Assistant, ReasoningContent: "unfinished private reasoning"},
+		schema.UserMessage("continue after stop"),
+	}, false)
+	if len(got) != 2 || got[0].Role != string(schema.User) || got[1].Role != string(schema.User) {
+		t.Fatalf("messages = %#v, want the invalid assistant prefix omitted", got)
+	}
+}
+
+func TestToOpenAIMessagesSuppliesContentForEmptyToolResult(t *testing.T) {
+	got := toOpenAIMessages([]*schema.Message{
+		schema.ToolMessage("", "call-empty", schema.WithToolName("empty_tool")),
+	}, false)
+	if len(got) != 1 || got[0].Role != string(schema.Tool) ||
+		got[0].ToolCallID != "call-empty" || got[0].Content == "" {
+		t.Fatalf("tool message = %#v, want required content and tool_call_id", got)
+	}
+}
+
 func TestToOpenAIMessagesKeepsCurrentImageAfterSystemReminder(t *testing.T) {
 	got := toOpenAIMessages([]*schema.Message{
 		multimodalToolMessage("PNG"),

--- a/internal/runner/responses_continuity_test.go
+++ b/internal/runner/responses_continuity_test.go
@@ -184,6 +184,12 @@ func TestRunFailedResponsesStreamDoesNotPersistOrphanOpaqueReasoning(t *testing.
 			if result.Err == nil {
 				t.Fatal("Run unexpectedly succeeded")
 			}
+			if got := len(result.Messages); got != btoi(test.wantAssistant) {
+				t.Fatalf("live assistant messages = %d, want %d", got, btoi(test.wantAssistant))
+			}
+			if test.wantAssistant && result.Messages[0].Content != test.content {
+				t.Fatalf("live assistant = %#v, want content %q", result.Messages[0], test.content)
+			}
 
 			entries, err := session.LoadSession(id)
 			if err != nil {
@@ -211,4 +217,11 @@ func TestRunFailedResponsesStreamDoesNotPersistOrphanOpaqueReasoning(t *testing.
 			}
 		})
 	}
+}
+
+func btoi(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -643,15 +643,16 @@ func runInner(
 				// A failed stream may contain only a prefix of tool-call arguments.
 				// Preserve text already shown to the user, but never persist or
 				// expose incomplete calls as executable conversation history.
-				if messageText.Len() > 0 || reasoningText.Len() > 0 || len(messageExtra) > 0 {
+				// A reasoning-only prefix is not a valid assistant turn for
+				// OpenAI-compatible chat APIs (DeepSeek requires content or
+				// tool_calls). It also was never shown by the handler, so retaining
+				// it would only poison the next request after a user stop.
+				if messageText.Len() > 0 {
 					partial := &schema.Message{
 						Role: schema.Assistant, Content: messageText.String(),
 						ReasoningContent: reasoningText.String(), Extra: messageExtra,
 					}
-					// Encrypted reasoning without visible output is not a complete
-					// assistant turn. Keep the live partial for diagnostics, but do
-					// not leave an orphan continuation item in the session journal.
-					if rec != nil && messageText.Len() > 0 {
+					if rec != nil {
 						rec.RecordAssistantMessage(partial)
 					}
 					result.Messages = append(result.Messages, partial)

--- a/packages/jcode-ui-core/src/hooks/index.ts
+++ b/packages/jcode-ui-core/src/hooks/index.ts
@@ -26,7 +26,18 @@ export function useAutoScroll<T extends HTMLElement>(threshold = 80) {
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     const el = ref.current
     if (!el) return
-    el.scrollTo({ top: el.scrollHeight, behavior })
+    // A scroll container carrying CSS `scroll-behavior: smooth` (the Thread's
+    // `scroll-smooth` class) turns `behavior: 'auto'` into an *animated* scroll.
+    // Mid-animation scroll events flip `isAtBottomRef` false before the target
+    // lands, which then suppresses the re-measure follow-up — conversation
+    // switches strand partway up. Assigning `scrollTop` directly is always
+    // instant and unaffected by the CSS, which is what 'auto' is documented to
+    // mean here. Only an explicit 'smooth' animates.
+    if (behavior === 'smooth') {
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+    } else {
+      el.scrollTop = el.scrollHeight
+    }
     isAtBottomRef.current = true
   }, [])
 

--- a/packages/jcode-ui-core/src/primitives/Thread.tsx
+++ b/packages/jcode-ui-core/src/primitives/Thread.tsx
@@ -11,7 +11,7 @@
  * `virtualize={false}` for short/replay timelines where DOM simplicity matters.
  */
 
-import { Fragment, useMemo } from 'react'
+import { Fragment, useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useRuntimeState } from '../runtime/context.js'
@@ -159,7 +159,30 @@ function VirtualizedThread({
   autoScroll,
   containerRef,
 }: VirtualizedThreadProps): ReactNode {
-  const parentRef = autoScroll.ref
+  const { ref: parentRef, getIsAtBottom, onScroll, scrollToBottom } = autoScroll
+  // Geometry alone cannot identify user intent while virtual rows are being
+  // measured: as the estimated total grows, the browser emits scroll events
+  // with a large temporary bottom gap. Keep the initial bottom lock until an
+  // actual upward user gesture releases it. Reaching the bottom manually arms
+  // the lock again for later streaming/measurement updates.
+  const followMeasurementsRef = useRef(true)
+  const userScrollDirectionRef = useRef<-1 | 0 | 1>(0)
+  const handleScroll = useCallback(() => {
+    onScroll()
+    // Do not re-arm during the first few pixels of an upward gesture: those
+    // events are still inside the bottom threshold. Only an explicit downward
+    // gesture that actually reaches the bottom restores measurement following.
+    if (userScrollDirectionRef.current > 0 && getIsAtBottom()) {
+      followMeasurementsRef.current = true
+    }
+  }, [getIsAtBottom, onScroll])
+  const releaseBottomLock = useCallback(() => {
+    userScrollDirectionRef.current = -1
+    followMeasurementsRef.current = false
+  }, [])
+  const rearmAtBottom = useCallback(() => {
+    if (getIsAtBottom()) followMeasurementsRef.current = true
+  }, [getIsAtBottom])
   // count includes the trailing pending row + overscan spacer when present.
   const trailingCount = (isRunning && renderPending ? 1 : 0) + (overscanBottom > 0 ? 1 : 0)
   const count = items.length + trailingCount
@@ -169,6 +192,16 @@ function VirtualizedThread({
     estimateSize: () => estimateSize,
     overscan: 8,
   })
+
+  // Pin to the true bottom once rows re-measure. On a freshly mounted thread
+  // (e.g. switching conversations) getTotalSize() starts at the row ESTIMATE and
+  // only converges after ResizeObserver measurements land — scrolling to the
+  // estimate would strand the view partway up. A layout effect closes each
+  // measurement gap before paint while the bottom lock remains armed.
+  const totalSize = rowVirtualizer.getTotalSize()
+  useLayoutEffect(() => {
+    if (followMeasurementsRef.current) scrollToBottom('auto')
+  }, [totalSize, scrollToBottom])
 
   return (
     // Wrapper: the scroll element MUST resolve to a concrete pixel height for the
@@ -193,7 +226,38 @@ function VirtualizedThread({
         className={className}
         data-jcode-ui=""
         role={role}
-        onScroll={autoScroll.onScroll}
+        onScroll={handleScroll}
+        onWheel={(event) => {
+          if (event.deltaY < 0) {
+            releaseBottomLock()
+          } else if (event.deltaY > 0) {
+            userScrollDirectionRef.current = 1
+          }
+        }}
+        onTouchMove={releaseBottomLock}
+        onTouchEnd={rearmAtBottom}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home') {
+            releaseBottomLock()
+          } else if (
+            event.key === 'ArrowDown' ||
+            event.key === 'PageDown' ||
+            event.key === 'End'
+          ) {
+            userScrollDirectionRef.current = 1
+          }
+        }}
+        onPointerDown={(event) => {
+          // A scrollbar-thumb drag does not emit wheel/touch events. Detect a
+          // pointer in the classic scrollbar gutter without treating ordinary
+          // clicks inside message content as scroll intent.
+          const el = event.currentTarget
+          const scrollbarWidth = el.offsetWidth - el.clientWidth
+          if (scrollbarWidth <= 0) return
+          const rect = el.getBoundingClientRect()
+          if (event.clientX >= rect.right - scrollbarWidth) releaseBottomLock()
+        }}
+        onPointerUp={rearmAtBottom}
         style={
           {
             overflowY: 'auto',

--- a/packages/jcode-ui/src/hooks/useAutoScroll.test.tsx
+++ b/packages/jcode-ui/src/hooks/useAutoScroll.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useAutoScroll } from 'jcode-ui-core/hooks'
+import type { MutableRefObject } from 'react'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/**
+ * The Thread scroll container carries the `scroll-smooth` Tailwind class
+ * (`scroll-behavior: smooth`). Under that CSS, `el.scrollTo({ behavior: 'auto' })`
+ * *animates* instead of snapping, and mid-animation scroll events flip
+ * `isAtBottomRef` to false before the target lands — which then suppresses the
+ * re-measure follow-up and strands conversation switches partway up the thread.
+ *
+ * `scrollToBottom` must therefore snap via a direct `scrollTop` assignment
+ * (unaffected by CSS `scroll-behavior`) for the default 'auto' behavior, and
+ * only animate when explicitly asked for 'smooth'.
+ */
+describe('useAutoScroll.scrollToBottom', () => {
+  function attachScrollContainer() {
+    const el = document.createElement('div')
+    let scrollTop = 0
+    Object.defineProperty(el, 'scrollHeight', {
+      configurable: true,
+      get: () => 1000,
+    })
+    Object.defineProperty(el, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = v
+      },
+    })
+    const scrollTo = vi.fn()
+    Object.defineProperty(el, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    })
+    return { el, scrollTo, getScrollTop: () => scrollTop }
+  }
+
+  it('snaps via scrollTop assignment for the default behavior (ignores scroll-behavior CSS)', () => {
+    const { el, scrollTo, getScrollTop } = attachScrollContainer()
+    const { result } = renderHook(() => useAutoScroll<HTMLDivElement>())
+    ;(result.current.ref as MutableRefObject<HTMLDivElement | null>).current = el
+
+    result.current.scrollToBottom()
+
+    expect(getScrollTop()).toBe(1000)
+    expect(scrollTo).not.toHaveBeenCalled()
+    expect(result.current.getIsAtBottom()).toBe(true)
+  })
+
+  it('animates only for an explicit smooth request', () => {
+    const { el, scrollTo } = attachScrollContainer()
+    const { result } = renderHook(() => useAutoScroll<HTMLDivElement>())
+    ;(result.current.ref as MutableRefObject<HTMLDivElement | null>).current = el
+
+    result.current.scrollToBottom('smooth')
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' })
+  })
+})

--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -762,20 +762,10 @@ const chatSlice = createSlice({
           item.data.awaitingApproval = undefined
         }
       }
-      if (a.payload?.stopped) {
-        // Manual stop — a calm muted notice, not an error card.
-        s.timeline.push({
-          kind: 'message',
-          data: {
-            id: genId('sys'),
-            role: 'system',
-            content: 'Stopped by user',
-            timestamp: Date.now(),
-            level: 'notice',
-          },
-          seq: nextSeq(),
-        })
-      } else if (a.payload?.error) {
+      // A manual stop (a.payload?.stopped) intentionally adds nothing to the
+      // timeline — the streaming indicator disappearing is enough feedback; a
+      // "Stopped by user" system card felt like noise.
+      if (a.payload?.error) {
         s.timeline.push({
           kind: 'message',
           data: {


### PR DESCRIPTION
## Summary

Several UX and stop-recovery fixes spanning the web UI, the `jcode-ui` library, and the Go model/runner boundary.

### Changes

**Web — stop feedback**
- Drop the "Stopped by user" system message on manual stop. The streaming indicator disappearing is enough feedback; a system card felt like noise. (`web/src/app/store.ts`)

**jcode-ui — scroll-to-bottom on conversation switch**
- Make auto-scroll-to-bottom snap instantly. A container with CSS `scroll-behavior: smooth` (the Thread's `scroll-smooth` class) turned `scrollTo({ behavior: 'auto' })` into an animated scroll, whose mid-flight scroll events flipped the at-bottom flag false and suppressed the re-measure follow-up — conversation switches stranded partway up. Assign `scrollTop` directly for the default `'auto'` behavior. (`packages/jcode-ui-core/src/hooks/index.ts`)
- Pin the virtualized thread to the bottom as rows re-measure (bottom lock + layout effect) so a freshly mounted conversation lands on the true bottom once ResizeObserver measurements converge. (`packages/jcode-ui-core/src/primitives/Thread.tsx`)
- Add a unit test locking the instant-scroll behavior. (`packages/jcode-ui/src/hooks/useAutoScroll.test.tsx`)

**Go — stop recovery against strict APIs**
- Drop reasoning-only assistant prefixes and supply required content for empty tool results, so strict OpenAI-compatible APIs (DeepSeek) don't reject the next request after a stop. A reasoning-only prefix is not a completed turn and was never shown to the user. (`internal/model/chatmodel.go`, `internal/runner/runner.go`)
- Tests for the two provider-boundary cases and the live-message count on a failed stream. (`internal/model/chatmodel_multimodal_test.go`, `internal/runner/responses_continuity_test.go`)

**Docs**
- Document `workspace:*` internal linking vs registry ranges for external consumers. (`AGENTS.md`)

### Verification
- `go test ./internal/model/... ./internal/runner/...` ✅
- `cd packages/jcode-ui && pnpm test` — 42 tests ✅
- `cd packages/jcode-ui-core && pnpm typecheck && pnpm build` ✅
- `cd web && npx tsc --noEmit` ✅ (after rebuilding `jcode-ui-core` dist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation handling by removing incomplete reasoning-only messages.
  * Preserved meaningful partial responses when streaming fails.
  * Added clear placeholder text for tool results with no output.
  * Prevented an inaccurate “Stopped by user” message when manually stopping a run.
  * Improved thread auto-scrolling, including reliable bottom-follow behavior and user scroll control.

* **Documentation**
  * Updated frontend package and publishing guidance for local and published dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->