### PR TITLE
fix(ui): auto-advance Ask User and hide duplicate pending cards

### DIFF
--- a/packages/jcode-ui-core/src/primitives/AskUserBlock.tsx
+++ b/packages/jcode-ui-core/src/primitives/AskUserBlock.tsx
@@ -100,8 +100,16 @@ export function AskUserBlock({ tool, className, renderPending, renderResolved }:
         other: { ...s.other, [key]: '' },
       }))
       setSubmitError(undefined)
+      // Single-select answers can advance immediately. The last question stays
+      // put so the user can still edit or hit Submit themselves.
+      if (!q.multi_select) {
+        const index = questions.findIndex((item) => keyOf(item) === key)
+        if (index >= 0 && index < questions.length - 1) {
+          setActiveIndex(index + 1)
+        }
+      }
     },
-    [isSubmitting, keyOf],
+    [isSubmitting, keyOf, questions, setActiveIndex],
   )
 
   const setOther = useCallback(

--- a/packages/jcode-ui/src/components/AskUserCard.test.tsx
+++ b/packages/jcode-ui/src/components/AskUserCard.test.tsx
@@ -69,7 +69,6 @@ describe('AskUserCard', () => {
     expect(screen.queryByText('(Recommended)')).toBeNull()
 
     fireEvent.click(screen.getByText('Home').closest('button')!)
-    fireEvent.click(primary(container))
     expect(screen.getByText('When should we start?')).toBeTruthy()
 
     const custom = screen.getByRole('textbox') as HTMLInputElement
@@ -116,15 +115,42 @@ describe('AskUserCard', () => {
   })
 
   it('scopes digit shortcuts to the visible question and ignores focused inputs', () => {
-    const { container } = renderCard(pendingTool(QUESTIONS.slice(0, 2)))
+    renderCard(pendingTool(QUESTIONS.slice(0, 2)))
     fireEvent.keyDown(window, { key: '2' })
-    expect(screen.getByText('Studio').closest('button')?.getAttribute('aria-pressed')).toBe('true')
-    fireEvent.click(primary(container))
+    expect(screen.getByText('When should we start?')).toBeTruthy()
 
     const custom = screen.getByRole('textbox')
     fireEvent.change(custom, { target: { value: 'Afternoon' } })
     fireEvent.keyDown(custom, { key: '1' })
     expect((custom as HTMLInputElement).value).toBe('Afternoon')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous question' }))
+    expect(screen.getByText('Studio').closest('button')?.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('auto-advances after a single-select choice but stays on the last question', () => {
+    const { container, runtime } = renderCard(pendingTool(QUESTIONS.slice(0, 2)))
+
+    fireEvent.click(screen.getByText('Studio').closest('button')!)
+    expect(screen.getByText('When should we start?')).toBeTruthy()
+    expect(runtime.calls).toEqual([])
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Tonight' } })
+    expect(screen.getByText('When should we start?')).toBeTruthy()
+    expect(primary(container).textContent).toContain('Submit')
+    expect(runtime.calls).toEqual([])
+  })
+
+  it('does not auto-advance multi-select questions', () => {
+    const { container } = renderCard()
+    fireEvent.click(screen.getByText('Home').closest('button')!)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Tonight' } })
+    fireEvent.click(primary(container))
+
+    expect(screen.getByText('What should we include?')).toBeTruthy()
+    fireEvent.click(screen.getByText('Tests').closest('button')!)
+    expect(screen.getByText('What should we include?')).toBeTruthy()
+    expect(screen.getByText('Tests').closest('button')?.getAttribute('aria-pressed')).toBe('true')
   })
 
   it('locks duplicate actions while submitting', () => {

--- a/packages/jcode-ui/src/components/Thread.askUser.test.tsx
+++ b/packages/jcode-ui/src/components/Thread.askUser.test.tsx
@@ -61,4 +61,20 @@ describe('Thread docked Ask User behavior', () => {
     expect(receipt).toBeTruthy()
     expect(receipt?.closest('.jcode-standalone-tool')?.classList.contains('jcode-gutter')).toBe(true)
   })
+
+  it('hides an in-flight Ask User even before askUserId is attached', () => {
+    const items: ThreadItem[] = [
+      { kind: 'message', seq: 1, data: { id: 'm1', role: 'assistant', content: 'Need a choice.', timestamp: 1 } },
+      { kind: 'tool', seq: 2, data: askTool({ askUserId: undefined, askUserQuestions: undefined }) },
+    ]
+    render(
+      <RuntimeProvider runtime={createMockRuntime({ items, isRunning: true })}>
+        <Thread virtualize={false} hidePendingAskUser renderPending={() => null} />
+      </RuntimeProvider>,
+    )
+
+    expect(screen.getByText('Need a choice.')).toBeTruthy()
+    expect(screen.queryByText('Hidden pending question?')).toBeNull()
+    expect(document.querySelector('.jcode-ask-user')).toBeNull()
+  })
 })

--- a/packages/jcode-ui/src/components/Thread.tsx
+++ b/packages/jcode-ui/src/components/Thread.tsx
@@ -77,7 +77,6 @@ export function Thread({
         ? items.filter((item) => !(
             item.kind === 'tool' &&
             item.data.name === 'ask_user' &&
-            !!item.data.askUserId &&
             item.data.status === 'running' &&
             !item.data.output
           ))

--- a/web/src/app/store.askUser.test.ts
+++ b/web/src/app/store.askUser.test.ts
@@ -38,6 +38,32 @@ describe('formatAskUserOutput', () => {
   })
 })
 
+describe('addToolCall ask_user merge', () => {
+  it('folds a late tool_call into the pending ask_user_request row', () => {
+    store.dispatch(
+      chatActions.attachAskUser({
+        toolName: 'ask_user',
+        askUserId: 'ask-merge',
+        questions: [{ header: 'Place', question: 'Where?' }],
+      }),
+    )
+    store.dispatch(
+      chatActions.addToolCall({
+        name: 'ask_user',
+        args: JSON.stringify({ questions: [{ header: 'Place', question: 'Where?' }] }),
+        toolCallID: 'tc-merge',
+      }),
+    )
+
+    const tools = store.getState().chat.timeline.filter((item) => item.kind === 'tool')
+    expect(tools).toHaveLength(1)
+    if (tools[0]?.kind !== 'tool') return
+    expect(tools[0].data.askUserId).toBe('ask-merge')
+    expect(tools[0].data.toolCallID).toBe('tc-merge')
+    expect(tools[0].data.status).toBe('running')
+  })
+})
+
 describe('resolveAskUserItem', () => {
   it('marks the matching ask_user tool done and clears pending markers', () => {
     store.dispatch(

--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -594,6 +594,28 @@ const chatSlice = createSlice({
       // starts a fresh assistant message).
       streamingText = ''
       streamingMsgId = ''
+      // ask_user_request can arrive before the matching tool_call and already
+      // insert a pending row. Fold this event into that row so the dock and
+      // timeline do not each render their own card.
+      if (a.payload.name === 'ask_user') {
+        for (let i = s.timeline.length - 1; i >= 0; i--) {
+          const item = s.timeline[i]
+          if (item.kind !== 'tool' || item.data.name !== 'ask_user') continue
+          if (item.data.status !== 'running' || item.data.output) continue
+          if (item.data.toolCallID && a.payload.toolCallID && item.data.toolCallID !== a.payload.toolCallID) continue
+          item.data.toolCallID = a.payload.toolCallID ?? item.data.toolCallID
+          if (a.payload.args) item.data.args = a.payload.args
+          item.data.displayInfo = a.payload.displayInfo ?? item.data.displayInfo
+          item.data.batchId = a.payload.batchId ?? item.data.batchId
+          item.data.batchIndex = a.payload.batchIndex ?? item.data.batchIndex
+          item.data.batchSize = a.payload.batchSize ?? item.data.batchSize
+          item.data.startedAt = a.payload.startedAt ?? item.data.startedAt
+          item.data.surface = a.payload.surface ?? item.data.surface
+          item.data.phase = a.payload.phase ?? item.data.phase
+          item.data.operationID = a.payload.operationID ?? item.data.operationID
+          return
+        }
+      }
       const tc: ToolCall = {
         id: genId('tool'),
         name: a.payload.name,

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -167,7 +167,7 @@ export function ChatView({ readOnly }: ChatViewProps) {
       <div className="chat-content-layer min-h-0 flex-1">
         <Thread
           overscanBottom={28}
-          hidePendingAskUser={!!pendingAskUser}
+          hidePendingAskUser
           renderPending={pendingAskUser ? () => null : () => <PendingIndicator />}
         />
       </div>


### PR DESCRIPTION
## Summary

- Single-select Ask User answers now advance to the next question immediately. The last question stays on screen so the user can still edit or submit.
- Fold a late `ask_user` `tool_call` into the existing pending `ask_user_request` row, so the dock and timeline do not each render their own card.
- Hide in-flight `ask_user` tools from the timeline even before `askUserId` is attached.

## Related Issues / Tickets

-

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Performance improvement
- [x] Test update

## Changes Made

1. Auto-advance single-select answers in `AskUserBlock.toggleOption`; leave the last question and multi-select questions in place.
2. Merge a late `ask_user` `tool_call` into the pending request row in the web store.
3. Always hide running `ask_user` tools from the chat timeline, even if `askUserId` has not been attached yet.

## Testing

- `cd packages/jcode-ui && pnpm exec vitest run src/components/AskUserCard.test.tsx src/components/Thread.askUser.test.tsx`
- `cd web && pnpm exec vitest run src/app/store.askUser.test.ts`
- Manual check: selecting options no longer creates a second card, and the last question does not auto-submit.

## Screenshots / Recordings

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests as needed.
- [ ] I have updated relevant documentation.
- [x] All new and existing tests pass.

## Additional Notes

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Single-choice prompts now automatically advance to the next question.
  * Multi-choice prompts continue to require manual progression.
  * Previous-question navigation preserves selected answers.

* **Bug Fixes**
  * Prevented duplicate pending prompts when ask-user responses arrive in stages.
  * Improved hiding of in-progress prompts until complete question data is available.
  * Keyboard shortcuts now target the visible question and do not interfere with focused inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->