### PR TITLE
fix(web): hide ask-user card immediately after submit

### DIFF
--- a/web/src/app/store.askUser.test.ts
+++ b/web/src/app/store.askUser.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Ask-user optimistic resolve: the docked card must leave pending the moment
+ * /api/ask succeeds, without waiting for the later tool_result event.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  chatActions,
+  formatAskUserOutput,
+  store,
+  submitAskUser,
+} from './store'
+import { api } from '../lib/api'
+
+afterEach(() => {
+  store.dispatch(chatActions.clearChat())
+  vi.restoreAllMocks()
+})
+
+describe('formatAskUserOutput', () => {
+  it('mirrors the backend single- and multi-question shapes', () => {
+    expect(formatAskUserOutput([])).toBe('The user did not provide any answers.')
+    expect(formatAskUserOutput([{ question_header: 'Place', answer: 'Home' }])).toBe(
+      "User's answer: Home",
+    )
+    expect(
+      formatAskUserOutput([
+        { question_header: 'Place', answer: 'Home' },
+        { question_header: 'Time', answer: 'Now' },
+      ]),
+    ).toBe(
+      JSON.stringify({
+        answers: [
+          { question_header: 'Place', answer: 'Home' },
+          { question_header: 'Time', answer: 'Now' },
+        ],
+      }),
+    )
+  })
+})
+
+describe('resolveAskUserItem', () => {
+  it('marks the matching ask_user tool done and clears pending markers', () => {
+    store.dispatch(
+      chatActions.attachAskUser({
+        toolName: 'ask_user',
+        askUserId: 'ask-1',
+        questions: [{ header: 'Place', question: 'Where?' }],
+        taskId: 'task-1',
+      }),
+    )
+
+    store.dispatch(
+      chatActions.resolveAskUserItem({
+        id: 'ask-1',
+        answers: [{ question_header: 'Place', answer: 'Home' }],
+      }),
+    )
+
+    const tool = store.getState().chat.timeline.find((item) => item.kind === 'tool')
+    expect(tool?.kind).toBe('tool')
+    if (tool?.kind !== 'tool') return
+    expect(tool.data.status).toBe('done')
+    expect(tool.data.askUserId).toBeUndefined()
+    expect(tool.data.askUserQuestions).toBeUndefined()
+    expect(tool.data.output).toBe("User's answer: Home")
+    expect((tool.data as { askUserTaskId?: string }).askUserTaskId).toBeUndefined()
+  })
+})
+
+describe('submitAskUser', () => {
+  it('optimistically resolves the card after a successful API submit', async () => {
+    const askUser = vi.spyOn(api, 'askUser').mockResolvedValue(undefined as never)
+    store.dispatch(
+      chatActions.attachAskUser({
+        toolName: 'ask_user',
+        askUserId: 'ask-2',
+        questions: [{ header: 'PR', question: 'Split?' }],
+        taskId: 'task-2',
+      }),
+    )
+
+    await store
+      .dispatch(
+        submitAskUser({
+          id: 'ask-2',
+          answers: [{ question_header: 'PR', answer: 'One PR' }],
+        }),
+      )
+      .unwrap()
+
+    expect(askUser).toHaveBeenCalledWith(
+      'ask-2',
+      [{ question_header: 'PR', answer: 'One PR' }],
+      'task-2',
+    )
+    const tool = store.getState().chat.timeline.find((item) => item.kind === 'tool')
+    expect(tool?.kind).toBe('tool')
+    if (tool?.kind !== 'tool') return
+    expect(tool.data.status).toBe('done')
+    expect(tool.data.askUserId).toBeUndefined()
+    expect(tool.data.output).toBe("User's answer: One PR")
+  })
+
+  it('keeps the pending card when the API submit fails', async () => {
+    vi.spyOn(api, 'askUser').mockRejectedValue(new Error('offline'))
+    store.dispatch(
+      chatActions.attachAskUser({
+        toolName: 'ask_user',
+        askUserId: 'ask-3',
+        questions: [{ header: 'PR', question: 'Split?' }],
+      }),
+    )
+
+    await expect(
+      store
+        .dispatch(
+          submitAskUser({
+            id: 'ask-3',
+            answers: [{ question_header: 'PR', answer: 'Two PRs' }],
+          }),
+        )
+        .unwrap(),
+    ).rejects.toThrow('offline')
+
+    const tool = store.getState().chat.timeline.find((item) => item.kind === 'tool')
+    expect(tool?.kind).toBe('tool')
+    if (tool?.kind !== 'tool') return
+    expect(tool.data.status).toBe('running')
+    expect(tool.data.askUserId).toBe('ask-3')
+    expect(tool.data.output).toBeUndefined()
+  })
+})

