### PR TITLE
feat(desktop): enable auto-update via Tauri updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,14 +551,40 @@ jobs:
           ART="$(basename "$SIG_FILE" .sig)"
           [ -f "$ART" ] || { echo "updater artifact '$ART' missing" >&2; exit 1; }
           URL="https://github.com/cnjack/jcode/releases/download/${VERSION}/${ART}"
+          # Verify the detached minisign signature against plugins.updater.pubkey
+          # before publishing: a wrong TAURI_SIGNING_PRIVATE_KEY (or a stale
+          # key in a fork) would otherwise ship a latest.json every client
+          # rejects. Scheme: pubkey = base64(minisign key file), "RWS" line =
+          # base64("Ed" + keynum + ed25519-pk); .sig = base64(minisign sig
+          # file), first non-comment line = base64("ED" + keynum + sig); the
+          # signature covers BLAKE2b-512 of the artifact (node crypto supports
+          # both via ed25519 + blake2b512).
           node -e '
             const fs = require("fs");
-            const [sigFile, platform, url] = process.argv.slice(1);
+            const crypto = require("crypto");
+            const [confPath, sigFile, platform, url] = process.argv.slice(1);
+            const conf = JSON.parse(fs.readFileSync(confPath, "utf8"));
+            const pubText = Buffer.from(conf.plugins.updater.pubkey, "base64").toString("utf8");
+            const keyBin = Buffer.from((pubText.split(/\r?\n/).find((l) => /^RW/.test(l)) || "").trim(), "base64");
+            if (keyBin.length !== 42) throw new Error(`unexpected public key length ${keyBin.length}`);
+            const sigText = Buffer.from(fs.readFileSync(sigFile, "utf8").trim(), "base64").toString("utf8");
+            const sigBin = Buffer.from((sigText.split(/\r?\n/).find((l) => !l.startsWith("untrusted")) || "").trim(), "base64");
+            if (sigBin.length !== 74) throw new Error(`unexpected signature length ${sigBin.length}`);
+            if (!sigBin.subarray(2, 10).equals(keyBin.subarray(2, 10))) {
+              throw new Error(`signature key id does not match plugins.updater.pubkey in ${confPath}`);
+            }
+            const spki = Buffer.concat([Buffer.from("302a300506032b6570032100", "hex"), keyBin.subarray(10)]);
+            const pub = crypto.createPublicKey({ key: spki, format: "der", type: "spki" });
+            const artifact = sigFile.replace(/\.sig$/, "");
+            const digest = crypto.createHash("blake2b512").update(fs.readFileSync(artifact)).digest();
+            if (!crypto.verify(null, digest, pub, sigBin.subarray(10))) {
+              console.error(`signature verification FAILED for ${artifact}: TAURI_SIGNING_PRIVATE_KEY does not match plugins.updater.pubkey`);
+              process.exit(1);
+            }
             const signature = fs.readFileSync(sigFile, "utf8").trim();
-            const fragment = { [platform]: { signature, url } };
-            fs.writeFileSync(`updater-fragment-${platform}.json`, JSON.stringify(fragment, null, 2) + "\n");
-            console.log(`updater fragment for ${platform}: ${url}`);
-          ' "$SIG_FILE" "$UPDATER_PLATFORM" "$URL"
+            fs.writeFileSync(`updater-fragment-${platform}.json`, JSON.stringify({ [platform]: { signature, url } }, null, 2) + "\n");
+            console.log(`updater fragment for ${platform}: ${url} (signature verified)`);
+          ' "$GITHUB_WORKSPACE/desktop/src-tauri/tauri.conf.json" "$SIG_FILE" "$UPDATER_PLATFORM" "$URL"
 
       - name: Upload desktop bundles
         uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,7 @@ jobs:
             cgo: 1
             bundles: dmg
             label: macos-arm64
+            updater-platform: darwin-aarch64
           # macOS Intel
           - os: macos-15-intel
             triple: x86_64-apple-darwin
@@ -195,6 +196,7 @@ jobs:
             cgo: 1
             bundles: dmg
             label: macos-x64
+            updater-platform: darwin-x86_64
           # Windows x64
           - os: windows-latest
             triple: x86_64-pc-windows-msvc
@@ -202,6 +204,7 @@ jobs:
             cgo: 0
             bundles: 'msi,nsis'
             label: windows-x64
+            updater-platform: windows-x86_64
           # Linux x64
           - os: ubuntu-22.04
             triple: x86_64-unknown-linux-gnu
@@ -209,6 +212,7 @@ jobs:
             cgo: 0
             bundles: 'deb,appimage'
             label: linux-x64
+            updater-platform: linux-x86_64
 
     steps:
       - name: Checkout code
@@ -276,8 +280,11 @@ jobs:
         run: |
           VER="${{ steps.get_version.outputs.version }}"
           VER="${VER#v}"
-          node -e "const fs=require('fs');const f='desktop/src-tauri/tauri.conf.json';const j=JSON.parse(fs.readFileSync(f));j.version='${VER}';fs.writeFileSync(f, JSON.stringify(j,null,2)+'\n')"
-          echo "Set desktop bundle version to ${VER}"
+          # createUpdaterArtifacts is deliberately absent from the committed
+          # conf (it would make every local `tauri build` require the signing
+          # key); CI turns it on for release builds only.
+          node -e "const fs=require('fs');const f='desktop/src-tauri/tauri.conf.json';const j=JSON.parse(fs.readFileSync(f));j.version='${VER}';j.bundle.createUpdaterArtifacts=true;fs.writeFileSync(f, JSON.stringify(j,null,2)+'\n')"
+          echo "Set desktop bundle version to ${VER} (updater artifacts enabled)"
 
       - name: Build sidecar
         shell: bash
@@ -477,6 +484,11 @@ jobs:
           # Lets linuxdeploy build the AppImage on runners without FUSE mounted.
           # The macOS signing/notarization vars arrive via $GITHUB_ENV (above).
           APPIMAGE_EXTRACT_AND_RUN: 1
+          # Updater artifact signing (minisign). The matching pubkey is in
+          # tauri.conf.json plugins.updater; with createUpdaterArtifacts on,
+          # the bundler hard-fails when the private key is missing.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           pnpm install --frozen-lockfile
           pnpm tauri build --bundles ${{ matrix.bundles }}
