### PR TITLE
feat(web): surface connection and model retry status

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -173,7 +173,7 @@ func newAgent(
 		MaxIterations: resolvedOptions.maxIterations,
 		Handlers:      enhanced,
 		ModelRetryConfig: &adk.ModelRetryConfig{
-			MaxRetries:  5,
+			MaxRetries:  internalmodel.DefaultMaxRetries,
 			IsRetryAble: internalmodel.IsRetryable,
 			BackoffFunc: internalmodel.SmartBackoff,
 		},

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -174,8 +174,8 @@ func newAgent(
 		Handlers:      enhanced,
 		ModelRetryConfig: &adk.ModelRetryConfig{
 			MaxRetries:  internalmodel.DefaultMaxRetries,
-			IsRetryAble: internalmodel.IsRetryable,
-			BackoffFunc: internalmodel.SmartBackoff,
+			ShouldRetry: internalmodel.ShouldRetryModelCall,
+			BackoffFunc: internalmodel.SmartBackoffWithMaxRetries(internalmodel.DefaultMaxRetries),
 		},
 	})
 }

--- a/internal/cloud/events.go
+++ b/internal/cloud/events.go
@@ -59,6 +59,7 @@ var eventDurability = map[string]bool{
 // can include host/error diagnostics that Cloud neither needs nor should store.
 var localOnlyEvents = map[string]bool{
 	"remote_connection_status": true,
+	"model_retry_status":       true,
 }
 
 // isDurableEvent reports whether a WS event type is uploaded as a durable

--- a/internal/cloud/events_unit_test.go
+++ b/internal/cloud/events_unit_test.go
@@ -39,9 +39,11 @@ func TestEventDurabilityClassification(t *testing.T) {
 	}
 }
 
-func TestRemoteConnectionStatusIsLocalOnly(t *testing.T) {
-	if !localOnlyEvents["remote_connection_status"] {
-		t.Fatal("remote_connection_status must be dropped before Cloud event routing")
+func TestOperationalStatusEventsAreLocalOnly(t *testing.T) {
+	for _, event := range []string{"remote_connection_status", "model_retry_status"} {
+		if !localOnlyEvents[event] {
+			t.Fatalf("%s must be dropped before Cloud event routing", event)
+		}
 	}
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -147,6 +147,36 @@ func EmitToolProgress(h AgentEventHandler, event ToolProgressEvent) {
 	}
 }
 
+// ModelRetryStatus is the task-local lifecycle of an observable model retry.
+type ModelRetryStatus string
+
+const (
+	ModelRetryWaiting ModelRetryStatus = "waiting"
+	ModelRetryReady   ModelRetryStatus = "ready"
+)
+
+// ModelRetryEvent reports task-local model retry progress without changing the
+// core AgentEventHandler contract used by custom transports.
+type ModelRetryEvent struct {
+	Status      ModelRetryStatus
+	Attempt     int
+	MaxAttempts int
+	RetryIn     time.Duration
+}
+
+// ModelRetryHandler is an optional transport extension for model retry status.
+type ModelRetryHandler interface {
+	OnModelRetry(ModelRetryEvent)
+}
+
+// EmitModelRetry reports a model retry to handlers that support the optional
+// status extension.
+func EmitModelRetry(h AgentEventHandler, event ModelRetryEvent) {
+	if retry, ok := h.(ModelRetryHandler); ok {
+		retry.OnModelRetry(event)
+	}
+}
+
 // TokenUsage carries token usage info to the UI surfaces.
 //
 // TotalTokens is the LAST call's total — i.e. current context-window

--- a/internal/handler/notifying.go
+++ b/internal/handler/notifying.go
@@ -121,6 +121,12 @@ func (h *NotifyingHandler) OnToolProgress(ev ToolProgressEvent) {
 	}
 }
 
+func (h *NotifyingHandler) OnModelRetry(ev ModelRetryEvent) {
+	if retry, ok := h.inner.(ModelRetryHandler); ok {
+		retry.OnModelRetry(ev)
+	}
+}
+
 func (h *NotifyingHandler) OnTodoUpdate() {
 	h.inner.OnTodoUpdate()
 }

--- a/internal/handler/web.go
+++ b/internal/handler/web.go
@@ -27,6 +27,13 @@ type WebTextData struct {
 	Text string `json:"text"`
 }
 
+type WebModelRetryData struct {
+	Status      ModelRetryStatus `json:"status"`
+	Attempt     int              `json:"attempt"`
+	MaxAttempts int              `json:"max_attempts"`
+	RetryInMS   int64            `json:"retry_in_ms,omitempty"`
+}
+
 // WebToolCallData carries tool invocation info. The batch fields group tool
 // calls issued by the same assistant message (batch_size > 1 → concurrent
 // batch); started_at is unix milliseconds.
@@ -679,6 +686,13 @@ func (h *WebHandler) OnToolProgress(ev ToolProgressEvent) {
 		Name: ev.Name, ToolCallID: ev.ToolCallID, Surface: ev.Surface,
 		Phase: ev.Phase, OperationID: ev.OperationID, ErrorCode: ev.ErrorCode,
 		Provider: ev.Provider, Model: ev.Model, Artifacts: ev.Artifacts,
+	})
+}
+
+func (h *WebHandler) OnModelRetry(ev ModelRetryEvent) {
+	h.emit("model_retry_status", WebModelRetryData{
+		Status: ev.Status, Attempt: ev.Attempt, MaxAttempts: ev.MaxAttempts,
+		RetryInMS: ev.RetryIn.Milliseconds(),
 	})
 }
 

--- a/internal/handler/web_test.go
+++ b/internal/handler/web_test.go
@@ -101,6 +101,30 @@ func TestWebHandler_AgentDoneCarriesRemoteErrorCode(t *testing.T) {
 	}
 }
 