--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -24,6 +24,7 @@ import type {
   TodoItem,
   QueuedMessage,
   AskUserQuestion,
+  AskUserAnswer,
 } from 'jcode-ui-core'
 import { api, isAPIError } from '../lib/api'
 import { extractToolDisplayInfo } from '../lib/toolInfo'
@@ -457,6 +458,14 @@ function applyResolvedToolFields(tool: ToolCall, fields: ResolvedToolFields): vo
   // clears the awaiting-approval highlight.
   tool.denied = fields.denied || undefined
   tool.awaitingApproval = undefined
+  // A finished ask_user is no longer interactive — drop the pending markers so
+  // the docked card cannot reappear if a late tool_result races the optimistic
+  // resolve path.
+  if (tool.name === 'ask_user' || fields.name === 'ask_user') {
+    tool.askUserId = undefined
+    tool.askUserQuestions = undefined
+    delete (tool as ToolCall & { askUserTaskId?: string }).askUserTaskId
+  }
   if (fields.streams) tool.streams = fields.streams
   if (fields.meta) tool.meta = fields.meta
   // Merge the event-level duration into meta when meta lacks one (falling back
@@ -897,8 +906,36 @@ const chatSlice = createSlice({
         }
       }
     },
+    // Optimistically settle the docked ask_user card the moment /api/ask
+    // succeeds. Waiting for the later tool_result leaves the card stuck in
+    // "Submitting…" while the agent is already unblocked.
+    resolveAskUserItem(s, a: { payload: { id: string; answers: AskUserAnswer[] } }) {
+      for (let i = s.timeline.length - 1; i >= 0; i--) {
+        const item = s.timeline[i]
+        if (item.kind !== 'tool' || item.data.askUserId !== a.payload.id) continue
+        item.data.status = 'done'
+        item.data.output = formatAskUserOutput(a.payload.answers)
+        item.data.askUserId = undefined
+        item.data.askUserQuestions = undefined
+        delete (item.data as ToolCall & { askUserTaskId?: string }).askUserTaskId
+        return
+      }
+    },
   },
 })
+
+/** Mirror the ask_user tool's formatBatchResponse so optimistic receipts match
+ *  the eventual tool_result / session replay text. */
+export function formatAskUserOutput(answers: AskUserAnswer[]): string {
+  if (answers.length === 0) return 'The user did not provide any answers.'
+  if (answers.length === 1) {
+    const ans = answers[0]
+    const text = ans.answer || (ans.selected?.length ? ans.selected.join(', ') : '')
+    if (!text) return 'The user did not provide an answer.'
+    return `User's answer: ${text}`
+  }
+  return JSON.stringify({ answers })
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // session slice — sessions/tasks list, current session, project
@@ -1627,7 +1664,7 @@ export const resolveApprovalOption = createAsyncThunk(
 
 export const submitAskUser = createAsyncThunk(
   'askUser/submit',
-  async (payload: { id: string; answers: import('jcode-ui-core').AskUserAnswer[] }, { dispatch, getState }) => {
+  async (payload: { id: string; answers: AskUserAnswer[] }, { dispatch, getState }) => {
     const state = getState() as RootState
     let taskId: string | undefined
     for (const item of state.chat.timeline) {
@@ -1638,6 +1675,8 @@ export const submitAskUser = createAsyncThunk(
     }
     try {
       await api.askUser(payload.id, payload.answers, taskId)
+      // Hide the docked card immediately; the real tool_result may arrive later.
+      dispatch(chatActions.resolveAskUserItem({ id: payload.id, answers: payload.answers }))
     } catch (error) {
       // surface in timeline as a system message
       dispatch(chatActions.addMessage({ role: 'system', content: 'Failed to submit answer', level: 'error' }))


### PR DESCRIPTION
## Summary
- After `/api/ask` succeeds, optimistically mark the matching `ask_user` tool as done and clear `askUserId`, so the docked answer card hides immediately instead of lingering in “Submitting…”.
- Clear pending ask-user markers when a real `tool_result` arrives, avoiding races with the optimistic path.
- Add store coverage for format/output, successful submit, and failed submit.

## Test plan
- [x] `cd web && pnpm exec vitest run src/app/store.askUser.test.ts`
- [x] `cd packages/jcode-ui && pnpm test -- AskUserCard Thread.askUser`
- [ ] Manually: trigger `ask_user`, submit an option, confirm the docked card disappears right away and the transcript shows the answer receipt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed ask-user interactions now resolve immediately after successful submission.
  * Prevented completed ask-user cards from reappearing.
  * Improved answer display for empty, single-answer, and multiple-answer responses.
  * Pending interactions are preserved when answer submission fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->