@@ -490,9 +502,24 @@ jobs:
           for f in "$B"/dmg/*.dmg "$B"/msi/*.msi "$B"/nsis/*-setup.exe "$B"/deb/*.deb "$B"/appimage/*.AppImage; do
             [ -f "$f" ] && cp "$f" dist-desktop/
           done
+          # Updater artifacts + signatures. Both macOS legs emit the same
+          # "jcode.app.tar.gz" name, so rename with the matrix label to keep
+          # the release assets collision-free.
+          if [ -f "$B"/macos/jcode.app.tar.gz ]; then
+            cp "$B"/macos/jcode.app.tar.gz "dist-desktop/jcode-${{ matrix.label }}.app.tar.gz"
+            cp "$B"/macos/jcode.app.tar.gz.sig "dist-desktop/jcode-${{ matrix.label }}.app.tar.gz.sig"
+          fi
+          for f in "$B"/nsis/*-setup.exe.sig "$B"/appimage/*.AppImage.sig; do
+            [ -f "$f" ] && cp "$f" dist-desktop/
+          done
+          # Note: the extra Windows .msi.zip updater artifact is intentionally
+          # NOT collected — NSIS is the update channel; humans still get .msi.
           cd dist-desktop
           for f in *; do
             [ -f "$f" ] || continue
+            case "$f" in
+              *.sig) continue ;; # signatures are verified by the updater, not checksums
+            esac
             if command -v sha256sum >/dev/null 2>&1; then
               sha256sum "$f" > "$f.sha256"
             else
@@ -500,6 +527,38 @@ jobs:
             fi
           done
           ls -la
+
+      # Per-platform latest.json fragment. Each matrix leg records its updater
+      # platform key with the signature and release URL; the release job merges
+      # them into the single latest.json the updater polls. Fails loudly when
+      # the .sig is missing (e.g. TAURI_SIGNING_PRIVATE_KEY not configured)
+      # rather than shipping an unsigned feed.
+      - name: Write updater fragment
+        shell: bash
+        env:
+          UPDATER_PLATFORM: ${{ matrix.updater-platform }}
+          VERSION: ${{ steps.get_version.outputs.version }}
+        run: |
+          set -euo pipefail
+          case "${{ runner.os }}" in
+            macOS)   PATTERN='jcode-*.app.tar.gz.sig' ;;
+            Windows) PATTERN='*-setup.exe.sig' ;;
+            Linux)   PATTERN='*.AppImage.sig' ;;
+          esac
+          cd dist-desktop
+          SIG_FILE="$(ls $PATTERN 2>/dev/null | head -n 1 || true)"
+          [ -n "$SIG_FILE" ] || { echo "no updater artifact signature matching '$PATTERN' — was signing skipped (TAURI_SIGNING_PRIVATE_KEY unset)?" >&2; exit 1; }
+          ART="$(basename "$SIG_FILE" .sig)"
+          [ -f "$ART" ] || { echo "updater artifact '$ART' missing" >&2; exit 1; }
+          URL="https://github.com/cnjack/jcode/releases/download/${VERSION}/${ART}"
+          node -e '
+            const fs = require("fs");
+            const [sigFile, platform, url] = process.argv.slice(1);
+            const signature = fs.readFileSync(sigFile, "utf8").trim();
+            const fragment = { [platform]: { signature, url } };
+            fs.writeFileSync(`updater-fragment-${platform}.json`, JSON.stringify(fragment, null, 2) + "\n");
+            console.log(`updater fragment for ${platform}: ${url}`);
+          ' "$SIG_FILE" "$UPDATER_PLATFORM" "$URL"
 
       - name: Upload desktop bundles
         uses: actions/upload-artifact@v5
@@ -548,6 +607,40 @@ jobs:
         run: |
           echo "── CLI binaries ──"; ls -la dist/
           echo "── Desktop bundles ──"; ls -la dist-desktop/
+
+      # Merge the per-platform updater fragments (written by the desktop matrix
+      # legs) into the single latest.json the desktop auto-updater polls
+      # (releases/latest/download/latest.json). GitHub's /latest never resolves
+      # to prereleases, so alpha/beta/rc tags never auto-update installs.
+      - name: Merge updater manifest
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+        run: |
+          node -e '
+            const fs = require("fs");
+            const path = require("path");
+            const dir = "dist-desktop";
+            const platforms = {};
+            let found = 0;
+            for (const f of fs.readdirSync(dir)) {
+              if (!f.startsWith("updater-fragment-") || !f.endsWith(".json")) continue;
+              found++;
+              Object.assign(platforms, JSON.parse(fs.readFileSync(path.join(dir, f), "utf8")));
+              fs.rmSync(path.join(dir, f));
+            }
+            if (found === 0) {
+              console.error("WARNING: no updater fragments found — publishing without latest.json");
+              process.exit(0);
+            }
+            const manifest = {
+              version: process.env.VERSION.replace(/^v/, ""),
+              notes: "",
+              pub_date: new Date().toISOString(),
+              platforms,
+            };
+            fs.writeFileSync(path.join(dir, "latest.json"), JSON.stringify(manifest, null, 2) + "\n");
+            console.log("latest.json platforms: " + Object.keys(platforms).join(", "));
+          '
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -568,7 +568,14 @@ jobs:
             const keyBin = Buffer.from((pubText.split(/\r?\n/).find((l) => /^RW/.test(l)) || "").trim(), "base64");
             if (keyBin.length !== 42) throw new Error(`unexpected public key length ${keyBin.length}`);
             const sigText = Buffer.from(fs.readFileSync(sigFile, "utf8").trim(), "base64").toString("utf8");
-            const sigBin = Buffer.from((sigText.split(/\r?\n/).find((l) => !l.startsWith("untrusted")) || "").trim(), "base64");
+            const lines = sigText.split(/\r?\n/).filter((l) => l.trim() !== "");
+            // minisign-verify (the client crate) requires all four lines:
+            // untrusted comment, signature, trusted comment, global signature.
+            // A truncated file would pass a primary-only check but the
+            // client's Signature::decode rejects it — fail it here instead.
+            if (lines.length < 4) throw new Error(`truncated signature: expected 4 lines, got ${lines.length}`);
+            if (!lines[2].startsWith("trusted comment: ")) throw new Error("malformed trusted comment");
+            const sigBin = Buffer.from(lines[1].trim(), "base64");
             if (sigBin.length !== 74) throw new Error(`unexpected signature length ${sigBin.length}`);
             if (!sigBin.subarray(2, 10).equals(keyBin.subarray(2, 10))) {
               throw new Error(`signature key id does not match plugins.updater.pubkey in ${confPath}`);
@@ -579,6 +586,16 @@ jobs:
             const digest = crypto.createHash("blake2b512").update(fs.readFileSync(artifact)).digest();
             if (!crypto.verify(null, digest, pub, sigBin.subarray(10))) {
               console.error(`signature verification FAILED for ${artifact}: TAURI_SIGNING_PRIVATE_KEY does not match plugins.updater.pubkey`);
+              process.exit(1);
+            }
+            // Global signature covers sig64 || trusted comment (minus its
+            // "trusted comment: " prefix) — mirrors verify_ed25519 in
+            // minisign-verify.
+            const globalSig = Buffer.from(lines[3].trim(), "base64");
+            if (globalSig.length !== 64) throw new Error(`unexpected global signature length ${globalSig.length}`);
+            const globalMsg = Buffer.concat([sigBin.subarray(10), Buffer.from(lines[2].slice(17), "utf8")]);
+            if (!crypto.verify(null, globalMsg, pub, globalSig)) {
+              console.error(`global signature verification FAILED for ${artifact}`);
               process.exit(1);
             }
             const signature = fs.readFileSync(sigFile, "utf8").trim();

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +686,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +987,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1542,6 +1572,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,8 +1880,10 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
  "windows-sys 0.61.2",
@@ -1857,6 +1904,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2061,6 +2138,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2335,6 +2418,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2534,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2885,15 +3000,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2930,6 +3050,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,6 +3092,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,6 +3177,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3028,6 +3244,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3288,6 +3527,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3400,6 +3655,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3482,7 +3743,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3516,6 +3777,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,7 +3811,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3750,6 +4022,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3786,6 +4068,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-plugin-window-state"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3810,7 +4125,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3833,7 +4148,7 @@ checksum = "fe41e015bf8fc4d6477ff4926a0ef769dc64ff34c7b0038b6f7cacae892acb5c"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4042,6 +4357,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4358,6 +4683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4607,6 +4938,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4834,6 +5174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5131,7 +5480,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5194,6 +5543,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xkeysym"
@@ -5327,6 +5686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5357,6 +5722,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -15,18 +15,21 @@ tauri-plugin-shell = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # Desktop-only plugins (no Android/iOS support).
-# NOTE: the updater plugin is intentionally absent — it panics at startup unless
-# `plugins.updater` (endpoints + pubkey) is configured, which requires a signed
-# release feed. Add it back together with that config. Autostart is likewise
-# deferred until there's a settings toggle for it.
+# The updater requires the `plugins.updater` config (endpoints + pubkey) in
+# tauri.conf.json — it is present. `bundle.createUpdaterArtifacts` is,
+# however, deliberately left out of the committed conf: with it set, every
+# `tauri build` needs TAURI_SIGNING_PRIVATE_KEY or it hard-fails, which would
+# break local `make desktop-build`. CI enables it per-build (release.yml).
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-updater = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 base64 = "0.22"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -27,6 +27,8 @@
         }
       ]
     },
-    "dialog:default"
+    "dialog:default",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -91,7 +91,9 @@ fn main() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_dialog::init());
+        .plugin(tauri_plugin_dialog::init())
+        // Relaunch support for the updater (swaps in the staged bundle).
+        .plugin(tauri_plugin_process::init());
 
     #[cfg(desktop)]
     {
@@ -99,7 +101,11 @@ fn main() {
             .plugin(tauri_plugin_window_state::Builder::default().build())
             // Registered without a shortcut here; the accelerator is bound in
             // setup() so a hotkey conflict logs instead of crashing the app.
-            .plugin(tauri_plugin_global_shortcut::Builder::new().build());
+            .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+            // Auto-updater: fetches the signed latest.json from GitHub Releases,
+            // verifies against the pubkey in tauri.conf.json. The in-app flow
+            // (banner → download → install → relaunch) lives in the web UI.
+            .plugin(tauri_plugin_updater::Builder::new().build());
     }
 
     let app = builder

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -50,5 +50,12 @@
     "longDescription": "Native desktop shell for jcode — the embedded Go backend runs as a sidecar and Tauri renders the web UI with native system integration.",
     "copyright": "© cnjack"
   },
-  "plugins": {}
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/cnjack/jcode/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDEwM0E1MzBENEQ5MThGODQKUldTRWo1Rk5EVk02RU9IMTQ4RWdDMFUyVE5wdExqamkrRTdLcUlJSEFkSEpHTEZPL0V1ckp6WUEK"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,12 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2.0.0
         version: 2.5.4
+      '@tauri-apps/plugin-process':
+        specifier: ^2.0.0
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.0.0
+        version: 2.10.1
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -876,6 +882,12 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2593,6 +2605,14 @@ snapshots:
       '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-opener@2.5.4':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/site/docs/desktop.md
+++ b/site/docs/desktop.md
@@ -165,8 +165,9 @@ The desktop app bundles [`tauri-plugin-updater`](https://v2.tauri.app/plugin/upd
   the installer), Linux `.AppImage` — each with a `.sig`. `.deb` / `.msi` are installers
   only. `bundle.createUpdaterArtifacts` is **not** in the committed config (it would
   make every local `tauri build` demand the signing key); CI enables it per build.
-- Desktop installs from **before** the updater shipped need one manual upgrade; from
-  that version on, updates chain automatically.
+- Desktop installs on **v0.5.3 or earlier** (the last releases without the
+  updater) need one manual upgrade; from the first updater-bearing release on,
+  updates chain automatically.
 
 ## Troubleshooting
 

--- a/site/docs/desktop.md
+++ b/site/docs/desktop.md
@@ -68,6 +68,7 @@ entry (`http://localhost:*`, `http://127.0.0.1:*`) in
 | **Native folder picker** | "Open folder" in the workspace switcher uses the OS dialog on desktop. |
 | **External links** | Links open in the system browser via the opener plugin. |
 | **Overlay title bar** | On macOS the traffic-light buttons sit in a slim draggable strip above the shell. |
+| **Auto-update** | Checks GitHub Releases for a newer version at startup and installs signed updates in place (see below). |
 
 ## Security model
 
@@ -144,6 +145,29 @@ The desktop bridge on the frontend side lives in
 `web/src/lib/useDesktop.ts` — every export is feature-detected, so the
 same web bundle runs unchanged in a browser and inside the desktop shell.
 
+## Auto-update
+
+The desktop app bundles [`tauri-plugin-updater`](https://v2.tauri.app/plugin/updater/)
+(desktop-only) plus `tauri-plugin-process` for the post-install relaunch.
+
+- **Feed:** `https://github.com/cnjack/jcode/releases/latest/download/latest.json`
+  (configured in `tauri.conf.json` → `plugins.updater`, together with the minisign
+  **pubkey**; artifacts are signed with the matching private key in CI).
+- **Flow:** ~4s after startup the app checks silently (never in `tauri dev`). When a
+  newer version exists, a bottom-right banner shows the version and release notes;
+  "Update & restart" downloads with a progress bar, verifies the signature, and
+  relaunches into the new build. Settings → General → *Version & updates* has a
+  manual check (useful after dismissing the banner). A failed passive check stays
+  silent — only the manual check surfaces errors.
+- **Channel:** stable only. The feed resolves via GitHub's `/releases/latest`, which
+  never matches prereleases, so `alpha` / `beta` / `rc` tags are never auto-installed.
+- **Artifacts:** macOS `.app.tar.gz` (per arch), Windows NSIS `-setup.exe` (doubles as
+  the installer), Linux `.AppImage` — each with a `.sig`. `.deb` / `.msi` are installers
+  only. `bundle.createUpdaterArtifacts` is **not** in the committed config (it would
+  make every local `tauri build` demand the signing key); CI enables it per build.
+- Desktop installs from **before** the updater shipped need one manual upgrade; from
+  that version on, updates chain automatically.
+
 ## Troubleshooting
 
 - **Window never appears.** The shell waits for the sidecar to accept
@@ -153,8 +177,9 @@ same web bundle runs unchanged in a browser and inside the desktop shell.
 - **Native notifications don't fire.** Confirm OS notification permission was
   granted, and that the localhost origin is listed under `remote.urls` in the
   capability file (this is what enables Tauri JS APIs on the loopback origin).
-- **Auto-update.** The updater plugin is intentionally not bundled yet: it
-  panics at startup unless `plugins.updater` (endpoints + pubkey) is configured,
-  which needs a signed release feed. To enable it, re-add `tauri-plugin-updater`
-  (Cargo + `main.rs` + the `updater:default` capability), set
-  `bundle.createUpdaterArtifacts: true`, and add the `plugins.updater` config.
+- **Auto-update finds nothing / errors on manual check.** The updater needs a
+  published, **non-prerelease** release carrying `latest.json` — check that the
+  release is marked "Latest" on GitHub and that the artifact for your platform
+  exists. A first run after the updater shipped also verifies against the pubkey
+  in `tauri.conf.json`; a mismatched key (re-generated without re-publishing)
+  fails every install.

--- a/site/docs/release.md
+++ b/site/docs/release.md
@@ -148,10 +148,39 @@ verified publisher is required.
 Linux `.deb` / `.AppImage` bundles are not code-signed (the platform has no equivalent
 Gatekeeper gate). No secrets are required.
 
+## Desktop auto-updater (required secret)
+
+The desktop bundles carry an auto-updater (see [Desktop App](desktop.html)). It
+verifies update artifacts with a **minisign** keypair: the public key lives in
+`desktop/src-tauri/tauri.conf.json` → `plugins.updater.pubkey`, and CI signs the
+updater artifacts with the private key from a secret.
+
+| Secret | What it is |
+| --- | --- |
+| `TAURI_SIGNING_PRIVATE_KEY` | **Required.** Contents of the minisign private key file (the local copy lives at `~/.jcode/desktop-updater.key`; generated once via `pnpm tauri signer generate`). **Losing it means no more signed updates** — every published version's signature chain depends on it. |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Only if the key was generated with a password (the jcode key has none — leave the secret unset). |
+
+How the feed is produced on every tagged release: each desktop matrix leg builds with
+`bundle.createUpdaterArtifacts` enabled, ships the updater artifact plus its `.sig`
+(macOS `.app.tar.gz` renamed per-arch, Windows NSIS `-setup.exe`, Linux `.AppImage`),
+and writes an `updater-fragment-<platform>.json`; the release job merges all fragments
+into **`latest.json`** and attaches it to the release. The build **fails loudly** if a
+`.sig` is missing (e.g. the secret is unset), so a release can never ship an unsigned
+feed by accident.
+
+Notes:
+
+- **Stable channel only.** The feed URL resolves via `releases/latest/download/…`,
+  which GitHub never points at prereleases — `alpha` / `beta` / `rc` tags are built
+  and published but never auto-installed.
+- Desktop installs from **before** the updater shipped need one manual upgrade; from
+  that version on, updates chain automatically.
+- `bundle.createUpdaterArtifacts` is intentionally **absent from the committed**
+  `tauri.conf.json` — with it set, every local `make desktop-build` would demand the
+  signing key or hard-fail. CI flips it on in the release workflow only.
+
 ## Notes
 
-- The desktop **auto-updater is not enabled**, so **no** `TAURI_SIGNING_PRIVATE_KEY` /
-  `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets are needed.
 - If a single platform's desktop build fails, the matrix uses `fail-fast: false` so the
   others still publish; re-run the failed job afterward.
 

--- a/site/docs/release.md
+++ b/site/docs/release.md
@@ -173,8 +173,8 @@ Notes:
 - **Stable channel only.** The feed URL resolves via `releases/latest/download/…`,
   which GitHub never points at prereleases — `alpha` / `beta` / `rc` tags are built
   and published but never auto-installed.
-- Desktop installs from **before** the updater shipped need one manual upgrade; from
-  that version on, updates chain automatically.
+- Desktop installs on **v0.5.3 or earlier** (no updater) need one manual upgrade; from
+  the first updater-bearing release on, updates chain automatically.
 - `bundle.createUpdaterArtifacts` is intentionally **absent from the committed**
   `tauri.conf.json` — with it set, every local `make desktop-build` would demand the
   signing key or hard-fail. CI flips it on in the release workflow only.

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,8 @@
     "@tauri-apps/plugin-dialog": "^2.0.0",
     "@tauri-apps/plugin-notification": "^2.0.0",
     "@tauri-apps/plugin-opener": "^2.0.0",
+    "@tauri-apps/plugin-process": "^2.0.0",
+    "@tauri-apps/plugin-updater": "^2.0.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -62,8 +62,10 @@ import { ComputerShotPiP } from './components/ComputerShotPiP'
 import { RightPanel } from './components/RightPanel'
 import { TerminalPanel } from './components/TerminalPanel'
 import { RemoteConnectWizard } from './components/RemoteConnectWizard'
+import { UpdateBanner } from './components/UpdateBanner'
 import type { RemotePrefill } from './lib/remote'
 import { isTauri } from './lib/useDesktop'
+import { AppUpdateProvider } from './lib/useAppUpdate'
 
 export default function App() {
   const dispatch = useAppDispatch()
@@ -181,7 +183,13 @@ export default function App() {
     return <AuthGate />
   }
 
-  return <Shell activeView={activeView} />
+  // The update provider wraps the whole shell so both the UpdateBanner and the
+  // Settings "version & updates" row share one auto-update state machine.
+  return (
+    <AppUpdateProvider>
+      <Shell activeView={activeView} />
+    </AppUpdateProvider>
+  )
 }
 
 // store_getState is bound lazily to avoid a circular import at module eval.
@@ -391,6 +399,8 @@ function Shell({ activeView }: { activeView: 'chat' | 'automations' | 'cloud-mob
           )}
 
           {paletteOpen && <CommandPalette />}
+          {/* Desktop auto-update toast — bottom-right, all views. */}
+          <UpdateBanner />
           <RemoteConnectWizard
             open={remoteWizardOpen}
             prefill={remotePrefill}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -93,7 +93,8 @@ import {
   writeProviderCatalogCache,
 } from '../lib/providerCatalogCache'
 import { openRemoteConnect } from '../lib/remote'