+func TestWebHandlerModelRetryCarriesBackoffStatus(t *testing.T) {
+	h := NewWebHandler()
+	h.OnModelRetry(ModelRetryEvent{
+		Status: ModelRetryWaiting, Attempt: 2, MaxAttempts: 5, RetryIn: 1500 * time.Millisecond,
+	})
+
+	select {
+	case event := <-h.Events():
+		if event.Event != "model_retry_status" {
+			t.Fatalf("event = %q", event.Event)
+		}
+		data, ok := event.Data.(WebModelRetryData)
+		if !ok {
+			t.Fatalf("data = %T, want WebModelRetryData", event.Data)
+		}
+		if data.Status != ModelRetryWaiting || data.Attempt != 2 ||
+			data.MaxAttempts != 5 || data.RetryInMS != 1500 {
+			t.Fatalf("model retry data = %+v", data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for model_retry_status")
+	}
+}
+
 func TestWebHandlerBillableApprovalRequiresOpaqueOneTimeOption(t *testing.T) {
 	h := NewWebHandler()
 	issuedOptions := []ApprovalOption{

--- a/internal/model/retry.go
+++ b/internal/model/retry.go
@@ -9,11 +9,16 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cnjack/jcode/internal/config"
 	openai "github.com/sashabaranov/go-openai"
 )
+
+// DefaultMaxRetries is shared by the agent retry configuration and retry-status
+// observers so every transport reports the same bounded attempt count.
+const DefaultMaxRetries = 5
 
 // ---------------------------------------------------------------------------
 // Error Classification
@@ -292,10 +297,13 @@ const (
 // Auth errors are NOT retryable — they need user action.
 // Quota errors are NOT retryable — a spent balance does not refill on a backoff
 // timer, so retrying only delays telling the user the one thing they can act on.
-func IsRetryable(_ context.Context, err error) bool {
+func IsRetryable(ctx context.Context, err error) bool {
 	cat := ClassifyError(err)
 	switch cat {
 	case ErrCategoryTransient, ErrCategoryRateLimit:
+		if observer := RetryObserverFromContext(ctx); observer != nil {
+			observer.record(err)
+		}
 		return true
 	default:
 		return false
@@ -311,21 +319,32 @@ func IsRetryable(_ context.Context, err error) bool {
 //  2. Otherwise fall back to exponential backoff: 500ms × 2^(attempt-1),
 //     capped at 32s, plus 0-25% random jitter.
 func SmartBackoff(ctx context.Context, attempt int) time.Duration {
+	observer := RetryObserverFromContext(ctx)
 	// Try to extract Retry-After from the most recent error via context.
 	// Eino does not pass the error to BackoffFunc, so we rely on the
-	// context wrapper set by our middleware (see retryErrorKey below).
-	if retryErr := retryErrorFromCtx(ctx); retryErr != nil {
+	// context observer populated by IsRetryable. WithRetryError remains supported
+	// for direct callers and older integrations.
+	retryErr := retryErrorFromCtx(ctx)
+	if retryErr == nil && observer != nil {
+		retryErr = observer.lastError()
+	}
+	delay := time.Duration(0)
+	if retryErr != nil {
 		if serverDelay := ParseRetryAfter(retryErr); serverDelay > 0 {
-			delay := serverDelay
+			delay = serverDelay
 			if delay > maxRetryAfter {
 				delay = maxRetryAfter
 			}
 			config.Logger().Printf("[retry] attempt %d: using server Retry-After %v (capped from %v)", attempt, delay, serverDelay)
-			return delay
 		}
 	}
-
-	return exponentialBackoff(attempt)
+	if delay == 0 {
+		delay = exponentialBackoff(attempt)
+	}
+	if observer != nil && retryErr != nil && ClassifyError(retryErr) == ErrCategoryRateLimit {
+		observer.publish(RetryBackoffEvent{Attempt: attempt, Delay: delay})
+	}
+	return delay
 }
 
 // exponentialBackoff calculates delay: baseDelay × 2^(attempt-1) + jitter,
@@ -348,6 +367,104 @@ func exponentialBackoff(attempt int) time.Duration {
 type retryErrorKeyType struct{}
 
 var retryErrorKey retryErrorKeyType
+
+type retryObserverKeyType struct{}
+
+var retryObserverKey retryObserverKeyType
+
+// RetryBackoffEvent is emitted immediately before Eino waits and retries a
+// rate-limited model call. Attempt is 1-based and Delay is the actual backoff
+// selected after applying Retry-After and caps.
+type RetryBackoffEvent struct {
+	Attempt int
+	Delay   time.Duration
+}
+
+// RetryObserver keeps retry observability outside the retry decision itself.
+// It is safe for the model callback and runner event loop to use concurrently.
+type RetryObserver struct {
+	mu      sync.Mutex
+	lastErr error
+	active  bool
+	notify  func(RetryBackoffEvent)
+}
+
+// NewRetryObserver creates a retry observer with an optional event callback.
+func NewRetryObserver(notify func(RetryBackoffEvent)) *RetryObserver {
+	return &RetryObserver{notify: notify}
+}
+
+// WithRetryObserver attaches retry observability to a model request context.
+func WithRetryObserver(ctx context.Context, observer *RetryObserver) context.Context {
+	if observer == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, retryObserverKey, observer)
+}
+
+// RetryObserverFromContext returns the observer attached to ctx, if any.
+func RetryObserverFromContext(ctx context.Context) *RetryObserver {
+	if ctx == nil {
+		return nil
+	}
+	observer, _ := ctx.Value(retryObserverKey).(*RetryObserver)
+	return observer
+}
+
+func (o *RetryObserver) record(err error) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	o.lastErr = err
+	o.mu.Unlock()
+}
+
+func (o *RetryObserver) lastError() error {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.lastErr
+}
+
+func (o *RetryObserver) publish(event RetryBackoffEvent) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	o.active = true
+	notify := o.notify
+	o.mu.Unlock()
+	if notify != nil {
+		notify(event)
+	}
+}
+
+// Resolve clears the active marker after the first successful model output.
+// It returns true exactly once per retry cycle so callers can emit a recovery
+// transition without duplicate events.
+func (o *RetryObserver) Resolve() bool {
+	return o.clearActive()
+}
+
+// Clear drops an in-flight marker when the turn stops or exhausts retries.
+func (o *RetryObserver) Clear() bool {
+	return o.clearActive()
+}
+
+func (o *RetryObserver) clearActive() bool {
+	if o == nil {
+		return false
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	wasActive := o.active
+	o.active = false
+	o.lastErr = nil
+	return wasActive
+}
 
 // WithRetryError stores an error in context for BackoffFunc to inspect.
 func WithRetryError(ctx context.Context, err error) context.Context {

--- a/internal/model/retry.go
+++ b/internal/model/retry.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloudwego/eino/adk"
 	"github.com/cnjack/jcode/internal/config"
 	openai "github.com/sashabaranov/go-openai"
 )
@@ -290,8 +291,8 @@ const (
 	jitterFraction = 0.25            // 0-25% random jitter
 )
 
-// IsRetryable returns true if the error should be retried. It is designed to
-// be used as ModelRetryConfig.IsRetryAble in the Eino framework.
+// IsRetryable returns true if the error is safe to retry. The shared Eino
+// decision callback uses it after inspecting whether a stream emitted output.
 //
 // Context overflow errors are NOT retryable — they need compaction.
 // Auth errors are NOT retryable — they need user action.
@@ -310,6 +311,21 @@ func IsRetryable(ctx context.Context, err error) bool {
 	}
 }
 
+// ShouldRetryModelCall applies the shared retry classification with one
+// important streaming guard: once a model has emitted any output, accepting a
+// framework retry would append a second attempt after an already-visible prefix
+// on append-only transports. Preserve that partial attempt and surface its
+// error instead; retries remain enabled for failures that happen before output.
+func ShouldRetryModelCall(ctx context.Context, retryCtx *adk.RetryContext) *adk.RetryDecision {
+	if retryCtx == nil || !IsRetryable(ctx, retryCtx.Err) {
+		return &adk.RetryDecision{}
+	}
+	if retryCtx.OutputMessage != nil {
+		return &adk.RetryDecision{}
+	}
+	return &adk.RetryDecision{Retry: true}
+}
+
 // SmartBackoff returns a delay for the given retry attempt, respecting
 // server-sent Retry-After hints when available. It is designed to be used
 // as ModelRetryConfig.BackoffFunc in the Eino framework.
@@ -319,6 +335,19 @@ func IsRetryable(ctx context.Context, err error) bool {
 //  2. Otherwise fall back to exponential backoff: 500ms × 2^(attempt-1),
 //     capped at 32s, plus 0-25% random jitter.
 func SmartBackoff(ctx context.Context, attempt int) time.Duration {
+	return smartBackoff(ctx, attempt, DefaultMaxRetries)
+}
+
+// SmartBackoffWithMaxRetries binds the configured retry ceiling to emitted
+// status events. Subagents use a lower ceiling than the top-level agent, so the
+// UI denominator must travel with the callback that actually performs backoff.
+func SmartBackoffWithMaxRetries(maxRetries int) func(context.Context, int) time.Duration {
+	return func(ctx context.Context, attempt int) time.Duration {
+		return smartBackoff(ctx, attempt, maxRetries)
+	}
+}
+
+func smartBackoff(ctx context.Context, attempt, maxRetries int) time.Duration {
 	observer := RetryObserverFromContext(ctx)
 	// Try to extract Retry-After from the most recent error via context.
 	// Eino does not pass the error to BackoffFunc, so we rely on the
@@ -342,7 +371,7 @@ func SmartBackoff(ctx context.Context, attempt int) time.Duration {
 		delay = exponentialBackoff(attempt)
 	}
 	if observer != nil && retryErr != nil && ClassifyError(retryErr) == ErrCategoryRateLimit {
-		observer.publish(RetryBackoffEvent{Attempt: attempt, Delay: delay})
+		observer.publish(RetryBackoffEvent{Attempt: attempt, MaxAttempts: maxRetries, Delay: delay})
 	}
 	return delay
 }
@@ -376,8 +405,9 @@ var retryObserverKey retryObserverKeyType
 // rate-limited model call. Attempt is 1-based and Delay is the actual backoff
 // selected after applying Retry-After and caps.
 type RetryBackoffEvent struct {
-	Attempt int
-	Delay   time.Duration
+	Attempt     int
+	MaxAttempts int
+	Delay       time.Duration
 }
 
 // RetryObserver keeps retry observability outside the retry decision itself.
@@ -386,6 +416,7 @@ type RetryObserver struct {
 	mu      sync.Mutex
 	lastErr error
 	active  bool
+	max     int
 	notify  func(RetryBackoffEvent)
 }
 
@@ -435,6 +466,7 @@ func (o *RetryObserver) publish(event RetryBackoffEvent) {
 	}
 	o.mu.Lock()
 	o.active = true
+	o.max = event.MaxAttempts
 	notify := o.notify
 	o.mu.Unlock()
 	if notify != nil {
@@ -443,10 +475,19 @@ func (o *RetryObserver) publish(event RetryBackoffEvent) {
 }
 
 // Resolve clears the active marker after the first successful model output.
-// It returns true exactly once per retry cycle so callers can emit a recovery
-// transition without duplicate events.
-func (o *RetryObserver) Resolve() bool {
-	return o.clearActive()
+// It returns the retry ceiling exactly once per cycle so callers can emit a
+// correctly bounded recovery transition without duplicate events.
+func (o *RetryObserver) Resolve() (resolved bool, maxAttempts int) {
+	if o == nil {
+		return false, 0
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if !o.active {
+		return false, 0
+	}
+	o.active = false
+	return true, o.max
 }
 
 // Clear drops an in-flight marker when the turn stops or exhausts retries.

--- a/internal/model/retry_test.go
+++ b/internal/model/retry_test.go
@@ -315,6 +315,22 @@ func TestSmartBackoff_WithoutRetryError(t *testing.T) {
 	}
 }
 
+func TestSmartBackoffWithMaxRetriesPublishesConfiguredBound(t *testing.T) {
+	var got RetryBackoffEvent
+	observer := NewRetryObserver(func(event RetryBackoffEvent) { got = event })
+	ctx := WithRetryObserver(context.Background(), observer)
+	err := &openai.APIError{HTTPStatusCode: 429, Message: "rate limited"}
+	if !IsRetryable(ctx, err) {
+		t.Fatal("429 error was not classified as retryable")
+	}
+
+	_ = SmartBackoffWithMaxRetries(3)(ctx, 1)
+
+	if got.Attempt != 1 || got.MaxAttempts != 3 || got.Delay <= 0 {
+		t.Fatalf("retry event = %+v, want attempt 1 with max 3 and positive delay", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Category String
 // ---------------------------------------------------------------------------

--- a/internal/review/investigate.go
+++ b/internal/review/investigate.go
@@ -65,8 +65,8 @@ func (e *Engine) reviewWithTools(ctx context.Context, req Request, cm einomodel.
 		MaxIterations: reviewMaxIterations,
 		ModelRetryConfig: &adk.ModelRetryConfig{
 			MaxRetries:  3,
-			IsRetryAble: internalmodel.IsRetryable,
-			BackoffFunc: internalmodel.SmartBackoff,
+			ShouldRetry: internalmodel.ShouldRetryModelCall,
+			BackoffFunc: internalmodel.SmartBackoffWithMaxRetries(3),
 		},
 	})
 	if err != nil {

--- a/internal/runner/model_retry_test.go
+++ b/internal/runner/model_retry_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -49,7 +50,14 @@ type modelRetryCaptureHandler struct {
 	stubHandler
 	mu      sync.Mutex
 	events  []internalhandler.ModelRetryEvent
+	text    strings.Builder
 	doneErr error
+}
+
+func (h *modelRetryCaptureHandler) OnAgentText(text string) {
+	h.mu.Lock()
+	h.text.WriteString(text)
+	h.mu.Unlock()
 }
 
 func (h *modelRetryCaptureHandler) OnModelRetry(event internalhandler.ModelRetryEvent) {
@@ -73,8 +81,8 @@ func TestRunReportsRateLimitBackoffAndRecovery(t *testing.T) {
 		Model: model, MaxIterations: 2,
 		ModelRetryConfig: &adk.ModelRetryConfig{
 			MaxRetries:  internalmodel.DefaultMaxRetries,
-			IsRetryAble: internalmodel.IsRetryable,
-			BackoffFunc: internalmodel.SmartBackoff,
+			ShouldRetry: internalmodel.ShouldRetryModelCall,
+			BackoffFunc: internalmodel.SmartBackoffWithMaxRetries(internalmodel.DefaultMaxRetries),
 		},
 	})
 	if err != nil {
@@ -106,7 +114,76 @@ func TestRunReportsRateLimitBackoffAndRecovery(t *testing.T) {
 		waiting.MaxAttempts != internalmodel.DefaultMaxRetries || waiting.RetryIn <= 0 {
 		t.Fatalf("waiting event = %+v", waiting)
 	}
-	if ready.Status != internalhandler.ModelRetryReady {
+	if ready.Status != internalhandler.ModelRetryReady || ready.MaxAttempts != internalmodel.DefaultMaxRetries {
 		t.Fatalf("ready event = %+v", ready)
+	}
+}
+
+type partialRateLimitModel struct {
+	calls atomic.Int32
+}
+
+func (m *partialRateLimitModel) WithTools([]*schema.ToolInfo) (einomodel.ToolCallingChatModel, error) {
+	return m, nil
+}
+
+func (*partialRateLimitModel) Generate(
+	context.Context,
+	[]*schema.Message,
+	...einomodel.Option,
+) (*schema.Message, error) {
+	return nil, errors.New("Generate is not used: streaming is enabled")
+}
+
+func (m *partialRateLimitModel) Stream(
+	context.Context,
+	[]*schema.Message,
+	...einomodel.Option,
+) (*schema.StreamReader[*schema.Message], error) {
+	if m.calls.Add(1) > 1 {
+		return schema.StreamReaderFromArray([]*schema.Message{{
+			Role: schema.Assistant, Content: "prefix recovered",
+		}}), nil
+	}
+	reader, writer := schema.Pipe[*schema.Message](2)
+	writer.Send(&schema.Message{Role: schema.Assistant, Content: "prefix"}, nil)
+	writer.Send(nil, &openai.APIError{HTTPStatusCode: 429, Message: "rate limited"})
+	writer.Close()
+	return reader, nil
+}
+
+func TestRunDoesNotRetryAfterPartialModelOutput(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	model := &partialRateLimitModel{}
+	ag, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name: "partial-retry-test", Description: "partial-retry-test", Instruction: "test",
+		Model: model, MaxIterations: 2,
+		ModelRetryConfig: &adk.ModelRetryConfig{
+			MaxRetries:  internalmodel.DefaultMaxRetries,
+			ShouldRetry: internalmodel.ShouldRetryModelCall,
+			BackoffFunc: internalmodel.SmartBackoffWithMaxRetries(internalmodel.DefaultMaxRetries),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	h := &modelRetryCaptureHandler{}
+
+	result := Run(ctx, ag, []adk.Message{schema.UserMessage("hello")}, h, nil, nil, nil, nil, nil)
+
+	if result.Err == nil {
+		t.Fatal("Run error = nil, want partial stream rate-limit error")
+	}
+	if got := model.calls.Load(); got != 1 {
+		t.Fatalf("model calls = %d, want 1 after partial output", got)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if got := h.text.String(); got != "prefix" {
+		t.Fatalf("streamed text = %q, want one partial prefix", got)
+	}
+	if len(h.events) != 0 {
+		t.Fatalf("retry events = %+v, want none for rejected mid-stream retry", h.events)
 	}
 }

--- a/internal/runner/model_retry_test.go
+++ b/internal/runner/model_retry_test.go
@@ -1,0 +1,112 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudwego/eino/adk"
+	einomodel "github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+	openai "github.com/sashabaranov/go-openai"
+
+	internalhandler "github.com/cnjack/jcode/internal/handler"
+	internalmodel "github.com/cnjack/jcode/internal/model"
+)
+
+type rateLimitThenSuccessModel struct {
+	calls atomic.Int32
+}
+
+func (m *rateLimitThenSuccessModel) WithTools([]*schema.ToolInfo) (einomodel.ToolCallingChatModel, error) {
+	return m, nil
+}
+
+func (*rateLimitThenSuccessModel) Generate(
+	context.Context,
+	[]*schema.Message,
+	...einomodel.Option,
+) (*schema.Message, error) {
+	return nil, errors.New("Generate is not used: streaming is enabled")
+}
+
+func (m *rateLimitThenSuccessModel) Stream(
+	context.Context,
+	[]*schema.Message,
+	...einomodel.Option,
+) (*schema.StreamReader[*schema.Message], error) {
+	if m.calls.Add(1) == 1 {
+		return nil, &openai.APIError{HTTPStatusCode: 429, Message: "rate limited; retry-after-ms: 1"}
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{{
+		Role: schema.Assistant, Content: "recovered",
+	}}), nil
+}
+
+type modelRetryCaptureHandler struct {
+	stubHandler
+	mu      sync.Mutex
+	events  []internalhandler.ModelRetryEvent
+	doneErr error
+}
+
+func (h *modelRetryCaptureHandler) OnModelRetry(event internalhandler.ModelRetryEvent) {
+	h.mu.Lock()
+	h.events = append(h.events, event)
+	h.mu.Unlock()
+}
+
+func (h *modelRetryCaptureHandler) OnAgentDone(err error) {
+	h.mu.Lock()
+	h.doneErr = err
+	h.mu.Unlock()
+}
+
+func TestRunReportsRateLimitBackoffAndRecovery(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	model := &rateLimitThenSuccessModel{}
+	ag, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name: "model-retry-test", Description: "model-retry-test", Instruction: "test",
+		Model: model, MaxIterations: 2,
+		ModelRetryConfig: &adk.ModelRetryConfig{
+			MaxRetries:  internalmodel.DefaultMaxRetries,
+			IsRetryAble: internalmodel.IsRetryable,
+			BackoffFunc: internalmodel.SmartBackoff,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	h := &modelRetryCaptureHandler{}
+
+	result := Run(
+		ctx, ag, []adk.Message{schema.UserMessage("hello")}, h,
+		nil, nil, nil, nil, nil,
+	)
+
+	if result.Err != nil || result.Response != "recovered" {
+		t.Fatalf("result = %#v", result)
+	}
+	if got := model.calls.Load(); got != 2 {
+		t.Fatalf("model calls = %d, want 2", got)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.doneErr != nil {
+		t.Fatalf("OnAgentDone error = %v", h.doneErr)
+	}
+	if len(h.events) != 2 {
+		t.Fatalf("retry events = %+v, want waiting then ready", h.events)
+	}
+	waiting, ready := h.events[0], h.events[1]
+	if waiting.Status != internalhandler.ModelRetryWaiting || waiting.Attempt != 1 ||
+		waiting.MaxAttempts != internalmodel.DefaultMaxRetries || waiting.RetryIn <= 0 {
+		t.Fatalf("waiting event = %+v", waiting)
+	}
+	if ready.Status != internalhandler.ModelRetryReady {
+		t.Fatalf("ready event = %+v", ready)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -124,7 +124,7 @@ func Run(
 	modelRetryObserver := internalmodel.NewRetryObserver(func(event internalmodel.RetryBackoffEvent) {
 		handler.EmitModelRetry(h, handler.ModelRetryEvent{
 			Status: handler.ModelRetryWaiting, Attempt: event.Attempt,
-			MaxAttempts: internalmodel.DefaultMaxRetries, RetryIn: event.Delay,
+			MaxAttempts: event.MaxAttempts, RetryIn: event.Delay,
 		})
 	})
 	ctx = internalmodel.WithRetryObserver(ctx, modelRetryObserver)
@@ -655,8 +655,17 @@ func runInner(
 			if streamErr != nil {
 				var willRetry *adk.WillRetryError
 				if errors.As(streamErr, &willRetry) {
-					config.Logger().Printf("[runner] model stream will retry: %v", streamErr)
-					continue
+					if messageText.Len() == 0 && reasoningText.Len() == 0 && len(pending) == 0 && len(messageExtra) == 0 {
+						config.Logger().Printf("[runner] model stream will retry: %v", streamErr)
+						continue
+					}
+					// Shared retry configs reject mid-stream retries, but keep this
+					// boundary defensive for custom agents: never append a fresh
+					// attempt after text already emitted to append-only handlers.
+					config.Logger().Printf("[runner] refusing model retry after partial stream: %v", streamErr)
+					if underlying := errors.Unwrap(streamErr); underlying != nil {
+						streamErr = underlying
+					}
 				}
 				// A failed stream may contain only a prefix of tool-call arguments.
 				// Preserve text already shown to the user, but never persist or
@@ -813,11 +822,15 @@ func runInner(
 
 func resolveModelRetry(ctx context.Context, h handler.AgentEventHandler) {
 	observer := internalmodel.RetryObserverFromContext(ctx)
-	if observer == nil || !observer.Resolve() {
+	if observer == nil {
+		return
+	}
+	resolved, maxAttempts := observer.Resolve()
+	if !resolved {
 		return
 	}
 	handler.EmitModelRetry(h, handler.ModelRetryEvent{
-		Status: handler.ModelRetryReady, MaxAttempts: internalmodel.DefaultMaxRetries,
+		Status: handler.ModelRetryReady, MaxAttempts: maxAttempts,
 	})
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -121,6 +121,14 @@ func Run(
 			h.OnTokenUpdate(buildTokenUsage(tokenUsage, ctxLimit))
 		})
 	}
+	modelRetryObserver := internalmodel.NewRetryObserver(func(event internalmodel.RetryBackoffEvent) {
+		handler.EmitModelRetry(h, handler.ModelRetryEvent{
+			Status: handler.ModelRetryWaiting, Attempt: event.Attempt,
+			MaxAttempts: internalmodel.DefaultMaxRetries, RetryIn: event.Delay,
+		})
+	})
+	ctx = internalmodel.WithRetryObserver(ctx, modelRetryObserver)
+	defer modelRetryObserver.Clear()
 	h.OnAgentStart()
 
 	// Continuations need the exact structured output of the previous lap, but
@@ -482,6 +490,11 @@ func runInner(
 		}
 		eventCount++
 		if event.Err != nil {
+			var willRetry *adk.WillRetryError
+			if errors.As(event.Err, &willRetry) {
+				config.Logger().Printf("[runner] model call will retry: %v", event.Err)
+				continue
+			}
 			// If the run was canceled, the stream error is just fallout from the
 			// cancellation (e.g. "[NodeRunError] context canceled"), not a real
 			// failure — report a clean stop instead of surfacing the noise.
@@ -640,6 +653,11 @@ func runInner(
 				messageExtra = mergeAssistantExtra(messageExtra, chunk.Extra)
 			}
 			if streamErr != nil {
+				var willRetry *adk.WillRetryError
+				if errors.As(streamErr, &willRetry) {
+					config.Logger().Printf("[runner] model stream will retry: %v", streamErr)
+					continue
+				}
 				// A failed stream may contain only a prefix of tool-call arguments.
 				// Preserve text already shown to the user, but never persist or
 				// expose incomplete calls as executable conversation history.
@@ -674,6 +692,7 @@ func runInner(
 				h.OnAgentDone(runErr)
 				return finish(true, runErr)
 			}
+			resolveModelRetry(ctx, h)
 			// Notify and record accumulated tool calls in index order.
 			// All tool calls from this assistant message form one batch.
 			indices := make([]int, 0, len(pending))
@@ -734,6 +753,7 @@ func runInner(
 				}
 			}
 		} else if mo.Message != nil {
+			resolveModelRetry(ctx, h)
 			if mo.Message.Content != "" || mo.Message.ReasoningContent != "" || len(mo.Message.ToolCalls) > 0 || len(mo.Message.Extra) > 0 {
 				var toolCalls []schema.ToolCall
 				if len(mo.Message.ToolCalls) > 0 {
@@ -789,6 +809,16 @@ func runInner(
 		return finish(true, persistErr)
 	}
 	return finish(false, nil)
+}
+
+func resolveModelRetry(ctx context.Context, h handler.AgentEventHandler) {
+	observer := internalmodel.RetryObserverFromContext(ctx)
+	if observer == nil || !observer.Resolve() {
+		return
+	}
+	handler.EmitModelRetry(h, handler.ModelRetryEvent{
+		Status: handler.ModelRetryReady, MaxAttempts: internalmodel.DefaultMaxRetries,
+	})
 }
 
 func mergeAssistantExtra(dst, src map[string]any) map[string]any {

--- a/internal/team/manager.go
+++ b/internal/team/manager.go
@@ -670,8 +670,8 @@ func (m *Manager) runAgentTurn(ctx context.Context, state *TeammateState) (strin
 		Handlers:      handlers,
 		ModelRetryConfig: &adk.ModelRetryConfig{
 			MaxRetries:  3,
-			IsRetryAble: internalmodel.IsRetryable,
-			BackoffFunc: internalmodel.SmartBackoff,
+			ShouldRetry: internalmodel.ShouldRetryModelCall,
+			BackoffFunc: internalmodel.SmartBackoffWithMaxRetries(3),
 		},
 	})
 	if err != nil {

--- a/internal/tools/flow_spawn.go
+++ b/internal/tools/flow_spawn.go
@@ -106,8 +106,8 @@ func NewFlowSpawn(deps FlowSpawnDeps) flow.SpawnFunc {
 				Handlers:      flowAgentHandlers(),
 				ModelRetryConfig: &adk.ModelRetryConfig{
 					MaxRetries:  3,
-					IsRetryAble: internalmodel.IsRetryable,
-					BackoffFunc: internalmodel.SmartBackoff,
+					ShouldRetry: internalmodel.ShouldRetryModelCall,
+					BackoffFunc: internalmodel.SmartBackoffWithMaxRetries(3),
 				},
 			})
 			if aerr != nil {

--- a/internal/tools/subagent.go
+++ b/internal/tools/subagent.go
@@ -327,8 +327,8 @@ func (s *subagentTool) InvokableRun(ctx context.Context, argumentsInJSON string,
 			Handlers:      middlewares,
 			ModelRetryConfig: &adk.ModelRetryConfig{
 				MaxRetries:  3,
-				IsRetryAble: internalmodel.IsRetryable,
-				BackoffFunc: internalmodel.SmartBackoff,
+				ShouldRetry: internalmodel.ShouldRetryModelCall,
+				BackoffFunc: internalmodel.SmartBackoffWithMaxRetries(3),
 			},
 		})
 		if err != nil {

--- a/web/src/app/modelRetry.store.test.ts
+++ b/web/src/app/modelRetry.store.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { modelRetryActions, store } from './store'
+
+afterEach(() => store.dispatch(modelRetryActions.reset()))
+
+describe('model retry state', () => {
+  it('isolates tasks, guards stale clears, and clears an exhausted waiting retry', () => {
+    store.dispatch(modelRetryActions.statusReceived({
+      task_id: 'task-a', status: 'waiting', attempt: 1, max_attempts: 5, retry_in_ms: 1_250,
+    }))
+    store.dispatch(modelRetryActions.statusReceived({
+      task_id: 'task-b', status: 'ready', attempt: 2, max_attempts: 5,
+    }))
+    store.dispatch(modelRetryActions.statusReceived({
+      task_id: 'task-a', status: 'waiting', attempt: 2, max_attempts: 5, retry_in_ms: 2_000,
+    }))
+
+    store.dispatch(modelRetryActions.clear({ taskId: 'task-a', revision: 1 }))
+    expect(store.getState().modelRetry.byTaskId['task-a'].revision).toBe(2)
+    expect(store.getState().modelRetry.byTaskId['task-b'].status).toBe('ready')
+
+    store.dispatch(modelRetryActions.clearWaiting('task-a'))
+    expect(store.getState().modelRetry.byTaskId['task-a']).toBeUndefined()
+    store.dispatch(modelRetryActions.clearWaiting('task-b'))
+    expect(store.getState().modelRetry.byTaskId['task-b'].status).toBe('ready')
+  })
+})

--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -28,7 +28,7 @@ import type {
 } from 'jcode-ui-core'
 import { api, isAPIError } from '../lib/api'
 import { extractToolDisplayInfo } from '../lib/toolInfo'
-import { normalizeMode, type AgentMode, type CustomAgentInfo, type ProviderInfo, type SessionItem, type TaskItem, type ProjectInfo, type SlashCommandInfo, type SessionEntry, type ModelRef, type RemoteConnectRequest, type RemoteHostKeyErrorPayload, type RemoteHostKeyErrorCode, type RemoteConnectionStatusData, type SessionActivationResponse } from '../lib/types'
+import { normalizeMode, type AgentMode, type CustomAgentInfo, type ProviderInfo, type SessionItem, type TaskItem, type ProjectInfo, type SlashCommandInfo, type SessionEntry, type ModelRef, type RemoteConnectRequest, type RemoteHostKeyErrorPayload, type RemoteHostKeyErrorCode, type RemoteConnectionStatusData, type ModelRetryStatusData, type SessionActivationResponse } from '../lib/types'
 import { parseRemoteLabel } from '../lib/remote'
 import { i18n, setLocale, SUPPORTED_LOCALES } from '../i18n'
 import { hydrateTheme } from '../lib/useTheme'
@@ -1272,6 +1272,58 @@ const remoteConnectionSlice = createSlice({
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
+// model retry slice — task-scoped rate-limit backoff notices
+// ═══════════════════════════════════════════════════════════════════════════
+
+export interface ModelRetryNotice extends Omit<ModelRetryStatusData, 'status'> {
+  task_id: string
+  status: 'waiting' | 'ready'
+  /** Guards the recovery timer against a newer retry cycle for this task. */
+  revision: number
+}
+
+interface ModelRetryState {
+  byTaskId: Record<string, ModelRetryNotice>
+}
+
+const initialModelRetry: ModelRetryState = { byTaskId: {} }
+
+const modelRetrySlice = createSlice({
+  name: 'modelRetry',
+  initialState: initialModelRetry,
+  reducers: {
+    statusReceived(s, a: { payload: ModelRetryStatusData }) {
+      const taskId = a.payload.task_id
+      if (!taskId) return
+      const previous = s.byTaskId[taskId]
+      s.byTaskId[taskId] = {
+        ...a.payload,
+        task_id: taskId,
+        status: a.payload.status === 'ready' ? 'ready' : 'waiting',
+        attempt: Math.max(0, a.payload.attempt || 0),
+        max_attempts: Math.max(0, a.payload.max_attempts || 0),
+        retry_in_ms: a.payload.retry_in_ms === undefined
+          ? undefined
+          : Math.max(0, a.payload.retry_in_ms),
+        revision: (previous?.revision || 0) + 1,
+      }
+    },
+    clearWaiting(s, a: { payload: string }) {
+      if (s.byTaskId[a.payload]?.status === 'waiting') delete s.byTaskId[a.payload]
+    },
+    clear(s, a: { payload: { taskId: string; revision?: number } }) {
+      const current = s.byTaskId[a.payload.taskId]
+      if (!current) return
+      if (a.payload.revision !== undefined && current.revision !== a.payload.revision) return
+      delete s.byTaskId[a.payload.taskId]
+    },
+    reset(s) {
+      s.byTaskId = {}
+    },
+  },
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
 // model slice — provider/model/mode/favorites
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -1493,6 +1545,7 @@ export const chatActions = chatSlice.actions
 export const sessionActions = sessionSlice.actions
 export const conversationLoadActions = conversationLoadSlice.actions
 export const remoteConnectionActions = remoteConnectionSlice.actions
+export const modelRetryActions = modelRetrySlice.actions
 export const modelActions = modelSlice.actions
 export const uiActions = uiSlice.actions
 
@@ -2592,6 +2645,7 @@ export const store = configureStore({
     session: sessionSlice.reducer,
     conversationLoad: conversationLoadSlice.reducer,
     remoteConnection: remoteConnectionSlice.reducer,
+    modelRetry: modelRetrySlice.reducer,
     model: modelSlice.reducer,
     ui: uiSlice.reducer,
   },

--- a/web/src/app/wsBridge.remoteConnection.test.ts
+++ b/web/src/app/wsBridge.remoteConnection.test.ts
@@ -23,6 +23,20 @@ function baseState(status: 'waiting' | 'failed'): RootState {
 }
 
 describe('remote connection WebSocket bridge', () => {
+  it('dispatches task-scoped model retry status into its dedicated slice', () => {
+    const dispatch = vi.fn()
+    const handlers = createWSHandlers(() => baseState('waiting'), dispatch as unknown as AppDispatch)
+
+    handlers.onModelRetryStatus?.({
+      task_id: 'task-1', status: 'waiting', attempt: 1, max_attempts: 5, retry_in_ms: 750,
+    })
+
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'modelRetry/statusReceived',
+      payload: expect.objectContaining({ task_id: 'task-1', status: 'waiting' }),
+    }))
+  })
+
   it('dispatches task-scoped status into the dedicated slice', () => {
     const dispatch = vi.fn()
     const handlers = createWSHandlers(() => baseState('waiting'), dispatch as unknown as AppDispatch)
@@ -44,6 +58,7 @@ describe('remote connection WebSocket bridge', () => {
     handlers.onAgentDone?.({ task_id: 'task-1', stopped: true })
 
     expect(dispatch).toHaveBeenCalledWith({ type: 'remoteConnection/clearTransient', payload: 'task-1' })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'modelRetry/clearWaiting', payload: 'task-1' })
   })
 
   it('does not suppress an unstructured model error just because a failed notice remains', () => {

--- a/web/src/app/wsBridge.ts
+++ b/web/src/app/wsBridge.ts
@@ -13,6 +13,7 @@ import {
   chatActions,
   sessionActions,
   remoteConnectionActions,
+  modelRetryActions,
   modelActions,
   sendMessage,
   loadTasks,
@@ -76,6 +77,7 @@ export function createWSHandlers(
   const applyAgentDoneBackgroundEffects = (taskId: string | undefined, background: boolean) => {
     // These effects belong to the completed task even when its foreground
     // transcript is still pending or the user later cancels navigation.
+    if (taskId) dispatch(modelRetryActions.clearWaiting(taskId))
     void dispatch(loadTasks() as never)
     void dispatch(loadSessions() as never)
     const queued = taskId ? getState().chat.queuedBySession[taskId] : undefined
@@ -315,6 +317,9 @@ export function createWSHandlers(
     },
     onRemoteConnectionStatus: (d) => {
       dispatch(remoteConnectionActions.statusReceived(d))
+    },
+    onModelRetryStatus: (d) => {
+      dispatch(modelRetryActions.statusReceived(d))
     },
     onTaskStatus: (taskId, running, project, updatedAt) => {
       dispatch(sessionActions.setTaskRunning({ taskId, running }))

--- a/web/src/components/RemoteConnectionNotice.test.tsx
+++ b/web/src/components/RemoteConnectionNotice.test.tsx
@@ -44,8 +44,25 @@ describe('RemoteConnectionNotice', () => {
 
     const status = screen.getByRole('status', { name: 'Model retry status' })
     expect(status.className).toContain('remote-connection-notice--inline')
+    expect(status.querySelector('svg')?.classList.contains('h-4')).toBe(true)
+    expect(status.querySelector('svg')?.classList.contains('w-4')).toBe(true)
     expect(screen.getByText('Model rate limited. Retrying in about 2s 1/5')).toBeTruthy()
     expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('shows an active model retry instead of a stale connection recovery notice', () => {
+    store.dispatch(remoteConnectionActions.statusReceived({
+      task_id: 'task-active', kind: 'ssh', status: 'ready', attempt: 2, max_attempts: 8,
+    }))
+    store.dispatch(modelRetryActions.statusReceived({
+      task_id: 'task-active', status: 'waiting', attempt: 1, max_attempts: 5, retry_in_ms: 1_000,
+    }))
+
+    renderNotice()
+
+    expect(screen.getByRole('status', { name: 'Model retry status' })).toBeTruthy()
+    expect(screen.getByText('Model rate limited. Retrying in about 1s 1/5')).toBeTruthy()
+    expect(screen.queryByText('Reconnected')).toBeNull()
   })
 
   it('announces a bounded backoff with attempt and delay without replacing the conversation', () => {

--- a/web/src/components/RemoteConnectionNotice.test.tsx
+++ b/web/src/components/RemoteConnectionNotice.test.tsx
@@ -6,6 +6,7 @@ import { i18n } from '../i18n'
 import {
   conversationLoadActions,
   cancelConversationLoad,
+  modelRetryActions,
   remoteConnectionActions,
   sessionActions,
   store,
@@ -15,6 +16,7 @@ import { RemoteConnectionNotice } from './RemoteConnectionNotice'
 beforeEach(async () => {
   await i18n.changeLanguage('en')
   store.dispatch(conversationLoadActions.reset())
+  store.dispatch(modelRetryActions.reset())
   store.dispatch(remoteConnectionActions.reset())
   store.dispatch(sessionActions.setCurrentSession('task-active'))
   store.dispatch(sessionActions.setProjectPath('ssh://dev@example.com/workspace'))
@@ -24,6 +26,7 @@ afterEach(() => {
   cleanup()
   vi.useRealTimers()
   vi.restoreAllMocks()
+  store.dispatch(modelRetryActions.reset())
   store.dispatch(remoteConnectionActions.reset())
 })
 
@@ -32,6 +35,19 @@ function renderNotice() {
 }
 
 describe('RemoteConnectionNotice', () => {
+  it('shows model rate-limit backoff in the same quiet inline status position', () => {
+    store.dispatch(modelRetryActions.statusReceived({
+      task_id: 'task-active', status: 'waiting', attempt: 1, max_attempts: 5, retry_in_ms: 1_250,
+    }))
+
+    renderNotice()
+
+    const status = screen.getByRole('status', { name: 'Model retry status' })
+    expect(status.className).toContain('remote-connection-notice--inline')
+    expect(screen.getByText('Model rate limited. Retrying in about 2s 1/5')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
   it('announces a bounded backoff with attempt and delay without replacing the conversation', () => {
     store.dispatch(remoteConnectionActions.statusReceived({
       task_id: 'task-active',
@@ -46,8 +62,9 @@ describe('RemoteConnectionNotice', () => {
     renderNotice()
 
     expect(screen.getByRole('status', { name: 'Remote connection status' })).toBeTruthy()
-    expect(screen.getByText('Attempt 2/8')).toBeTruthy()
-    expect(screen.getByText('Retrying dev@example.com in about 3s.')).toBeTruthy()
+    expect(screen.getByText('Retrying in about 3s 2/8')).toBeTruthy()
+    expect(document.querySelector('.remote-connection-notice__track')).toBeNull()
+    expect(screen.getByRole('status').className).toContain('remote-connection-notice--inline')
   })
 
   it('does not expose a background task status in the foreground conversation', () => {
@@ -62,6 +79,25 @@ describe('RemoteConnectionNotice', () => {
     renderNotice()
 
     expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('renders an active SSH reconnect as a quiet inline status', () => {
+    store.dispatch(remoteConnectionActions.statusReceived({
+      task_id: 'task-active',
+      kind: 'ssh',
+      status: 'reconnecting',
+      attempt: 1,
+      max_attempts: 8,
+      host: 'dev@example.com',
+    }))
+
+    renderNotice()
+
+    const status = screen.getByRole('status', { name: 'Remote connection status' })
+    expect(status.className).toContain('remote-connection-notice--inline')
+    expect(screen.getByText('Reconnecting 1/8')).toBeTruthy()
+    expect(screen.queryByText(/dev@example\.com/)).toBeNull()
+    expect(screen.queryByRole('button')).toBeNull()
   })
 
   it('does not let an old recovered timer clear a newer status revision', () => {
@@ -113,7 +149,7 @@ describe('RemoteConnectionNotice', () => {
 
     await waitFor(() => expect(activate).toHaveBeenCalledTimes(1))
     expect(activate.mock.calls[0][0]).toMatchObject({ session_id: 'task-active', focus: false })
-    await waitFor(() => expect(screen.getByText('SSH connection restored')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('Reconnected')).toBeTruthy())
   })
 
   it('clears a manual retry notice when the user switches tasks before focus', async () => {

--- a/web/src/components/RemoteConnectionNotice.tsx
+++ b/web/src/components/RemoteConnectionNotice.tsx
@@ -3,17 +3,22 @@ import {
   CheckCircleIcon,
   ClockIcon,
   ExclamationTriangleIcon,
+  SignalIcon,
+  SignalSlashIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { remoteConnectionActions, retryRemoteConnection } from '../app/store'
+import { modelRetryActions, remoteConnectionActions, retryRemoteConnection } from '../app/store'
 import { useAppDispatch, useAppSelector } from '../app/hooks'
-import type { RemoteConnectionNotice as RemoteConnectionNoticeState } from '../app/store'
+import type {
+  ModelRetryNotice,
+  RemoteConnectionNotice as RemoteConnectionNoticeState,
+} from '../app/store'
 
 const READY_VISIBLE_MS = 4_000
 
-/** A task-scoped operational notice for transparent SSH/Docker recovery.
+/** A task-scoped operational notice for SSH/Docker and model retry recovery.
  * It deliberately lives beside the composer instead of replacing the thread:
  * saved history stays readable and transport failures never masquerade as a
  * model/agent error in the transcript. */
@@ -23,6 +28,7 @@ export function RemoteConnectionNotice() {
   const taskId = useAppSelector((s) => s.session.currentSessionId)
   const taskRunning = useAppSelector((s) => s.chat.isRunning)
   const notice = useAppSelector((s) => taskId ? s.remoteConnection.byTaskId[taskId] : undefined)
+  const modelRetry = useAppSelector((s) => taskId ? s.modelRetry.byTaskId[taskId] : undefined)
 
   useEffect(() => {
     if (!notice || notice.status !== 'ready') return
@@ -32,22 +38,67 @@ export function RemoteConnectionNotice() {
     return () => window.clearTimeout(timer)
   }, [dispatch, notice])
 
+  useEffect(() => {
+    if (!modelRetry || modelRetry.status !== 'ready') return
+    const timer = window.setTimeout(() => {
+      dispatch(modelRetryActions.clear({ taskId: modelRetry.task_id, revision: modelRetry.revision }))
+    }, READY_VISIBLE_MS)
+    return () => window.clearTimeout(timer)
+  }, [dispatch, modelRetry])
+
+  if (!notice && !modelRetry) return null
+
+  // A connection outage is the more fundamental blocker. Keep model retry
+  // state alive underneath it so the right status appears if transport recovers.
+  if (!notice && modelRetry) {
+    const Icon = modelRetry.status === 'ready' ? CheckCircleIcon : ClockIcon
+    return (
+      <section
+        className="remote-connection-notice remote-connection-notice--inline"
+        data-status={modelRetry.status}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label={t('modelRetry.label')}
+      >
+        <span key={modelRetry.revision} className="remote-connection-notice__inline-content">
+          <Icon className="remote-connection-notice__inline-icon" aria-hidden="true" />
+          <span className="remote-connection-notice__inline-copy">{modelRetryCopy(modelRetry, t)}</span>
+        </span>
+      </section>
+    )
+  }
+
   if (!notice) return null
 
+  const inline = notice.status === 'waiting' || notice.status === 'reconnecting' || notice.status === 'ready'
+  if (inline) {
+    const Icon = notice.status === 'ready'
+      ? CheckCircleIcon
+      : notice.kind === 'ssh'
+        ? notice.status === 'waiting' ? SignalSlashIcon : SignalIcon
+        : notice.status === 'waiting' ? ClockIcon : ArrowPathIcon
+
+    return (
+      <section
+        className="remote-connection-notice remote-connection-notice--inline"
+        data-status={notice.status}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label={t('remoteConnection.label')}
+      >
+        <span key={notice.revision} className="remote-connection-notice__inline-content">
+          <Icon className="remote-connection-notice__inline-icon" aria-hidden="true" />
+          <span className="remote-connection-notice__inline-copy">{inlineNoticeCopy(notice, t)}</span>
+        </span>
+      </section>
+    )
+  }
+
   const copy = noticeCopy(notice, t)
-  const showProgress = notice.status === 'waiting' || notice.status === 'reconnecting'
   const showAttempt = notice.attempt > 0 && notice.max_attempts > 0
   const outcomeUnknown = notice.code === 'remote_outcome_unknown'
-  const progress = showAttempt
-    ? Math.min(100, Math.max(8, (notice.attempt / notice.max_attempts) * 100))
-    : 8
-  const Icon = notice.status === 'ready'
-    ? CheckCircleIcon
-    : notice.status === 'waiting'
-      ? ClockIcon
-      : notice.status === 'reconnecting'
-        ? ArrowPathIcon
-        : ExclamationTriangleIcon
 
   return (
     <section
@@ -58,15 +109,8 @@ export function RemoteConnectionNotice() {
       aria-atomic="true"
       aria-label={t('remoteConnection.label')}
     >
-      {showProgress && (
-        <div className="remote-connection-notice__track" aria-hidden="true">
-          <span style={{ width: `${progress}%` }} />
-        </div>
-      )}
       <span className="remote-connection-notice__icon" aria-hidden="true">
-        <Icon
-          className={`h-4 w-4${notice.status === 'reconnecting' ? ' animate-spin motion-reduce:animate-none' : ''}`}
-        />
+        <ExclamationTriangleIcon className="h-4 w-4" />
       </span>
       <div className="remote-connection-notice__copy">
         <div className="remote-connection-notice__heading">
@@ -85,7 +129,7 @@ export function RemoteConnectionNotice() {
           </details>
         )}
       </div>
-      {(notice.status === 'ready' || notice.status === 'failed' || notice.status === 'action_required') && (
+      {(notice.status === 'failed' || notice.status === 'action_required') && (
         <div className="remote-connection-notice__actions">
           {(notice.status === 'action_required' || (notice.status === 'failed' && notice.retryable !== false)) && (
             <button
@@ -127,31 +171,39 @@ export function RemoteConnectionNotice() {
 
 type Translate = (key: string, options?: Record<string, unknown>) => string
 
+function inlineNoticeCopy(notice: RemoteConnectionNoticeState, t: Translate): string {
+  const options = {
+    attempt: notice.attempt,
+    max: notice.max_attempts,
+    seconds: Math.max(1, Math.ceil((notice.retry_in_ms || 0) / 1_000)),
+  }
+  if (notice.status === 'waiting') {
+    return notice.retry_in_ms
+      ? t('remoteConnection.inline.waitingWithDelay', options)
+      : t('remoteConnection.inline.waiting', options)
+  }
+  if (notice.status === 'reconnecting') {
+    return t('remoteConnection.inline.reconnecting', options)
+  }
+  return t('remoteConnection.inline.ready')
+}
+
+function modelRetryCopy(notice: ModelRetryNotice, t: Translate): string {
+  if (notice.status === 'ready') return t('modelRetry.ready')
+  const options = {
+    attempt: notice.attempt,
+    max: notice.max_attempts,
+    seconds: Math.max(1, Math.ceil((notice.retry_in_ms || 0) / 1_000)),
+  }
+  return notice.retry_in_ms
+    ? t('modelRetry.waitingWithDelay', options)
+    : t('modelRetry.waiting', options)
+}
+
 function noticeCopy(notice: RemoteConnectionNoticeState, t: Translate): { title: string; detail: string } {
   const detailOptions = {
     host: notice.host || t('remoteConnection.remoteHost'),
     transport: t(`remoteConnection.transport.${notice.kind}`),
-    seconds: Math.max(1, Math.ceil((notice.retry_in_ms || 0) / 1_000)),
-  }
-  if (notice.status === 'waiting') {
-    return {
-      title: t('remoteConnection.waiting.title', detailOptions),
-      detail: notice.retry_in_ms
-        ? t('remoteConnection.waiting.withDelay', detailOptions)
-        : t('remoteConnection.waiting.detail', detailOptions),
-    }
-  }
-  if (notice.status === 'reconnecting') {
-    return {
-      title: t('remoteConnection.reconnecting.title', detailOptions),
-      detail: t('remoteConnection.reconnecting.detail', detailOptions),
-    }
-  }
-  if (notice.status === 'ready') {
-    return {
-      title: t('remoteConnection.ready.title', detailOptions),
-      detail: t('remoteConnection.ready.detail', detailOptions),
-    }
   }
   if (notice.status === 'action_required') {
     const codeKey = actionRequiredKey(notice.code)

--- a/web/src/components/RemoteConnectionNotice.tsx
+++ b/web/src/components/RemoteConnectionNotice.tsx
@@ -50,7 +50,7 @@ export function RemoteConnectionNotice() {
 
   // A connection outage is the more fundamental blocker. Keep model retry
   // state alive underneath it so the right status appears if transport recovers.
-  if (!notice && modelRetry) {
+  if (modelRetry && (!notice || notice.status === 'ready')) {
     const Icon = modelRetry.status === 'ready' ? CheckCircleIcon : ClockIcon
     return (
       <section
@@ -62,7 +62,7 @@ export function RemoteConnectionNotice() {
         aria-label={t('modelRetry.label')}
       >
         <span key={modelRetry.revision} className="remote-connection-notice__inline-content">
-          <Icon className="remote-connection-notice__inline-icon" aria-hidden="true" />
+          <Icon className="h-4 w-4 remote-connection-notice__inline-icon" aria-hidden="true" />
           <span className="remote-connection-notice__inline-copy">{modelRetryCopy(modelRetry, t)}</span>
         </span>
       </section>
@@ -89,7 +89,7 @@ export function RemoteConnectionNotice() {
         aria-label={t('remoteConnection.label')}
       >
         <span key={notice.revision} className="remote-connection-notice__inline-content">
-          <Icon className="remote-connection-notice__inline-icon" aria-hidden="true" />
+          <Icon className="h-4 w-4 remote-connection-notice__inline-icon" aria-hidden="true" />
           <span className="remote-connection-notice__inline-copy">{inlineNoticeCopy(notice, t)}</span>
         </span>
       </section>

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -1089,6 +1089,12 @@ export default {
     remoteHost: 'the remote host',
     transport: { ssh: 'SSH', docker: 'Docker' },
     attempt: 'Attempt {attempt}/{max}',
+    inline: {
+      waiting: 'Waiting to retry {attempt}/{max}',
+      waitingWithDelay: 'Retrying in about {seconds}s {attempt}/{max}',
+      reconnecting: 'Reconnecting {attempt}/{max}',
+      ready: 'Reconnected',
+    },
     waiting: {
       title: '{transport} connection interrupted',
       detail: 'Waiting before reconnecting to {host}.',
@@ -1120,6 +1126,13 @@ export default {
     acknowledge: 'I understand',
     details: 'Technical details',
     dismiss: 'Dismiss connection status',
+  },
+
+  modelRetry: {
+    label: 'Model retry status',
+    waiting: 'Model rate limited. Retrying {attempt}/{max}',
+    waitingWithDelay: 'Model rate limited. Retrying in about {seconds}s {attempt}/{max}',
+    ready: 'Model recovered',
   },
 
   wizard: {

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -976,6 +976,12 @@ export default {
     remoteHost: 'リモートホスト',
     transport: { ssh: 'SSH', docker: 'Docker' },
     attempt: '{attempt}/{max} 回目',
+    inline: {
+      waiting: '再接続を待機中 {attempt}/{max}',
+      waitingWithDelay: '約 {seconds} 秒後に再試行 {attempt}/{max}',
+      reconnecting: '再接続中 {attempt}/{max}',
+      ready: '再接続しました',
+    },
     waiting: {
       title: '{transport} 接続が一時的に切れました',
       detail: '{host} への再接続を待機しています。',
@@ -1007,6 +1013,13 @@ export default {
     acknowledge: '確認しました',
     details: '技術的な詳細',
     dismiss: '接続状態を閉じる',
+  },
+
+  modelRetry: {
+    label: 'モデル再試行ステータス',
+    waiting: 'モデルがレート制限中です。再試行しています {attempt}/{max}',
+    waitingWithDelay: 'モデルがレート制限中です。約 {seconds} 秒後に再試行 {attempt}/{max}',
+    ready: 'モデルが復旧しました',
   },
 
   wizard: {

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -975,6 +975,12 @@ export default {
     remoteHost: '원격 호스트',
     transport: { ssh: 'SSH', docker: 'Docker' },
     attempt: '{attempt}/{max}번째 시도',
+    inline: {
+      waiting: '다시 연결 대기 중 {attempt}/{max}',
+      waitingWithDelay: '약 {seconds}초 후 재시도 {attempt}/{max}',
+      reconnecting: '다시 연결 중 {attempt}/{max}',
+      ready: '다시 연결됨',
+    },
     waiting: {
       title: '{transport} 연결이 일시적으로 끊겼습니다',
       detail: '{host}에 다시 연결하기 위해 기다리는 중입니다.',
@@ -1006,6 +1012,13 @@ export default {
     acknowledge: '확인했습니다',
     details: '기술 세부 정보',
     dismiss: '연결 상태 닫기',
+  },
+
+  modelRetry: {
+    label: '모델 재시도 상태',
+    waiting: '모델 요청이 제한되었습니다. 재시도 중 {attempt}/{max}',
+    waitingWithDelay: '모델 요청이 제한되었습니다. 약 {seconds}초 후 재시도 {attempt}/{max}',
+    ready: '모델이 복구되었습니다',
   },
 
   wizard: {

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -1066,6 +1066,12 @@ export default {
     remoteHost: '远程主机',
     transport: { ssh: 'SSH', docker: 'Docker' },
     attempt: '第 {attempt}/{max} 次',
+    inline: {
+      waiting: '等待重新连接 {attempt}/{max}',
+      waitingWithDelay: '约 {seconds} 秒后重试 {attempt}/{max}',
+      reconnecting: '正在重新连接 {attempt}/{max}',
+      ready: '已重新连接',
+    },
     waiting: {
       title: '{transport} 连接暂时中断',
       detail: '正在等待重新连接 {host}。',
@@ -1097,6 +1103,13 @@ export default {
     acknowledge: '我知道了',
     details: '技术详情',
     dismiss: '关闭连接状态',
+  },
+
+  modelRetry: {
+    label: '模型重试状态',
+    waiting: '模型限流，正在重试 {attempt}/{max}',
+    waitingWithDelay: '模型限流，约 {seconds} 秒后重试 {attempt}/{max}',
+    ready: '模型已恢复',
   },
 
   wizard: {

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -970,6 +970,12 @@ export default {
     remoteHost: '遠端主機',
     transport: { ssh: 'SSH', docker: 'Docker' },
     attempt: '第 {attempt}/{max} 次',
+    inline: {
+      waiting: '等待重新連線 {attempt}/{max}',
+      waitingWithDelay: '約 {seconds} 秒後重試 {attempt}/{max}',
+      reconnecting: '正在重新連線 {attempt}/{max}',
+      ready: '已重新連線',
+    },
     waiting: {
       title: '{transport} 連線暫時中斷',
       detail: '正在等待重新連線 {host}。',
@@ -1001,6 +1007,13 @@ export default {
     acknowledge: '我知道了',
     details: '技術詳細資訊',
     dismiss: '關閉連線狀態',
+  },
+
+  modelRetry: {
+    label: '模型重試狀態',
+    waiting: '模型達到速率限制，正在重試 {attempt}/{max}',
+    waitingWithDelay: '模型達到速率限制，約 {seconds} 秒後重試 {attempt}/{max}',
+    ready: '模型已恢復',
   },
 
   wizard: {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -493,6 +493,18 @@ export interface RemoteConnectionStatusData {
   retryable?: boolean
 }
 
+/** Task-scoped model rate-limit retry status. The WebSocket envelope task id is
+ * merged into the payload before it reaches Redux. */
+export type ModelRetryStatus = 'waiting' | 'ready'
+
+export interface ModelRetryStatusData {
+  task_id?: string
+  status: ModelRetryStatus
+  attempt: number
+  max_attempts: number
+  retry_in_ms?: number
+}
+
 export interface AgentDoneData {
   error?: string
   detail?: string

--- a/web/src/lib/ws.artifact.test.ts
+++ b/web/src/lib/ws.artifact.test.ts
@@ -24,6 +24,50 @@ afterEach(() => {
 })
 
 describe('WSClient artifact routing', () => {
+  it('keeps legacy all-task delivery when no active-task resolver is configured', () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const onToolCall = vi.fn()
+    const client = new WSClient({ onToolCall })
+    client.connect()
+
+    FakeWebSocket.instances[0].onmessage?.({ data: JSON.stringify({
+      type: 'tool_call',
+      task_id: 'task-running',
+      data: { name: 'execute', args: '{}', tool_call_id: 'call-legacy' },
+    }) })
+
+    expect(onToolCall).toHaveBeenCalledTimes(1)
+    client.disconnect()
+  })
+
+  it('does not leak a running task tool event into the new-chat gap', () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const onToolCall = vi.fn()
+    const onAgentDone = vi.fn()
+    const client = new WSClient({
+      activeTaskId: () => undefined,
+      onToolCall,
+      onAgentDone,
+    })
+    client.connect()
+
+    const socket = FakeWebSocket.instances[0]
+    socket.onmessage?.({ data: JSON.stringify({
+      type: 'tool_call',
+      task_id: 'task-running-over-ssh',
+      data: { name: 'execute', args: '{}', tool_call_id: 'call-background' },
+    }) })
+    socket.onmessage?.({ data: JSON.stringify({
+      type: 'agent_done',
+      task_id: 'task-running-over-ssh',
+      data: {},
+    }) })
+
+    expect(onToolCall).not.toHaveBeenCalled()
+    expect(onAgentDone).toHaveBeenCalledWith({ task_id: 'task-running-over-ssh' })
+    client.disconnect()
+  })
+
   it('delivers background artifact metadata with its task id', () => {
     vi.stubGlobal('WebSocket', FakeWebSocket)
     const onArtifactUpserted = vi.fn()

--- a/web/src/lib/ws.remoteConnection.test.ts
+++ b/web/src/lib/ws.remoteConnection.test.ts
@@ -20,6 +20,24 @@ afterEach(() => {
 })
 
 describe('WSClient remote connection routing', () => {
+  it('merges and preserves a background task id for model retry status', () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const onModelRetryStatus = vi.fn()
+    const client = new WSClient({ activeTaskId: () => 'task-active', onModelRetryStatus })
+    client.connect()
+
+    FakeWebSocket.instances[0].onmessage?.({ data: JSON.stringify({
+      type: 'model_retry_status',
+      task_id: 'task-background',
+      data: { status: 'waiting', attempt: 1, max_attempts: 5, retry_in_ms: 500 },
+    }) })
+
+    expect(onModelRetryStatus).toHaveBeenCalledWith({
+      task_id: 'task-background', status: 'waiting', attempt: 1, max_attempts: 5, retry_in_ms: 500,
+    })
+    client.disconnect()
+  })
+
   it('merges the envelope task id into an active-task status', () => {
     vi.stubGlobal('WebSocket', FakeWebSocket)
     const onRemoteConnectionStatus = vi.fn()

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -80,6 +80,7 @@ export interface WSHandlers {
   onSubagentProgress?: (data: import('./types').SubagentProgressData) => void
   onUserMessage?: (data: { content: string; source: string; local_echo?: boolean }) => void
   onRemoteConnectionStatus?: (data: import('./types').RemoteConnectionStatusData) => void
+  onModelRetryStatus?: (data: import('./types').ModelRetryStatusData) => void
   onTaskStatus?: (taskId: string, running: boolean, project?: string, updatedAt?: string) => void
   onArtifactUpserted?: (data: {
     task_id: string
@@ -117,8 +118,14 @@ const TASK_ID_DATA_TYPES = new Set([
   'agent_done',
   'artifact_upserted',
   'remote_connection_status',
+  'model_retry_status',
 ])
-const BACKGROUND_EVENT_TYPES = new Set(['agent_done', 'artifact_upserted', 'remote_connection_status'])
+const BACKGROUND_EVENT_TYPES = new Set([
+  'agent_done',
+  'artifact_upserted',
+  'remote_connection_status',
+  'model_retry_status',
+])
 const PENDING_FOREGROUND_EVENT_TYPES = new Set([
   'agent_start',
   'agent_text',
@@ -140,6 +147,7 @@ const PENDING_FOREGROUND_EVENT_TYPES = new Set([
   'subagent_progress',
   'user_message',
   'remote_connection_status',
+  'model_retry_status',
 ])
 
 export class WSClient {
@@ -318,6 +326,7 @@ export function dispatchWSHandler(handlers: WSHandlers, type: string, data: unkn
     case 'subagent_progress': handlers.onSubagentProgress?.(d); break
     case 'user_message': handlers.onUserMessage?.(d); break
     case 'remote_connection_status': handlers.onRemoteConnectionStatus?.(d); break
+    case 'model_retry_status': handlers.onModelRetryStatus?.(d); break
     case 'task_status': handlers.onTaskStatus?.(d?.task_id, !!d?.running, d?.project, d?.updated_at); break
     case 'artifact_upserted': handlers.onArtifactUpserted?.(d); break
   }

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -90,8 +90,8 @@ export interface WSHandlers {
   }) => void
   /** Fired when the socket opens/closes so the UI can show online/offline. */
   onConnectionChange?: (connected: boolean) => void
-  /** Returns the task currently shown in the foreground. Events tagged with a
-   *  DIFFERENT task id are dropped so they don't pollute the active view. */
+  /** Returns the task currently shown in the foreground. Foreground-only events
+   * tagged with any other task — including while no task is active — are dropped. */
   activeTaskId?: () => string | undefined
   /** Existing conversation whose history snapshot is ready but has not yet
    * become foreground. Its task-scoped events are buffered by the bridge. */
@@ -201,6 +201,7 @@ export class WSClient {
       if (this.gen !== gen || this.ws !== ws) return
       try {
         const msg: WSMessage = JSON.parse(event.data)
+        const taskRoutingEnabled = this.handlers.activeTaskId !== undefined
         const active = this.handlers.activeTaskId?.()
         let data = msg.data
         if (msg.task_id && TASK_ID_DATA_TYPES.has(msg.type)) {
@@ -216,10 +217,14 @@ export class WSClient {
           this.handlers.onPendingTaskEvent?.({ type: msg.type, taskId: msg.task_id, data })
           return
         }
-        // Events tagged with a different task id are dropped so they don't
-        // pollute the active view — EXCEPT agent_done, which the bridge needs
-        // for every session to drain that session's type-ahead queue.
-        if (msg.task_id && active && msg.task_id !== active && !BACKGROUND_EVENT_TYPES.has(msg.type)) return
+        // Foreground mutations must match the active task. This also covers the
+        // short new-chat window where currentSessionId is empty: a running
+        // background task must not repopulate the freshly cleared timeline.
+        // Background metadata still passes so queues/status/sidebar can settle.
+        if (
+          taskRoutingEnabled && msg.task_id && msg.task_id !== active &&
+          !BACKGROUND_EVENT_TYPES.has(msg.type)
+        ) return
         dispatchWSHandler(this.handlers, msg.type, data)
       } catch {
         // parse error — drop

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1207,9 +1207,9 @@ html.is-tauri-macos .titlebar-drag {
   color: var(--color-muted-foreground);
 }
 
-/* ─── Task-scoped remote recovery ───
-   A quiet operational layer above the composer. It deliberately does not use
-   chat error styling: an SSH transport interruption is not a model failure. */
+/* ─── Task-scoped operational recovery ───
+   A quiet layer above the composer for bounded SSH/Docker and model retries.
+   Transient recovery stays outside the permanent chat transcript. */
 .remote-connection-notice {
   position: relative;
   display: grid;
@@ -1239,17 +1239,60 @@ html.is-tauri-macos .titlebar-drag {
   border-color: var(--color-error-fg);
   background: var(--color-error-bg);
 }
-.remote-connection-notice__track {
-  position: absolute;
-  inset: 0 0 auto;
-  height: 2px;
-  background: var(--color-border);
+.remote-connection-notice--inline {
+  display: flex;
+  min-height: 1.5rem;
+  align-items: center;
+  margin-bottom: 0.45rem;
+  padding: 0.125rem 0.5rem;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--color-muted-foreground);
 }
-.remote-connection-notice__track > span {
-  display: block;
-  height: 100%;
-  background: var(--color-warning-fg);
-  transition: width var(--duration-normal);
+.remote-connection-notice--inline[data-status='waiting'],
+.remote-connection-notice--inline[data-status='reconnecting'] {
+  border-color: transparent;
+  background: transparent;
+}
+.remote-connection-notice--inline[data-status='ready'] {
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-success-fg);
+}
+.remote-connection-notice__inline-content {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.45rem;
+  animation: remote-connection-status-in var(--duration-fast) ease-out;
+}
+.remote-connection-notice__inline-icon {
+  width: 1rem;
+  height: 1rem;
+  flex: none;
+}
+.remote-connection-notice__inline-copy {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+@keyframes remote-connection-status-in {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 .remote-connection-notice__icon {
   display: inline-flex;
@@ -1367,9 +1410,10 @@ html.is-tauri-macos .titlebar-drag {
   outline-offset: -2px;
 }
 @media (prefers-reduced-motion: reduce) {
-  .remote-connection-notice__track > span,
+  .remote-connection-notice__inline-content,
   .remote-connection-notice__retry,
   .remote-connection-notice__dismiss {
+    animation: none;
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary

- replace transient SSH/Docker recovery cards with a quiet task-scoped inline status while keeping actionable failure states
- expose model rate-limit backoff and recovery from the existing Eino retry path
- route retry events through WebSocket and Redux, with localized attempt/delay copy and brief recovery feedback

## Validation

- go test ./...
- make lint
- make build-web
- repository pre-push checks: go build, go vet, incremental golangci-lint, and go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task-scoped status updates for model rate-limit retries, including attempt counts, delays, waiting states, and recovery notifications.
  * Added inline remote-connection notices for waiting, reconnecting, and recovered states.
  * Added localized retry and connection messages in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.
* **Bug Fixes**
  * Improved retry handling so temporary model and connection failures recover automatically without incorrectly reporting an error.
  * Cleared stale retry notices when processing completes or a retry cycle ends.
* **Style**
  * Replaced the connection progress bar with compact, status-specific inline messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->