### PR TITLE
fix: record Langfuse usage details and inherit Grok image support

### DIFF
--- a/internal/model/chatmodel.go
+++ b/internal/model/chatmodel.go
@@ -42,6 +42,7 @@ type TokenUsage struct {
 	lastCached     int64
 	lastReasoning  int64
 	lastCacheWrite int64
+	lastModel      string
 	// cacheSeen is set (sticky) once the provider returns a prompt_tokens_details
 	// object, so CacheObserved can report "caching supported" even on a 0-hit
 	// turn. Cleared by Reset (a session boundary), never by ResetContext.
@@ -212,6 +213,7 @@ func (t *TokenUsage) Reset() {
 	atomic.StoreInt64(&t.turnBaseCached, 0)
 	t.mu.Lock()
 	t.byModel = nil
+	t.lastModel = ""
 	t.mu.Unlock()
 }
 
@@ -269,7 +271,15 @@ func (t *TokenUsage) AddByModel(model string, prompt, completion, total int) {
 		t.byModel = make(map[string]int64)
 	}
 	t.byModel[model] += int64(total)
+	t.lastModel = model
 	t.mu.Unlock()
+}
+
+// GetLastModel returns the model name of the last recorded API call.
+func (t *TokenUsage) GetLastModel() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.lastModel
 }
 
 // GetByModel returns a snapshot of per-model token totals.

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -272,8 +272,76 @@ func (r *ModelRegistry) MergeConfigProviders(providers map[string]*config.Provid
 			if cm.Context > 0 {
 				rm.Limit = &ModelLimit{Context: cm.Context}
 			}
+			// Managed rows persist only what the live catalog last wrote. A newer
+			// Grok/Codex ID often lands before the static registry lists it, so
+			// omitted capabilities inherit from the closest baked-in sibling
+			// (grok-4.6 ← grok-4.5) instead of rendering as text-only.
+			if cm.Managed {
+				applyRelatedManagedModelDefaults(rm, RelatedRegistryModel(prov, cm.ID))
+			}
 			prov.Models[cm.ID] = rm
 		}