-import { openUrl } from '../lib/useDesktop'
+import { isTauri, openUrl } from '../lib/useDesktop'
+import { useAppUpdate } from '../lib/useAppUpdate'
 import { LOCALE_LABELS, SUPPORTED_LOCALES, setLocale, type SupportedLocale } from '../i18n'
 import type {
   BrowserConfig,
@@ -1875,6 +1876,11 @@ function GeneralTab() {
         </div>
       </div>
 
+      {/* Desktop only: current app version + manual update check. The banner
+          is the install surface; this row lets the user re-check after
+          dismissing it. */}
+      {isTauri && <VersionUpdateRow />}
+
       {tokenSnapshot && (
         <div className={ROW}>
           <div className="min-w-0 flex-1">
@@ -1961,6 +1967,67 @@ function GeneralTab() {
       <ToolSearchSection />
       <ApprovalReviewSection />
 
+    </div>
+  )
+}
+
+function VersionUpdateRow() {
+  const { t } = useTranslation()
+  const { status, version, check } = useAppUpdate()
+  const [appVersion, setAppVersion] = useState('')
+
+  // The Tauri app version (capability core:app:allow-version), not the sidecar
+  // version — the updater compares against this one.
+  useEffect(() => {
+    if (!isTauri) return
+    let cancelled = false
+    import('@tauri-apps/api/app')
+      .then(({ getVersion }) => getVersion())
+      .then((v) => {
+        if (!cancelled) setAppVersion(v)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const busy = status === 'checking' || status === 'downloading' || status === 'restarting'
+  const hint =
+    status === 'checking'
+      ? t('update.checking')
+      : status === 'up-to-date'
+        ? t('update.upToDate')
+        : status === 'available'
+          ? t('update.newVersionFound', { version })
+          : status === 'downloading'
+            ? t('update.downloading')
+            : status === 'restarting'
+              ? t('update.restarting')
+              : status === 'error'
+                ? t('update.checkFailed')
+                : ''
+
+  return (
+    <div className={ROW}>
+      <div className="grid h-7 w-7 shrink-0 place-items-center rounded-[var(--radius-md)] text-[var(--color-muted-foreground)]">
+        <ArrowPathIcon className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-[12px] font-medium text-[var(--color-foreground)]">{t('update.sectionTitle')}</div>
+        <div className="text-[11px] text-[var(--color-muted-foreground)]">
+          {appVersion ? `${t('update.currentVersion')} v${appVersion}` : ''}
+          {hint ? (appVersion ? ` · ${hint}` : hint) : ''}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => void check({ manual: true })}
+        disabled={busy}
+        className={`${BTN_SECONDARY} ${BTN_XS}`}
+      >
+        {t('update.checkButton')}
+      </button>
     </div>
   )
 }

--- a/web/src/components/UpdateBanner.tsx
+++ b/web/src/components/UpdateBanner.tsx
@@ -1,0 +1,115 @@
+/**
+ * UpdateBanner — desktop auto-update toast, floating bottom-right. It is the
+ * only visible surface of the useAppUpdate flow and is mounted once by App's
+ * Shell so it stays reachable from every workspace view. Renders nothing in
+ * the browser bundle or once dismissed (Settings → "check for updates" can
+ * bring it back by finding a newer version again).
+ */
+
+import { ArrowPathIcon, ArrowUpTrayIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { useTranslation } from 'react-i18next'
+import { useAppUpdate } from '../lib/useAppUpdate'
+import { isTauri } from '../lib/useDesktop'
+
+export function UpdateBanner() {
+  const { t } = useTranslation()
+  const { status, version, notes, progress, error, dismissed, install, dismiss } = useAppUpdate()
+
+  if (!isTauri || dismissed) return null
+  // Passive states stay invisible; manual-check feedback lives in Settings.
+  if (status === 'idle' || status === 'checking' || status === 'up-to-date') return null
+
+  const pct = progress > 0 ? Math.round(progress * 100) : null
+
+  return (
+    <div
+      role="status"
+      className="fixed bottom-4 right-4 z-50 flex w-[340px] flex-col gap-2.5 rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-sm)]"
+    >
+      <div className="flex items-start gap-2.5">
+        {status === 'error' ? (
+          <ArrowPathIcon className="mt-0.5 h-4 w-4 shrink-0 text-[var(--color-destructive)]" />
+        ) : (
+          <ArrowUpTrayIcon className="mt-0.5 h-4 w-4 shrink-0 text-[var(--color-primary)]" />
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] font-semibold text-[var(--color-foreground)]">
+            {status === 'available' && t('update.availableTitle')}
+            {status === 'downloading' && t('update.downloading')}
+            {status === 'restarting' && t('update.restarting')}
+            {status === 'error' && t('update.failed')}
+          </p>
+          {status === 'available' && !!version && (
+            <p className="mt-0.5 text-[12px] text-[var(--color-muted-foreground)]">
+              {t('update.updateTo', { version })}
+            </p>
+          )}
+          {status === 'available' && !!notes && (
+            <p className="mt-1.5 line-clamp-3 whitespace-pre-line text-[12px] leading-relaxed text-[var(--color-muted-foreground)]">
+              {notes}
+            </p>
+          )}
+          {status === 'error' && !!error && (
+            <p className="mt-1.5 line-clamp-3 text-[12px] leading-relaxed text-[var(--color-error-fg)]">{error}</p>
+          )}
+        </div>
+        {(status === 'available' || status === 'error') && (
+          <button
+            type="button"
+            aria-label={t('update.dismiss')}
+            onClick={dismiss}
+            className="rounded-[var(--radius-md)] p-1 text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-secondary)] hover:text-[var(--color-foreground)]"
+          >
+            <XMarkIcon className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {(status === 'downloading' || status === 'restarting') && (
+        <div className="flex flex-col gap-1">
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--color-secondary)]">
+            <div
+              className="h-full rounded-full bg-[var(--color-primary)] transition-[width] duration-200"
+              style={{ width: `${status === 'restarting' ? 100 : Math.max(progress * 100, 6)}%` }}
+            />
+          </div>
+          <p className="text-right text-[11px] tabular-nums text-[var(--color-muted-foreground)]">
+            {pct !== null ? `${pct}%` : ''}
+          </p>
+        </div>
+      )}
+
+      {status === 'available' && (
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={dismiss}
+            className="rounded-[var(--radius-md)] px-2.5 py-1.5 text-[12px] font-medium text-[var(--color-muted-foreground)] transition-colors hover:bg-[var(--color-secondary)] hover:text-[var(--color-foreground)]"
+          >
+            {t('update.later')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void install()}
+            className="rounded-[var(--radius-md)] bg-[var(--color-primary)] px-3 py-1.5 text-[12px] font-semibold text-[var(--color-on-primary)] transition-opacity hover:opacity-90"
+          >
+            {t('update.updateRestart')}
+          </button>
+        </div>
+      )}
+
+      {status === 'error' && (
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => void install()}
+            className="inline-flex items-center gap-1.5 rounded-[var(--radius-md)] bg-[var(--color-primary)] px-3 py-1.5 text-[12px] font-semibold text-[var(--color-on-primary)] transition-opacity hover:opacity-90"
+          >
+            <ArrowPathIcon className="h-3.5 w-3.5" />
+            {t('update.retry')}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/UpdateBanner.tsx
+++ b/web/src/components/UpdateBanner.tsx
@@ -13,7 +13,7 @@ import { isTauri } from '../lib/useDesktop'
 
 export function UpdateBanner() {
   const { t } = useTranslation()
-  const { status, version, notes, progress, error, dismissed, install, dismiss } = useAppUpdate()
+  const { status, version, notes, progress, error, dismissed, check, install, dismiss } = useAppUpdate()
 
   if (!isTauri || dismissed) return null
   // Passive states stay invisible; manual-check feedback lives in Settings.
@@ -100,9 +100,12 @@ export function UpdateBanner() {
 
       {status === 'error' && (
         <div className="flex items-center justify-end gap-2">
+          {/* Retry re-runs the check rather than install(): an error from a
+              failed check leaves no Update handle, and after a failed install
+              a fresh check rediscovers the update for another attempt. */}
           <button
             type="button"
-            onClick={() => void install()}
+            onClick={() => void check({ manual: true })}
             className="inline-flex items-center gap-1.5 rounded-[var(--radius-md)] bg-[var(--color-primary)] px-3 py-1.5 text-[12px] font-semibold text-[var(--color-on-primary)] transition-opacity hover:opacity-90"
           >
             <ArrowPathIcon className="h-3.5 w-3.5" />

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -53,6 +53,7 @@ export default {
     downloading: 'Downloading update…',
     restarting: 'Restarting to finish update…',
     failed: 'Update failed',
+    checkFailed: 'Check failed',
     later: 'Later',
     updateRestart: 'Update & restart',
     retry: 'Retry',

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -41,6 +41,24 @@ export default {
     done: 'Done',
   },
 
+  update: {
+    sectionTitle: 'Version & updates',
+    currentVersion: 'Current version',
+    checkButton: 'Check for updates',
+    checking: 'Checking…',
+    upToDate: 'Up to date',
+    newVersionFound: 'New version {version} available',
+    availableTitle: 'A new version is available',
+    updateTo: 'Update to {version}',
+    downloading: 'Downloading update…',
+    restarting: 'Restarting to finish update…',
+    failed: 'Update failed',
+    later: 'Later',
+    updateRestart: 'Update & restart',
+    retry: 'Retry',
+    dismiss: 'Dismiss',
+  },
+
   nav: {
     newTask: 'New task',
     automations: 'Automations',

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -51,6 +51,7 @@ export default {
     downloading: 'アップデートをダウンロード中…',
     restarting: '再起動して更新を完了しています…',
     failed: 'アップデートに失敗しました',
+    checkFailed: '確認に失敗しました',
     later: '後で',
     updateRestart: '更新して再起動',
     retry: '再試行',

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -39,6 +39,24 @@ export default {
     done: '完了',
   },
 
+  update: {
+    sectionTitle: 'バージョンとアップデート',
+    currentVersion: '現在のバージョン',
+    checkButton: 'アップデートを確認',
+    checking: '確認中…',
+    upToDate: '最新です',
+    newVersionFound: '新バージョン {version} があります',
+    availableTitle: '新しいバージョンがあります',
+    updateTo: '{version} にアップデート',
+    downloading: 'アップデートをダウンロード中…',
+    restarting: '再起動して更新を完了しています…',
+    failed: 'アップデートに失敗しました',
+    later: '後で',
+    updateRestart: '更新して再起動',
+    retry: '再試行',
+    dismiss: '閉じる',
+  },
+
   nav: {
     newTask: '新しいタスク',
     automations: '自動化',

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -51,6 +51,7 @@ export default {
     downloading: '업데이트 다운로드 중…',
     restarting: '업데이트를 완료하기 위해 재시작 중…',
     failed: '업데이트 실패',
+    checkFailed: '확인 실패',
     later: '나중에',
     updateRestart: '업데이트 후 재시작',
     retry: '재시도',

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -39,6 +39,24 @@ export default {
     done: '완료',
   },
 
+  update: {
+    sectionTitle: '버전 및 업데이트',
+    currentVersion: '현재 버전',
+    checkButton: '업데이트 확인',
+    checking: '확인 중…',
+    upToDate: '최신 버전입니다',
+    newVersionFound: '새 버전 {version} 사용 가능',
+    availableTitle: '새 버전이 있습니다',
+    updateTo: '{version}(으)로 업데이트',
+    downloading: '업데이트 다운로드 중…',
+    restarting: '업데이트를 완료하기 위해 재시작 중…',
+    failed: '업데이트 실패',
+    later: '나중에',
+    updateRestart: '업데이트 후 재시작',
+    retry: '재시도',
+    dismiss: '닫기',
+  },
+
   nav: {
     newTask: '새 작업',
     automations: '자동화',

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -48,6 +48,7 @@ export default {
     downloading: '正在下载更新…',
     restarting: '正在重启以完成更新…',
     failed: '更新失败',
+    checkFailed: '检查失败',
     later: '稍后',
     updateRestart: '更新并重启',
     retry: '重试',

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -36,6 +36,24 @@ export default {
     done: '完成',
   },
 
+  update: {
+    sectionTitle: '版本与更新',
+    currentVersion: '当前版本',
+    checkButton: '检查更新',
+    checking: '检查中…',
+    upToDate: '已是最新版本',
+    newVersionFound: '发现新版本 {version}',
+    availableTitle: '有新版本可用',
+    updateTo: '可更新到 {version}',
+    downloading: '正在下载更新…',
+    restarting: '正在重启以完成更新…',
+    failed: '更新失败',
+    later: '稍后',
+    updateRestart: '更新并重启',
+    retry: '重试',
+    dismiss: '关闭',
+  },
+
   nav: {
     newTask: '新建任务',
     automations: '自动化',

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -52,6 +52,7 @@ export default {
     downloading: '正在下載更新…',
     restarting: '正在重新啟動以完成更新…',
     failed: '更新失敗',
+    checkFailed: '檢查失敗',
     later: '稍後',
     updateRestart: '更新並重新啟動',
     retry: '重試',

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -40,6 +40,24 @@ export default {
     done: '完成',
   },
 
+  update: {
+    sectionTitle: '版本與更新',
+    currentVersion: '目前版本',
+    checkButton: '檢查更新',
+    checking: '檢查中…',
+    upToDate: '已是最新版本',
+    newVersionFound: '發現新版本 {version}',
+    availableTitle: '有新版本可用',
+    updateTo: '可更新到 {version}',
+    downloading: '正在下載更新…',
+    restarting: '正在重新啟動以完成更新…',
+    failed: '更新失敗',
+    later: '稍後',
+    updateRestart: '更新並重新啟動',
+    retry: '重試',
+    dismiss: '關閉',
+  },
+
   nav: {
     newTask: '新增工作',
     automations: '自動化',

--- a/web/src/lib/useAppUpdate.tsx
+++ b/web/src/lib/useAppUpdate.tsx
@@ -87,6 +87,10 @@ export function AppUpdateProvider({
       const update = await tauriCheck()
       if (update) {
         updateRef.current = update
+        // A check that finds an update re-arms the banner: the user dismissed
+        // the previous notice, but this is a fresh discovery — and the
+        // Settings row has no install button of its own.
+        setDismissed(false)
         setState((s) => ({
           ...s,
           status: 'available',

--- a/web/src/lib/useAppUpdate.tsx
+++ b/web/src/lib/useAppUpdate.tsx
@@ -100,7 +100,9 @@ export function AppUpdateProvider({
           error: '',
         }))
       } else {
-        setState((s) => ({ ...s, status: 'up-to-date' }))
+        // No update: also drop any stale version/notes from an earlier
+        // discovery so nothing renders outdated details.
+        setState((s) => ({ ...s, status: 'up-to-date', version: '', notes: '' }))
       }
     } catch (err) {
       // A failed passive startup check must never nag the user; only a manual

--- a/web/src/lib/useAppUpdate.tsx
+++ b/web/src/lib/useAppUpdate.tsx
@@ -1,0 +1,164 @@
+/**
+ * useAppUpdate — desktop auto-update flow (Tauri updater plugin), ported from
+ * jtype's useAppUpdate. Mirrors the useDesktop.ts bridge rules: everything is
+ * feature-detected via `isTauri` and the plugin packages are dynamically
+ * imported so the browser bundle never executes Tauri updater code.
+ *
+ * Flow: passive check ~4s after mount (silent on failure) → "available" →
+ * user consents via the UpdateBanner → downloadAndInstall with progress →
+ * relaunch (process plugin) swaps in the staged bundle.
+ *
+ * The state lives in a single provider (mounted once by App) and is shared
+ * through a context so the Settings "version & updates" row can trigger a
+ * manual check and reuse the same banner.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import type { Update } from '@tauri-apps/plugin-updater'
+import { isTauri } from './useDesktop'
+
+/** Delay before the passive startup check — past first paint and sidecar boot. */
+const AUTO_CHECK_DELAY_MS = 4000
+
+export type AppUpdateStatus =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'up-to-date'
+  | 'downloading'
+  | 'restarting'
+  | 'error'
+
+export interface AppUpdateState {
+  status: AppUpdateStatus
+  /** Version string of the pending update ('' when none). */
+  version: string
+  /** Release notes body of the pending update ('' when none). */
+  notes: string
+  /** Download progress ratio 0..1 (stays 0 when the size is unknown). */
+  progress: number
+  /** Error message when status === 'error'. */
+  error: string
+}
+
+export interface AppUpdateApi extends AppUpdateState {
+  /** True once the user closed the banner (hidden until the next check). */
+  dismissed: boolean
+  check: (opts?: { manual?: boolean }) => Promise<void>
+  install: () => Promise<void>
+  dismiss: () => void
+}
+
+const initialState: AppUpdateState = {
+  status: 'idle',
+  version: '',
+  notes: '',
+  progress: 0,
+  error: '',
+}
+
+const AppUpdateContext = createContext<AppUpdateApi | null>(null)
+
+export function AppUpdateProvider({
+  autoCheck = true,
+  children,
+}: {
+  autoCheck?: boolean
+  children: ReactNode
+}) {
+  const [state, setState] = useState<AppUpdateState>(initialState)
+  const [dismissed, setDismissed] = useState(false)
+  // The Update handle is imperative (downloadAndInstall); keep it out of state.
+  const updateRef = useRef<Update | null>(null)
+
+  const check = useCallback(async (opts?: { manual?: boolean }) => {
+    if (!isTauri) return
+    setState((s) => ({ ...s, status: 'checking', error: '' }))
+    try {
+      const { check: tauriCheck } = await import('@tauri-apps/plugin-updater')
+      const update = await tauriCheck()
+      if (update) {
+        updateRef.current = update
+        setState((s) => ({
+          ...s,
+          status: 'available',
+          version: update.version,
+          notes: update.body || '',
+          progress: 0,
+          error: '',
+        }))
+      } else {
+        setState((s) => ({ ...s, status: 'up-to-date' }))
+      }
+    } catch (err) {
+      // A failed passive startup check must never nag the user; only a manual
+      // check (Settings button) surfaces the error.
+      const message = err instanceof Error ? err.message : String(err)
+      setState((s) => ({ ...s, status: opts?.manual ? 'error' : 'idle', error: opts?.manual ? message : '' }))
+    }
+  }, [])
+
+  const install = useCallback(async () => {
+    const update = updateRef.current
+    if (!update) return
+    setState((s) => ({ ...s, status: 'downloading', progress: 0, error: '' }))
+    let contentLength = 0
+    let downloaded = 0
+    try {
+      await update.downloadAndInstall((event) => {
+        switch (event.event) {
+          case 'Started':
+            contentLength = event.data.contentLength ?? 0
+            break
+          case 'Progress':
+            downloaded += event.data.chunkLength
+            if (contentLength > 0) {
+              setState((s) => ({ ...s, progress: Math.min(1, downloaded / contentLength) }))
+            }
+            break
+          case 'Finished':
+            setState((s) => ({ ...s, progress: 1 }))
+            break
+        }
+      })
+      setState((s) => ({ ...s, status: 'restarting' }))
+      const { relaunch } = await import('@tauri-apps/plugin-process')
+      await relaunch()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setState((s) => ({ ...s, status: 'error', error: message }))
+    }
+  }, [])
+
+  const dismiss = useCallback(() => setDismissed(true), [])
+
+  // Passive startup check. Skipped entirely in dev mode — the dev app version
+  // (from tauri.conf.json) would otherwise "update" over the dev session.
+  useEffect(() => {
+    if (!autoCheck || !isTauri || import.meta.env.DEV) return
+    const timer = window.setTimeout(() => {
+      void check()
+    }, AUTO_CHECK_DELAY_MS)
+    return () => window.clearTimeout(timer)
+  }, [autoCheck, check])
+
+  return (
+    <AppUpdateContext.Provider value={{ ...state, dismissed, check, install, dismiss }}>
+      {children}
+    </AppUpdateContext.Provider>
+  )
+}
+
+export function useAppUpdate(): AppUpdateApi {
+  const ctx = useContext(AppUpdateContext)
+  if (!ctx) throw new Error('useAppUpdate must be used within <AppUpdateProvider>')
+  return ctx
+}


### PR DESCRIPTION
## Summary

Brings jtype's desktop auto-update flow to jcode: the desktop shell checks GitHub Releases for a newer version shortly after startup, shows a bottom-right banner (version + release notes + download progress), and installs the signed update in place on consent, then relaunches.

### Desktop shell (Rust)
- Bundle `tauri-plugin-updater` (desktop-only) + `tauri-plugin-process`; feed: `releases/latest/download/latest.json`, verified against a minisign pubkey in `tauri.conf.json`.
- `bundle.createUpdaterArtifacts` is deliberately **absent from the committed conf** — with it set, every local `tauri build` hard-fails without `TAURI_SIGNING_PRIVATE_KEY` (tauri-apps/tauri#9134). CI flips it on per build, so `make desktop-build` stays key-free.

### Frontend (web/)
- `useAppUpdate.tsx`: state machine + progress + context provider; passive check ~4s after mount, skipped in `tauri dev` and browser builds; passive failures stay silent (only the manual check surfaces errors).
- `UpdateBanner.tsx`: bottom-right toast — new version + notes (3-line clamp) + progress bar + 更新并重启 / 稍后 / 重试; theme tokens + heroicons only.
- Settings → General: "version & updates" row (current app version via `getVersion()` + manual check).
- i18n: `update.*` keys in all five locales.

### CI (release.yml)
- Desktop matrix legs ship signed updater artifacts (per-arch macOS `.app.tar.gz` renamed by matrix label to avoid collisions, Windows NSIS `-setup.exe`, Linux `.AppImage`) plus `.sig` and a per-platform fragment; the release job merges fragments into `latest.json` attached to the release.
- A missing `.sig` fails the build loudly instead of shipping an unsigned feed.

### Docs
- `site/docs/desktop.md`: new Auto-update section + troubleshooting entry.
- `site/docs/release.md`: `TAURI_SIGNING_PRIVATE_KEY` secret table + feed generation flow.

## Notes

- **Secret required**: `TAURI_SIGNING_PRIVATE_KEY` (already configured; key generated without a password, so `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` stays unset).
- **Stable channel only**: the feed resolves via `/releases/latest`, so alpha/beta/rc tags never auto-update.
- Existing installs ≤0.5.3 (no updater) need one manual upgrade to bootstrap the chain.

## Test plan

- [x] `cargo check` in `desktop/src-tauri` (plugin wiring + conf schema)
- [x] `make lint-web`, `cd web && pnpm typecheck && pnpm test` (163 tests)
- [x] `make build-web` (dynamic plugin imports bundle cleanly)
- [x] `release.yml` YAML validated; desktop/release job step order reviewed
- [x] First tagged release exercises signing + `latest.json` end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic update checks for desktop installations.
  * Added update notifications with version details, download progress, restart, retry, and dismiss actions.
  * Added manual update checks and status information in Settings.
  * Added signed update packages for supported desktop platforms.
  * Added localized update messages in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

* **Documentation**
  * Documented desktop update behavior, supported packages, release requirements, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->