+	}
+}
+
+// RelatedRegistryModel returns a baked-in sibling that shares a versioned
+// family key with modelID. grok-4.6 matches grok-4.5; grok-imagine-image
+// does not. Used when a live managed catalog lists an ID the static
+// registry has not been updated to include yet.
+func RelatedRegistryModel(provider *RegistryProvider, modelID string) *RegistryModel {
+	if provider == nil {
+		return nil
+	}
+	key := managedModelFamilyKey(modelID)
+	if key == "" {
+		return nil
+	}
+	var related *RegistryModel
+	for _, candidate := range provider.Models {
+		if candidate == nil || candidate.ID == modelID || managedModelFamilyKey(candidate.ID) != key {
+			continue
+		}
+		if related == nil || candidate.DefaultEnabled && !related.DefaultEnabled {
+			related = candidate
+		}
+	}
+	return related
+}
+
+func managedModelFamilyKey(id string) string {
+	id = strings.ToLower(strings.TrimSpace(id))
+	for i := 0; i < len(id); i++ {
+		if id[i] != '-' || i+1 >= len(id) || id[i+1] < '0' || id[i+1] > '9' {
+			continue
+		}
+		end := i + 1
+		for end < len(id) && id[end] >= '0' && id[end] <= '9' {
+			end++
+		}
+		return id[:end]
+	}
+	return ""
+}
+
+func applyRelatedManagedModelDefaults(dst *RegistryModel, related *RegistryModel) {
+	if dst == nil || related == nil {
+		return
+	}
+	if !dst.Attachment && related.Attachment {
+		dst.Attachment = true
+		if dst.Modalities == nil && related.Modalities != nil {
+			dst.Modalities = deepCopyModel(related).Modalities
+		}
+	}
+	if !dst.Reasoning && related.Reasoning {
+		dst.Reasoning = true
+		if len(dst.ReasoningOptions) == 0 && len(related.ReasoningOptions) > 0 {
+			dst.ReasoningOptions = append([]ReasoningOption(nil), related.ReasoningOptions...)
+		}
+	}
+	if dst.Limit == nil && related.Limit != nil && related.Limit.Context > 0 {
+		limitCopy := *related.Limit
+		dst.Limit = &limitCopy
 	}
 }
 

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -288,24 +288,53 @@ func (r *ModelRegistry) MergeConfigProviders(providers map[string]*config.Provid
 // family key with modelID. grok-4.6 matches grok-4.5; grok-imagine-image
 // does not. Used when a live managed catalog lists an ID the static
 // registry has not been updated to include yet.
+//
+// Candidates come from immutable generatedProviders, never from the live
+// provider.Models map, so an earlier custom row cannot pollute inheritance.
 func RelatedRegistryModel(provider *RegistryProvider, modelID string) *RegistryModel {
 	if provider == nil {
 		return nil
 	}
-	key := managedModelFamilyKey(modelID)
-	if key == "" {
+	baked := generatedProviders[provider.ID]
+	if baked == nil {
 		return nil
 	}
+	return relatedBakedInModel(baked.Models, modelID)
+}
+
+func relatedBakedInModel(models map[string]*RegistryModel, modelID string) *RegistryModel {
+	key := managedModelFamilyKey(modelID)
+	if key == "" || models == nil {
+		return nil
+	}
+	targetParts := managedModelVersionParts(modelID)
 	var related *RegistryModel
-	for _, candidate := range provider.Models {
+	var relatedDist int
+	for _, candidate := range models {
 		if candidate == nil || candidate.ID == modelID || managedModelFamilyKey(candidate.ID) != key {
 			continue
 		}
-		if related == nil || candidate.DefaultEnabled && !related.DefaultEnabled {
-			related = candidate
+		dist := managedModelVersionDistance(managedModelVersionParts(candidate.ID), targetParts)
+		if !preferRelatedModel(related, relatedDist, candidate, dist) {
+			continue
 		}
+		related = candidate
+		relatedDist = dist
 	}
 	return related
+}
+
+func preferRelatedModel(current *RegistryModel, currentDist int, candidate *RegistryModel, candidateDist int) bool {
+	if current == nil {
+		return true
+	}
+	if candidateDist != currentDist {
+		return candidateDist < currentDist
+	}
+	if candidate.DefaultEnabled != current.DefaultEnabled {
+		return candidate.DefaultEnabled
+	}
+	return candidate.ID < current.ID
 }
 
 func managedModelFamilyKey(id string) string {
@@ -323,11 +352,68 @@ func managedModelFamilyKey(id string) string {
 	return ""
 }
 
+func managedModelVersionParts(id string) []int {
+	id = strings.ToLower(strings.TrimSpace(id))
+	i := 0
+	for i < len(id) {
+		if id[i] == '-' && i+1 < len(id) && id[i+1] >= '0' && id[i+1] <= '9' {
+			i++
+			break
+		}
+		i++
+	}
+	var parts []int
+	for i < len(id) {
+		if id[i] < '0' || id[i] > '9' {
+			if id[i] == '.' || id[i] == '-' {
+				i++
+				continue
+			}
+			break
+		}
+		n := 0
+		for i < len(id) && id[i] >= '0' && id[i] <= '9' {
+			n = n*10 + int(id[i]-'0')
+			i++
+		}
+		parts = append(parts, n)
+	}
+	return parts
+}
+
+func managedModelVersionDistance(a, b []int) int {
+	n := len(a)
+	if len(b) > n {
+		n = len(b)
+	}
+	dist := 0
+	weights := [...]int{1_000_000, 1_000, 1}
+	for i := 0; i < n; i++ {
+		av, bv := 0, 0
+		if i < len(a) {
+			av = a[i]
+		}
+		if i < len(b) {
+			bv = b[i]
+		}
+		d := av - bv
+		if d < 0 {
+			d = -d
+		}
+		w := 1
+		if i < len(weights) {
+			w = weights[i]
+		}
+		dist += d * w
+	}
+	return dist
+}
+
 func applyRelatedManagedModelDefaults(dst *RegistryModel, related *RegistryModel) {
 	if dst == nil || related == nil {
 		return
 	}
-	if !dst.Attachment && related.Attachment {
+	if related.Attachment {
 		dst.Attachment = true
 		if dst.Modalities == nil && related.Modalities != nil {
 			dst.Modalities = deepCopyModel(related).Modalities

--- a/internal/model/registry_test.go
+++ b/internal/model/registry_test.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"testing"
+
+	"github.com/cnjack/jcode/internal/config"
 )
 
 // TestLookupModel tests model lookup from the generated registry.
@@ -81,5 +83,38 @@ func TestHasProvider(t *testing.T) {
 	// Test with non-existent provider
 	if r.HasProvider("definitely-not-a-real-provider-123") {
 		t.Error("Expected HasProvider to return false for non-existent provider")
+	}
+}
+
+func TestMergeConfigProvidersInheritsGrokFamilyImageSupport(t *testing.T) {
+	registry := NewModelRegistryWithConfig(&config.Config{
+		Providers: map[string]*config.ProviderConfig{
+			"xai": {
+				CustomModels: []config.CustomModelConfig{{
+					ID: "grok-4.6", Name: "Grok 4.6", ToolCall: true, Managed: true,
+				}},
+			},
+		},
+	})
+	_, got, ok := registry.LookupModel("xai", "grok-4.6")
+	if !ok || got == nil {
+		t.Fatal("managed grok-4.6 was not merged")
+	}
+	if !got.Attachment || !got.SupportsImageInput() {
+		t.Fatalf("grok-4.6 should inherit grok-4.5 image support: %#v", got)
+	}
+	if !got.Reasoning || got.Limit == nil || got.Limit.Context <= 0 {
+		t.Fatalf("grok-4.6 should inherit grok-4.5 reasoning/context: %#v", got)
+	}
+}
+
+func TestRelatedRegistryModelDoesNotMatchImagineIDs(t *testing.T) {
+	provider := NewModelRegistry().GetProvider("xai")
+	if RelatedRegistryModel(provider, "grok-imagine-image") != nil {
+		t.Fatal("image-generation ids must not inherit chat-family metadata")
+	}
+	related := RelatedRegistryModel(provider, "grok-4.6")
+	if related == nil || related.ID != "grok-4.5" {
+		t.Fatalf("related grok-4.6 = %#v", related)
 	}
 }

--- a/internal/model/registry_test.go
+++ b/internal/model/registry_test.go
@@ -118,3 +118,55 @@ func TestRelatedRegistryModelDoesNotMatchImagineIDs(t *testing.T) {
 		t.Fatalf("related grok-4.6 = %#v", related)
 	}
 }
+
+func TestRelatedRegistryModelIgnoresLiveCustomSiblings(t *testing.T) {
+	registry := NewModelRegistry()
+	provider := registry.GetProvider("xai")
+	if provider == nil {
+		t.Fatal("xai missing")
+	}
+	provider.Models["grok-4.7"] = &RegistryModel{
+		ID: "grok-4.7", Name: "Custom Grok 4.7", DefaultEnabled: true,
+	}
+	related := RelatedRegistryModel(provider, "grok-4.6")
+	if related == nil || related.ID != "grok-4.5" {
+		t.Fatalf("related grok-4.6 should stay on baked-in grok-4.5, got %#v", related)
+	}
+}
+
+func TestRelatedBakedInModelPicksClosestEnabledSibling(t *testing.T) {
+	models := map[string]*RegistryModel{
+		"grok-4.1": {ID: "grok-4.1", DefaultEnabled: true},
+		"grok-4.5": {ID: "grok-4.5", DefaultEnabled: true},
+		"grok-4.8": {ID: "grok-4.8", DefaultEnabled: false},
+	}
+	got := relatedBakedInModel(models, "grok-4.6")
+	if got == nil || got.ID != "grok-4.5" {
+		t.Fatalf("closest sibling for grok-4.6 = %#v", got)
+	}
+
+	models["grok-4.5-preview"] = &RegistryModel{ID: "grok-4.5-preview", DefaultEnabled: true}
+	got = relatedBakedInModel(models, "grok-4.5-new")
+	if got == nil || got.ID != "grok-4.5" {
+		t.Fatalf("tied versions should pick lexicographically first enabled id, got %#v", got)
+	}
+}
+
+func TestMergeConfigProvidersCopiesModalitiesWhenLiveAttachmentIsSet(t *testing.T) {
+	registry := NewModelRegistryWithConfig(&config.Config{
+		Providers: map[string]*config.ProviderConfig{
+			"xai": {
+				CustomModels: []config.CustomModelConfig{{
+					ID: "grok-4.6", Name: "Grok 4.6", ToolCall: true, Managed: true, Attachment: true,
+				}},
+			},
+		},
+	})
+	_, got, ok := registry.LookupModel("xai", "grok-4.6")
+	if !ok || got == nil {
+		t.Fatal("managed grok-4.6 was not merged")
+	}
+	if !got.Attachment || !got.SupportsImageInput() {
+		t.Fatalf("live attachment should still copy related modalities: %#v", got)
+	}
+}

--- a/internal/model/token_usage_test.go
+++ b/internal/model/token_usage_test.go
@@ -1,6 +1,10 @@
 package model
 
-import "testing"
+import (
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
 
 func TestTokenUsage_AddAndGetFull(t *testing.T) {
 	u := &TokenUsage{}
@@ -136,6 +140,9 @@ func TestTokenUsage_Reset(t *testing.T) {
 	u := &TokenUsage{}
 	u.Add(AddParams{Prompt: 100, Completion: 20, Total: 120, Cached: 80, Reasoning: 5})
 	u.AddByModel("m", 100, 20, 120)
+	if u.GetLastModel() != "m" {
+		t.Errorf("GetLastModel() = %q, want m", u.GetLastModel())
+	}
 	u.Reset()
 	if got := u.GetFull(); got.PromptTokens != 0 || got.CachedTokens != 0 || got.CallCount != 0 {
 		t.Errorf("after Reset GetFull() = %+v, want zero", got)
@@ -145,5 +152,35 @@ func TestTokenUsage_Reset(t *testing.T) {
 	}
 	if u.CacheObserved() {
 		t.Errorf("after Reset CacheObserved() should be false")
+	}
+	if u.GetLastModel() != "" {
+		t.Errorf("after Reset GetLastModel() = %q, want empty", u.GetLastModel())
+	}
+}
+
+func TestExtractUsage_ReadsAPITotalAndDetails(t *testing.T) {
+	got := extractUsage(openai.Usage{
+		PromptTokens:     19,
+		CompletionTokens: 10,
+		TotalTokens:      29,
+		PromptTokensDetails: &openai.PromptTokensDetails{
+			CachedTokens: 4,
+		},
+		CompletionTokensDetails: &openai.CompletionTokensDetails{
+			ReasoningTokens: 3,
+		},
+	})
+	if got.Prompt != 19 || got.Completion != 10 || got.Total != 29 || got.Cached != 4 || got.Reasoning != 3 {
+		t.Errorf("extractUsage() = %+v, want prompt/completion/total from API and cached/reasoning from details", got)
+	}
+	if !got.CacheDetailsPresent {
+		t.Error("CacheDetailsPresent = false, want true when prompt_tokens_details is present")
+	}
+}
+
+func TestExtractUsage_DerivesTotalWhenAPIOmitsIt(t *testing.T) {
+	got := extractUsage(openai.Usage{PromptTokens: 19, CompletionTokens: 10})
+	if got.Total != 29 {
+		t.Errorf("extractUsage() Total = %d, want 19+10 when API total_tokens is 0", got.Total)
 	}
 }

--- a/internal/providerauth/models.go
+++ b/internal/providerauth/models.go
@@ -204,12 +204,15 @@ func parseManagedModel(method Method, value any, fallbackID string) (Model, bool
 		name = id
 	}
 	vendor := firstModelString(object, "vendor", "owned_by", "ownedBy", "provider", "owner")
+	kind := kindForManagedModel(method, id)
 	return Model{
-		ID:       id,
-		Name:     name,
-		Vendor:   vendor,
-		Protocol: protocolForManagedModel(method, vendor),
-		Kind:     kindForManagedModel(method, id),
+		ID:         id,
+		Name:       name,
+		Vendor:     vendor,
+		Protocol:   protocolForManagedModel(method, vendor),
+		Kind:       kind,
+		Attachment: managedModelAttachment(kind, object),
+		Context:    firstModelInt(object, "context_length", "context_window", "max_context_length"),
 	}, true
 }
 
@@ -220,6 +223,78 @@ func firstModelString(object map[string]any, keys ...string) string {
 		}
 	}
 	return ""
+}
+
+func firstModelNumber(object map[string]any, keys ...string) (float64, bool) {
+	for _, key := range keys {
+		switch value := object[key].(type) {
+		case json.Number:
+			parsed, err := value.Float64()
+			if err == nil {
+				return parsed, true
+			}
+		case float64:
+			return value, true
+		case int:
+			return float64(value), true
+		case int64:
+			return float64(value), true
+		}
+	}
+	return 0, false
+}
+
+func firstModelInt(object map[string]any, keys ...string) int {
+	value, ok := firstModelNumber(object, keys...)
+	if !ok || value <= 0 {
+		return 0
+	}
+	return int(value)
+}
+
+func managedModelAttachment(kind ModelKind, object map[string]any) bool {
+	if kind != ModelKindChat || object == nil {
+		return false
+	}
+	if price, ok := firstModelNumber(object, "prompt_image_token_price"); ok && price > 0 {
+		return true
+	}
+	if flag, ok := object["supports_image"].(bool); ok && flag {
+		return true
+	}
+	if flag, ok := object["vision"].(bool); ok && flag {
+		return true
+	}
+	return managedModelListsImageInput(object)
+}
+
+func managedModelListsImageInput(object map[string]any) bool {
+	for _, key := range []string{"input_modalities", "modalities"} {
+		switch value := object[key].(type) {
+		case []any:
+			if anyStringEquals(value, "image") {
+				return true
+			}
+		case map[string]any:
+			if anyStringEquals(value["input"], "image") || anyStringEquals(value["input_modalities"], "image") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func anyStringEquals(value any, target string) bool {
+	list, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range list {
+		if text, ok := item.(string); ok && strings.EqualFold(strings.TrimSpace(text), target) {
+			return true
+		}
+	}
+	return false
 }
 
 func protocolForManagedModel(method Method, vendor string) Protocol {

--- a/internal/providerauth/models_test.go
+++ b/internal/providerauth/models_test.go
@@ -1,7 +1,9 @@
 package providerauth
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"reflect"
@@ -64,6 +66,52 @@ func TestManagedModelParsersCoverProviderShapes(t *testing.T) {
 				t.Fatalf("models = %#v, want %#v", got, test.want)
 			}
 		})
+	}
+}
+
+func TestParseManagedModelsReadsXAIImagePriceAndContext(t *testing.T) {
+	t.Parallel()
+	models := parseManagedModels(MethodXAIOAuth, map[string]any{"data": []any{
+		map[string]any{
+			"id": "grok-4.6", "owned_by": "xai",
+			"prompt_image_token_price": float64(20000),
+			"context_length":           float64(500000),
+		},
+		map[string]any{
+			"id":                       "grok-imagine-image-quality",
+			"prompt_image_token_price": float64(20000),
+		},
+	}})
+	if len(models) != 2 {
+		t.Fatalf("models = %#v", models)
+	}
+	if models[0].ID != "grok-4.6" || !models[0].Attachment || models[0].Context != 500000 ||
+		models[0].Kind != ModelKindChat {
+		t.Fatalf("chat model = %#v", models[0])
+	}
+	if models[1].ID != "grok-imagine-image-quality" || models[1].Attachment || models[1].Kind != ModelKindImage {
+		t.Fatalf("image model should not inherit chat vision: %#v", models[1])
+	}
+}
+
+func TestParseManagedModelsReadsXAIImagePriceFromJSONNumbers(t *testing.T) {
+	t.Parallel()
+	decoder := json.NewDecoder(bytes.NewReader([]byte(`{
+		"data":[{
+			"id":"grok-4.6",
+			"owned_by":"xai",
+			"prompt_image_token_price":20000,
+			"context_length":500000
+		}]
+	}`)))
+	decoder.UseNumber()
+	var payload any
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	models := parseManagedModels(MethodXAIOAuth, payload)
+	if len(models) != 1 || !models[0].Attachment || models[0].Context != 500000 {
+		t.Fatalf("json-number catalog = %#v", models)
 	}
 }
 

--- a/internal/providerauth/types.go
+++ b/internal/providerauth/types.go
@@ -95,6 +95,13 @@ type Model struct {
 	Vendor   string    `json:"vendor,omitempty"`
 	Protocol Protocol  `json:"protocol"`
 	Kind     ModelKind `json:"kind"`
+	// Attachment is true when the live catalog advertises image input, e.g.
+	// xAI's prompt_image_token_price. Chat UIs use this when the static
+	// registry has not yet listed the model.
+	Attachment bool `json:"attachment,omitempty"`
+	// Context is the provider-declared context window when the catalog
+	// includes one (xAI context_length). Zero means unknown.
+	Context int `json:"context,omitempty"`
 }
 
 // ModelKind separates inference catalogs that share /models but require

--- a/internal/telemetry/langfuse.go
+++ b/internal/telemetry/langfuse.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -279,34 +278,44 @@ func (mw *langfuseMiddleware) AfterModelRewriteState(ctx context.Context, state 
 	}
 
 	// Read per-call token usage from the context-local TokenUsage tracker.
+	// Langfuse bills and charts from usageDetails + model; cached/reasoning
+	// belong in the nested details objects, not string metadata.
 	var usage *langfuseacl.Usage
-	var metadata map[string]string
+	var modelName string
 	if tracker := internalmodel.TokenTrackerFromContext(ctx); tracker != nil {
-		if d := tracker.GetLastDetail(); d != nil && d.TotalTokens > 0 {
-			usage = &langfuseacl.Usage{
-				PromptTokens:     d.PromptTokens,
-				CompletionTokens: d.CompletionTokens,
-				TotalTokens:      d.TotalTokens,
-			}
-			metadata = map[string]string{
-				"cached_tokens":    fmt.Sprintf("%d", d.CachedTokens),
-				"reasoning_tokens": fmt.Sprintf("%d", d.ReasoningTokens),
-			}
-		}
+		usage = langfuseUsage(tracker.GetLastDetail())
+		modelName = tracker.GetLastModel()
 	}
 
 	_ = t.client.EndGeneration(&langfuseacl.GenerationEventBody{
 		BaseObservationEventBody: langfuseacl.BaseObservationEventBody{
-			BaseEventBody: langfuseacl.BaseEventBody{
-				ID:       genID,
-				MetaData: metadata,
-			},
+			BaseEventBody: langfuseacl.BaseEventBody{ID: genID},
 		},
 		OutMessage: outMsg,
 		EndTime:    time.Now(),
+		Model:      modelName,
 		Usage:      usage,
 	})
 	return ctx, state, nil
+}
+
+// langfuseUsage maps one API call onto Langfuse's OpenAI-shaped usageDetails,
+// including cached_tokens / reasoning_tokens so the host can cost them.
+func langfuseUsage(d *internalmodel.TokenUsageDetail) *langfuseacl.Usage {
+	if d == nil || (d.TotalTokens <= 0 && d.PromptTokens <= 0 && d.CompletionTokens <= 0) {
+		return nil
+	}
+	return &langfuseacl.Usage{
+		PromptTokens:     d.PromptTokens,
+		CompletionTokens: d.CompletionTokens,
+		TotalTokens:      d.TotalTokens,
+		PromptTokensDetails: &langfuseacl.PromptTokensDetails{
+			CachedTokens: d.CachedTokens,
+		},
+		CompletionTokensDetails: &langfuseacl.CompletionTokensDetails{
+			ReasoningTokens: d.ReasoningTokens,
+		},
+	}
 }
 
 // WrapInvokableToolCall wraps a tool's execution in a Langfuse span and exposes

--- a/internal/telemetry/langfuse_multimodal_test.go
+++ b/internal/telemetry/langfuse_multimodal_test.go
@@ -9,6 +9,8 @@ import (
 	langfuseacl "github.com/cloudwego/eino-ext/libs/acl/langfuse"
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/schema"
+
+	internalmodel "github.com/cnjack/jcode/internal/model"
 )
 
 type captureLangfuse struct {
@@ -45,6 +47,35 @@ func (c *captureLangfuse) CreateEvent(*langfuseacl.EventEventBody) (string, erro
 }
 
 func (c *captureLangfuse) Flush() {}
+
+func TestLangfuseUsageMapsCachedAndReasoning(t *testing.T) {
+	if got := langfuseUsage(nil); got != nil {
+		t.Fatalf("langfuseUsage(nil) = %#v, want nil", got)
+	}
+	if got := langfuseUsage(&internalmodel.TokenUsageDetail{}); got != nil {
+		t.Fatalf("langfuseUsage(zero) = %#v, want nil", got)
+	}
+
+	got := langfuseUsage(&internalmodel.TokenUsageDetail{
+		PromptTokens:     19,
+		CompletionTokens: 10,
+		TotalTokens:      29,
+		CachedTokens:     4,
+		ReasoningTokens:  3,
+	})
+	if got == nil {
+		t.Fatal("langfuseUsage returned nil")
+	}
+	if got.PromptTokens != 19 || got.CompletionTokens != 10 || got.TotalTokens != 29 {
+		t.Fatalf("usage totals = %+v", got)
+	}
+	if got.PromptTokensDetails == nil || got.PromptTokensDetails.CachedTokens != 4 {
+		t.Fatalf("cached details = %#v", got.PromptTokensDetails)
+	}
+	if got.CompletionTokensDetails == nil || got.CompletionTokensDetails.ReasoningTokens != 3 {
+		t.Fatalf("reasoning details = %#v", got.CompletionTokensDetails)
+	}
+}
 
 func TestWithNewTraceCapturesLatestPlainUserInput(t *testing.T) {
 	client := &captureLangfuse{}

--- a/internal/web/models_test.go
+++ b/internal/web/models_test.go
@@ -188,6 +188,71 @@ func TestEnableManagedModelPersistsRuntimeMetadata(t *testing.T) {
 	}
 }
 
+func TestManagedModelConfigFromLiveUsesXAIImagePrice(t *testing.T) {
+	got := managedModelConfigFromLive(model.NewModelRegistry(), "xai", providerauth.Model{
+		ID: "grok-4.6", Name: "grok-4.6", Vendor: "xai",
+		Protocol: providerauth.ProtocolResponses, Kind: providerauth.ModelKindChat,
+		Attachment: true, Context: 500000,
+	})
+	if !got.Attachment || got.Context != 500000 || !got.Reasoning || !got.Managed {
+		t.Fatalf("live grok-4.6 metadata = %#v", got)
+	}
+}
+
+func TestListModelsShowsImageSupportForPersistedGrok46(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg := &config.Config{
+		Model: "xai/grok-4.6",
+		Providers: map[string]*config.ProviderConfig{
+			"xai": {
+				Auth: &config.ProviderAuthBinding{Method: string(providerauth.MethodXAIOAuth), AccountID: "account-1"},
+				CustomModels: []config.CustomModelConfig{{
+					ID: "grok-4.6", Name: "Grok 4.6", ToolCall: true, Managed: true,
+				}},
+			},
+		},
+	}
+	s := &Server{cfg: cfg, registry: model.NewModelRegistryWithConfig(cfg)}
+	rec := httptest.NewRecorder()
+	s.handleListModels(rec, httptest.NewRequest(http.MethodGet, "/api/models", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Providers []struct {
+			ID     string `json:"id"`
+			Models []struct {
+				ID              string   `json:"id"`
+				ImageSupport    bool     `json:"image_support"`
+				InputModalities []string `json:"input_modalities"`
+			} `json:"models"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	for _, provider := range response.Providers {
+		if provider.ID != "xai" {
+			continue
+		}
+		for _, item := range provider.Models {
+			if item.ID != "grok-4.6" {
+				continue
+			}
+			if !item.ImageSupport {
+				t.Fatalf("grok-4.6 image_support = false: %#v", item)
+			}
+			for _, modality := range item.InputModalities {
+				if modality == "image" {
+					return
+				}
+			}
+			t.Fatalf("grok-4.6 input_modalities missing image: %#v", item)
+		}
+	}
+	t.Fatal("xai/grok-4.6 missing from /api/models")
+}
+
 func TestEnsureManagedModelRefreshesProviderRouting(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	err := config.SaveConfig(&config.Config{

--- a/internal/web/models_test.go
+++ b/internal/web/models_test.go
@@ -197,6 +197,19 @@ func TestManagedModelConfigFromLiveUsesXAIImagePrice(t *testing.T) {
 	if !got.Attachment || got.Context != 500000 || !got.Reasoning || !got.Managed {
 		t.Fatalf("live grok-4.6 metadata = %#v", got)
 	}
+	if got.Name != "grok-4.6" {
+		t.Fatalf("related sibling leaked display name: %#v", got)
+	}
+}
+
+func TestManagedModelConfigFromLiveKeepsExactRegistryName(t *testing.T) {
+	got := managedModelConfigFromLive(model.NewModelRegistry(), "xai", providerauth.Model{
+		ID: "grok-4.5", Name: "grok-4.5", Vendor: "xai",
+		Protocol: providerauth.ProtocolResponses, Kind: providerauth.ModelKindChat,
+	})
+	if got.Name != "Grok 4.5" {
+		t.Fatalf("exact grok-4.5 should keep registry name, got %#v", got)
+	}
 }
 
 func TestListModelsShowsImageSupportForPersistedGrok46(t *testing.T) {

--- a/internal/web/providers.go
+++ b/internal/web/providers.go
@@ -508,6 +508,7 @@ func managedModelConfigFromLive(
 	result := config.CustomModelConfig{
 		ID: live.ID, Name: live.Name, ToolCall: true, Managed: true,
 		Protocol: string(live.Protocol), Vendor: live.Vendor,
+		Attachment: live.Attachment, Context: live.Context,
 	}
 	if result.Name == "" {
 		result.Name = live.ID
@@ -520,9 +521,13 @@ func managedModelConfigFromLive(
 		result.Name = metadata.Name
 	}
 	result.ToolCall = metadata.ToolCall
-	result.Reasoning = metadata.Reasoning
-	result.Attachment = metadata.Attachment
-	if metadata.Limit != nil {
+	if metadata.Reasoning {
+		result.Reasoning = true
+	}
+	if metadata.Attachment {
+		result.Attachment = true
+	}
+	if result.Context == 0 && metadata.Limit != nil {
 		result.Context = metadata.Limit.Context
 	}
 	for _, option := range metadata.ReasoningOptions {
@@ -543,6 +548,7 @@ func findManagedModelMetadata(
 	if registry == nil {
 		return nil
 	}
+	var related *model.RegistryModel
 	for _, candidate := range []string{providerID, strings.ToLower(strings.TrimSpace(vendor))} {
 		if candidate == "" {
 			continue
@@ -551,6 +557,9 @@ func findManagedModelMetadata(
 			if metadata := provider.Models[modelID]; metadata != nil {
 				return metadata
 			}
+			if related == nil {
+				related = model.RelatedRegistryModel(provider, modelID)
+			}
 		}
 	}
 	for _, provider := range registry.ListProviders() {
@@ -558,7 +567,7 @@ func findManagedModelMetadata(
 			return metadata
 		}
 	}
-	return nil
+	return related
 }
 
 // maskSecret hides a secret for display: first 4 and last 4 chars for longer

--- a/internal/web/providers.go
+++ b/internal/web/providers.go
@@ -517,10 +517,16 @@ func managedModelConfigFromLive(
 	if metadata == nil {
 		return result
 	}
-	if result.Name == live.ID && metadata.Name != "" {
-		result.Name = metadata.Name
+	// Exact registry rows may supply a nicer display name. Related siblings
+	// only donate capabilities — grok-4.6 must not be labeled "Grok 4.5".
+	if metadata.ID == live.ID {
+		if result.Name == live.ID && metadata.Name != "" {
+			result.Name = metadata.Name
+		}
+		result.ToolCall = metadata.ToolCall
+	} else if metadata.ToolCall {
+		result.ToolCall = true
 	}
-	result.ToolCall = metadata.ToolCall
 	if metadata.Reasoning {
 		result.Reasoning = true
 	}


### PR DESCRIPTION
## Summary

- Record Langfuse generation `usageDetails` with cached/reasoning tokens and the last model name, instead of stuffing those fields into string metadata.
- Parse xAI live `/models` `prompt_image_token_price` / `context_length` so OAuth-managed `grok-4.6` advertises image input.
- Persist that live metadata on managed models, and inherit omitted capabilities from the closest baked-in sibling (`grok-4.6` from `grok-4.5`) so already-saved rows do not stay text-only.

## Related Issues / Tickets

- Follow-up to local Grok OAuth usage/image investigation. Cache stats were already reading `cached_tokens`; this PR does not change that path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Performance improvement
- [x] Test update

## Changes Made

1. `TokenUsage` now keeps `GetLastModel()` so Langfuse `EndGeneration` can set `Model`.
2. `langfuseUsage()` maps prompt/completion/total plus nested `prompt_tokens_details.cached_tokens` and `completion_tokens_details.reasoning_tokens`.
3. Live managed-model parse copies image-price / context / optional vision flags; image-generation IDs stay `Kind=image` and do not get chat attachment.
4. `managedModelConfigFromLive()` persists Attachment/Context and ORs in related static metadata.
5. `RelatedRegistryModel()` inherits omitted Attachment/Reasoning/Context from the versioned family sibling.

## Testing

- `go test ./internal/providerauth ./internal/model ./internal/web ./internal/telemetry`
- New coverage: Langfuse cached/reasoning mapping, xAI JSON-number catalog parse, grok-4.6 family inheritance, `/api/models` image_support for persisted grok-4.6.
- Live probe (not in CI): xAI `/models` grok-4.6 reports `prompt_image_token_price: 20000` and `context_length: 500000`.

## Screenshots / Recordings

N/A

## Checklist

- [x] I have read the contributing guidelines.
- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests as needed.
- [ ] I have updated relevant documentation.
- [x] All new and existing tests pass.

## Additional Notes

- Restart / refresh the model list after this lands so an already-persisted `grok-4.6` row picks up image support.
- `grok-imagine-image*` IDs are excluded from chat-family inheritance.
- Unrelated web control-plane availability work remains uncommitted on this branch and is not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model listings now provide more accurate context limits, image-input support, reasoning capabilities, and model types.
  * Custom models can inherit missing capability details from related models in the same version family.
  * Live model information is preserved when available, improving configuration accuracy.
* **Improvements**
  * Usage telemetry now records the active model and reports cached and reasoning token details more accurately.
  * Model and token usage handling is more reliable when provider data is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->