### PR TITLE
feat: support file drops across browser and desktop

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -18,11 +18,23 @@ fail() { echo "" >&2; echo "✗ pre-push: $1" >&2; echo "  (bypass with: git pus
 # that distinction here so a local main push cannot pass a weaker check than
 # the GitHub job.
 pushes_main=0
-while read -r _local_ref _local_oid remote_ref _remote_oid; do
+push_count=0
+pushed_oid=""
+zero_oid=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
+while read -r _local_ref local_oid remote_ref _remote_oid; do
+	[ "$local_oid" = "$zero_oid" ] && continue
+	push_count=$((push_count + 1))
+	pushed_oid=$local_oid
 	if [ "$remote_ref" = "refs/heads/main" ]; then
 		pushes_main=1
 	fi
 done
+if [ "$push_count" -eq 0 ]; then
+	exit 0
+fi
+if [ "$push_count" -ne 1 ] || [ "$pushed_oid" != "$(git rev-parse HEAD)" ]; then
+	fail "pushes of multiple or non-current refs are not supported; check out and push one branch at a time"
+fi
 
 # The module embeds internal/web/dist via //go:embed and depends on generated
 # code — without them nothing compiles. Don't silently run the heavy
@@ -46,8 +58,10 @@ if command -v golangci-lint >/dev/null 2>&1; then
 		golangci-lint run ./... || fail "golangci-lint found issues"
 	else
 		echo "==> golangci-lint (new issues vs origin/main)..."
-		git fetch -q origin main 2>/dev/null || true
-		base=$(git merge-base HEAD origin/main 2>/dev/null || true)
+		base=""
+		if git fetch -q origin main 2>/dev/null; then
+			base=$(git merge-base "$pushed_oid" origin/main 2>/dev/null || true)
+		fi
 		if [ -n "$base" ]; then
 			golangci-lint run --new-from-rev="$base" ./... || fail "golangci-lint found new issues"
 		else

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -13,6 +13,17 @@ cd "$(git rev-parse --show-toplevel)"
 
 fail() { echo "" >&2; echo "✗ pre-push: $1" >&2; echo "  (bypass with: git push --no-verify)" >&2; exit 1; }
 
+# Git passes every ref update on stdin. CI runs a full lint on pushes to main,
+# but PR/feature branches only gate issues introduced since origin/main. Keep
+# that distinction here so a local main push cannot pass a weaker check than
+# the GitHub job.
+pushes_main=0
+while read -r _local_ref _local_oid remote_ref _remote_oid; do
+	if [ "$remote_ref" = "refs/heads/main" ]; then
+		pushes_main=1
+	fi
+done
+
 # The module embeds internal/web/dist via //go:embed and depends on generated
 # code — without them nothing compiles. Don't silently run the heavy
 # `make generate build-web` here; just point the way if it's missing.
@@ -26,17 +37,22 @@ go build ./... || fail "build failed"
 echo "==> go vet ./..."
 go vet ./... || fail "go vet reported problems"
 
-# golangci-lint: gate only NEW issues vs origin/main, exactly like CI, so
-# pre-existing lint debt doesn't block the push. Skip (with a warning) if the
-# tool isn't installed rather than blocking on a missing dependency.
+# golangci-lint: full run for pushes to main; new issues vs origin/main for
+# feature branches, exactly like CI. Skip (with a warning) if the tool isn't
+# installed rather than blocking on a missing dependency.
 if command -v golangci-lint >/dev/null 2>&1; then
-	echo "==> golangci-lint (new issues vs origin/main)..."
-	git fetch -q origin main 2>/dev/null || true
-	base=$(git merge-base HEAD origin/main 2>/dev/null || true)
-	if [ -n "$base" ]; then
-		golangci-lint run --new-from-rev="$base" ./... || fail "golangci-lint found new issues"
-	else
+	if [ "$pushes_main" = "1" ]; then
+		echo "==> golangci-lint (full run for main)..."
 		golangci-lint run ./... || fail "golangci-lint found issues"
+	else
+		echo "==> golangci-lint (new issues vs origin/main)..."
+		git fetch -q origin main 2>/dev/null || true
+		base=$(git merge-base HEAD origin/main 2>/dev/null || true)
+		if [ -n "$base" ]; then
+			golangci-lint run --new-from-rev="$base" ./... || fail "golangci-lint found new issues"
+		else
+			golangci-lint run ./... || fail "golangci-lint found issues"
+		fi
 	fi
 else
 	echo "⚠  golangci-lint not installed — skipping (install: https://golangci-lint.run/welcome/install/)"

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ setup-hooks:
 	@git config core.hooksPath .githooks
 	@echo "Git hooks installed (core.hooksPath = .githooks):"
 	@echo "  pre-commit  fast gofmt/goimports gate on staged Go files"
-	@echo "  pre-push    CI mirror: build + vet + golangci-lint (new issues) + test"
+	@echo "  pre-push    CI mirror: build + vet + golangci-lint (main: full; branches: new issues) + test"
 	@echo "Bypass with --no-verify; skip only tests via 'SKIP_TESTS=1 git push'."
 
 # ─── Desktop app (Tauri) ───

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
+base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
@@ -32,18 +33,15 @@ tauri-plugin-global-shortcut = "2"
 tauri-plugin-updater = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-base64 = "0.22"
 icns = { version = "0.4", default-features = false, features = ["pngio"] }
 objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSWorkspace"] }
 objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSArray", "NSString", "NSURL"] }
 plist = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-base64 = "0.22"
 shlex = "1.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-base64 = "0.22"
 png = "0.18"
 windows-sys = { version = "0.61", features = [
   "Win32_Foundation",

--- a/desktop/src-tauri/src/dropped_files.rs
+++ b/desktop/src-tauri/src/dropped_files.rs
@@ -1,0 +1,106 @@
+//! Narrow bridge for turning user-dropped image paths into chat attachments.
+//!
+//! Tauri's native drag/drop event exposes absolute paths, while the webview's
+//! `File` objects do not. Keep arbitrary files as paths in the prompt; only
+//! read the image formats already supported by the chat composer, with the
+//! same 10 MiB ceiling as browser-selected images.
+
+use std::fs;
+use std::path::Path;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::Serialize;
+
+const MAX_DROPPED_IMAGE_BYTES: u64 = 10 * 1024 * 1024;
+
+#[derive(Debug, Serialize)]
+pub struct DroppedImage {
+    data: String,
+    media_type: &'static str,
+    name: String,
+}
+
+#[tauri::command]
+pub fn read_dropped_image(path: String) -> Result<Option<DroppedImage>, String> {
+    let path = Path::new(&path);
+    let Some(media_type) = image_media_type(path) else {
+        return Ok(None);
+    };
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => metadata,
+        Ok(_) | Err(_) => return Ok(None),
+    };
+    if metadata.len() > MAX_DROPPED_IMAGE_BYTES {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(path).map_err(|error| format!("read dropped image: {error}"))?;
+    let name = path
+        .file_name()
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "attachment".to_owned());
+    Ok(Some(DroppedImage {
+        data: STANDARD.encode(bytes),
+        media_type,
+        name,
+    }))
+}
+
+fn image_media_type(path: &Path) -> Option<&'static str> {
+    match path
+        .extension()?
+        .to_string_lossy()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_supported_image_as_base64() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("sample.png");
+        fs::write(&path, b"png-bytes").expect("write image");
+
+        let image = read_dropped_image(path.to_string_lossy().into_owned())
+            .expect("read dropped image")
+            .expect("supported image");
+
+        assert_eq!(image.media_type, "image/png");
+        assert_eq!(image.name, "sample.png");
+        assert_eq!(image.data, STANDARD.encode(b"png-bytes"));
+    }
+
+    #[test]
+    fn leaves_non_images_for_prompt_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("notes.pdf");
+        fs::write(&path, b"pdf").expect("write file");
+
+        assert!(read_dropped_image(path.to_string_lossy().into_owned())
+            .expect("classify dropped file")
+            .is_none());
+    }
+
+    #[test]
+    fn leaves_oversized_images_for_prompt_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("large.webp");
+        let file = fs::File::create(&path).expect("create image");
+        file.set_len(MAX_DROPPED_IMAGE_BYTES + 1)
+            .expect("size image");
+
+        assert!(read_dropped_image(path.to_string_lossy().into_owned())
+            .expect("classify dropped image")
+            .is_none());
+    }
+}

--- a/desktop/src-tauri/src/dropped_files.rs
+++ b/desktop/src-tauri/src/dropped_files.rs
@@ -35,6 +35,9 @@ pub fn read_dropped_image(path: String) -> Result<Option<DroppedImage>, String> 
     }
 
     let bytes = fs::read(path).map_err(|error| format!("read dropped image: {error}"))?;
+    if detected_image_media_type(&bytes) != Some(media_type) {
+        return Ok(None);
+    }
     let name = path
         .file_name()
         .map(|value| value.to_string_lossy().into_owned())
@@ -44,6 +47,22 @@ pub fn read_dropped_image(path: String) -> Result<Option<DroppedImage>, String> 
         media_type,
         name,
     }))
+}
+
+fn detected_image_media_type(data: &[u8]) -> Option<&'static str> {
+    if data.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Some("image/png");
+    }
+    if data.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Some("image/jpeg");
+    }
+    if data.starts_with(b"GIF87a") || data.starts_with(b"GIF89a") {
+        return Some("image/gif");
+    }
+    if data.len() >= 12 && &data[..4] == b"RIFF" && &data[8..12] == b"WEBP" {
+        return Some("image/webp");
+    }
+    None
 }
 
 fn image_media_type(path: &Path) -> Option<&'static str> {
@@ -69,7 +88,8 @@ mod tests {
     fn reads_supported_image_as_base64() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("sample.png");
-        fs::write(&path, b"png-bytes").expect("write image");
+        let bytes = b"\x89PNG\r\n\x1a\npng-bytes";
+        fs::write(&path, bytes).expect("write image");
 
         let image = read_dropped_image(path.to_string_lossy().into_owned())
             .expect("read dropped image")
@@ -77,7 +97,7 @@ mod tests {
 
         assert_eq!(image.media_type, "image/png");
         assert_eq!(image.name, "sample.png");
-        assert_eq!(image.data, STANDARD.encode(b"png-bytes"));
+        assert_eq!(image.data, STANDARD.encode(bytes));
     }
 
     #[test]
@@ -101,6 +121,22 @@ mod tests {
 
         assert!(read_dropped_image(path.to_string_lossy().into_owned())
             .expect("classify dropped image")
+            .is_none());
+    }
+
+    #[test]
+    fn leaves_invalid_or_mismatched_images_for_prompt_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake = dir.path().join("fake.png");
+        fs::write(&fake, b"not-an-image").expect("write fake image");
+        assert!(read_dropped_image(fake.to_string_lossy().into_owned())
+            .expect("classify fake image")
+            .is_none());
+
+        let mismatch = dir.path().join("mismatch.jpg");
+        fs::write(&mismatch, b"\x89PNG\r\n\x1a\npng-bytes").expect("write mismatch");
+        assert!(read_dropped_image(mismatch.to_string_lossy().into_owned())
+            .expect("classify mismatched image")
             .is_none());
     }
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod desktop_apps;
+mod dropped_files;
 mod shell_env;
 mod sidecar;
 mod tray;
@@ -118,6 +119,7 @@ fn main() {
         .manage(DesktopState::default())
         .invoke_handler(tauri::generate_handler![
             get_sidecar_port,
+            dropped_files::read_dropped_image,
             desktop_apps::list_workspace_applications,
             desktop_apps::open_workspace_in_application
         ])

--- a/internal/agent/tool_observation_test.go
+++ b/internal/agent/tool_observation_test.go
@@ -101,7 +101,7 @@ func TestToolObservationTracksVisibilitySearchAndBypassWithoutPayloads(t *testin
 	directInfo, _ := direct.Info(ctx)
 	searchInfo := &schema.ToolInfo{Name: ToolSearchReservedName, Desc: "search"}
 	if _, err := middleware.WrapModel(ctx, nil, &adk.ModelContext{
-		Tools: []*schema.ToolInfo{directInfo, searchInfo},
+		Tools: []*schema.ToolInfo{directInfo, searchInfo}, //nolint:staticcheck // exercise the intentional final-attempt compatibility hook
 	}); err != nil {
 		t.Fatalf("WrapModel() error = %v", err)
 	}
@@ -137,7 +137,7 @@ func TestToolObservationTracksVisibilitySearchAndBypassWithoutPayloads(t *testin
 
 	deferredInfo, _ := deferred.Info(ctx)
 	if _, err := middleware.WrapModel(ctx, nil, &adk.ModelContext{
-		Tools: []*schema.ToolInfo{directInfo, searchInfo, deferredInfo},
+		Tools: []*schema.ToolInfo{directInfo, searchInfo, deferredInfo}, //nolint:staticcheck // exercise the intentional final-attempt compatibility hook
 	}); err != nil {
 		t.Fatalf("second WrapModel() error = %v", err)
 	}

--- a/internal/command/mode_helpers_test.go
+++ b/internal/command/mode_helpers_test.go
@@ -22,8 +22,8 @@ func TestResolveStartupMode(t *testing.T) {
 		{"default_mode plan", &config.Config{DefaultMode: "plan"}, false, mode.Plan},
 		{"default_mode auto", &config.Config{DefaultMode: "auto"}, false, mode.Auto},
 		{"default_mode full access", &config.Config{DefaultMode: "full_access"}, false, mode.FullAccess},
-		{"default_mode wins over auto_approve", &config.Config{DefaultMode: "approval", AutoApprove: true}, false, mode.Approval},
-		{"legacy auto_approve fallback", &config.Config{AutoApprove: true}, false, mode.FullAccess},
+		{"default_mode wins over auto_approve", &config.Config{DefaultMode: "approval", AutoApprove: true}, false, mode.Approval}, //nolint:staticcheck // compatibility precedence test
+		{"legacy auto_approve fallback", &config.Config{AutoApprove: true}, false, mode.FullAccess},                               //nolint:staticcheck // compatibility fallback test
 		{"empty defaults to approval", &config.Config{}, false, mode.Approval},
 		{"nil cfg defaults to approval", nil, false, mode.Approval},
 	}

--- a/internal/computer/configmap_test.go
+++ b/internal/computer/configmap_test.go
@@ -9,7 +9,7 @@ import (
 func TestFromConfigIgnoresSafeLegacyBackend(t *testing.T) {
 	for _, backend := range []string{"", "auto", " helper "} {
 		c := &config.ComputerConfig{
-			Enabled: true, Backend: backend,
+			Enabled: true, Backend: backend, //nolint:staticcheck // compatibility migration input
 			Approval:        map[string]string{"launch": "always_allow"},
 			AppPermissions:  []config.ComputerAppPermission{{BundleID: notesID, Tier: "read"}},
 			ClipboardRead:   true,
@@ -27,7 +27,7 @@ func TestFromConfigIgnoresSafeLegacyBackend(t *testing.T) {
 func TestFromConfigFailsClosedForUnsafeLegacyBackend(t *testing.T) {
 	for _, backend := range []string{"fake", "osa", "unknown"} {
 		c := &config.ComputerConfig{
-			Enabled: true, Backend: backend,
+			Enabled: true, Backend: backend, //nolint:staticcheck // compatibility migration input
 			Approval:        map[string]string{"launch": "always_allow"},
 			AppPermissions:  []config.ComputerAppPermission{{BundleID: notesID, Tier: "read", Launch: "allow"}},
 			ClipboardRead:   true,

--- a/internal/tools/computer_multimodal_test.go
+++ b/internal/tools/computer_multimodal_test.go
@@ -26,7 +26,7 @@ func TestComputerScreenshotToolReturnsTextAndPNG(t *testing.T) {
 		PNG: png, X: 120, Y: 80, Width: 900, Height: 600, PixelWidth: 1800, PixelHeight: 1200,
 	})
 
-	mgr := computer.NewManager(computer.Config{Enabled: true, Backend: "fake"}, home)
+	mgr := computer.NewManager(computer.Config{Enabled: true}, home)
 	mgr.SetFakeBackend(fake)
 	env := NewEnv(t.TempDir(), "darwin")
 	env.Computer = mgr
@@ -105,7 +105,8 @@ func TestComputerScreenshotToolReturnsTextAndPNG(t *testing.T) {
 
 func TestComputerPlanScreenshotIsEnhanced(t *testing.T) {
 	env := NewEnv(t.TempDir(), "darwin")
-	env.Computer = computer.NewManager(computer.Config{Enabled: true, Backend: "fake"}, t.TempDir())
+	env.Computer = computer.NewManager(computer.Config{Enabled: true}, t.TempDir())
+	env.Computer.SetFakeBackend(computer.NewFake())
 	for _, candidate := range env.NewComputerPlanTools() {
 		info, err := candidate.Info(context.Background())
 		if err != nil {

--- a/internal/tui/goal_test.go
+++ b/internal/tui/goal_test.go
@@ -14,7 +14,7 @@ import (
 func TestHandleGoalInput(t *testing.T) {
 	// Set with a plain objective.
 	m := Model{goalStore: tools.NewGoalStore()}
-	m.handleGoalInput("/goal Build the feature", nil)
+	m.handleGoalInput("/goal Build the feature")
 	if !m.goalStore.IsActive() {
 		t.Fatal("/goal <obj> should create an active goal")
 	}
@@ -26,21 +26,21 @@ func TestHandleGoalInput(t *testing.T) {
 	}
 
 	m2 := Model{goalStore: tools.NewGoalStore()}
-	m2.handleGoalInput("/goal Migrate DB", nil)
+	m2.handleGoalInput("/goal Migrate DB")
 	g := m2.goalStore.Get()
 	if g == nil || g.Objective != "Migrate DB" {
 		t.Fatalf("goal = %+v", g)
 	}
 
 	// Clear.
-	m2.handleGoalInput("/goal clear", nil)
+	m2.handleGoalInput("/goal clear")
 	if m2.goalStore.Has() {
 		t.Fatal("/goal clear should remove the goal")
 	}
 
 	// Status on an empty store must not panic and must not set a goal.
 	m3 := Model{goalStore: tools.NewGoalStore()}
-	m3.handleGoalInput("/goal", nil)
+	m3.handleGoalInput("/goal")
 	if m3.goalStore.Has() {
 		t.Fatal("/goal status should not create a goal")
 	}
@@ -49,7 +49,7 @@ func TestHandleGoalInput(t *testing.T) {
 	// kickoff prompt (the in-flight run's continuation guard picks it up);
 	// a blocking channel send here would freeze the UI.
 	m4 := Model{goalStore: tools.NewGoalStore(), thinking: true, agentDone: false}
-	_, cmd := m4.handleGoalInput("/goal Fix the tests", nil)
+	_, cmd := m4.handleGoalInput("/goal Fix the tests")
 	if !m4.goalStore.IsActive() {
 		t.Fatal("/goal while running should still set the goal")
 	}

--- a/internal/tui/input_views.go
+++ b/internal/tui/input_views.go
@@ -348,7 +348,8 @@ func (m *Model) handleCompactInput(cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 
 // handleGoalInput handles `/goal` (status), `/goal clear`, and
 // `/goal <objective>` (set + start working toward it).
-func (m *Model) handleGoalInput(prompt string, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+func (m *Model) handleGoalInput(prompt string) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
 	refresh := func() {
 		if m.ready {
 			m.viewport.SetHeight(m.calcViewportHeight(m.inputActive()))

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -863,7 +863,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:funlen
 					}
 
 					if prompt == "/goal" || strings.HasPrefix(prompt, "/goal ") {
-						return m.handleGoalInput(prompt, cmds)
+						return m.handleGoalInput(prompt)
 					}
 
 					if prompt == "/channel" {

--- a/internal/web/computer_test.go
+++ b/internal/web/computer_test.go
@@ -21,7 +21,7 @@ import (
 func TestComputerStatusReturnsCanonicalGrantConfig(t *testing.T) {
 	cfg := &config.Config{Computer: &config.ComputerConfig{
 		Enabled:         false,
-		Backend:         "fake", // migration-only field must never reach REST
+		Backend:         "fake", //nolint:staticcheck // migration-only field must never reach REST
 		ClipboardRead:   true,
 		ClipboardWrite:  true,
 		SystemKeyCombos: true,

--- a/internal/web/engine.go
+++ b/internal/web/engine.go
@@ -51,6 +51,11 @@ type Engine struct {
 	// client never observes the durable revision between fsync and the prepared
 	// agent/catalog publication.
 	toolOverrideMu sync.Mutex
+	// uploadMu serializes task-scoped file persistence with session deletion.
+	// uploadGeneration invalidates a request that finished reading its multipart
+	// body after the owning session was deleted or reset.
+	uploadMu         sync.Mutex
+	uploadGeneration uint64
 	// retired permanently closes this engine to new run/focus claims. Lifecycle
 	// transitions set it while holding Server.tasksMu -> Server.mu; readers use
 	// the atomic fast-path after resolving an engine pointer.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -467,6 +467,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("GET /api/files", s.handleListFiles)
 	mux.HandleFunc("GET /api/files/content", s.handleReadFile)
 	mux.HandleFunc("GET /api/tasks/{id}/artifacts", s.handleListArtifacts)
+	mux.HandleFunc("POST /api/tasks/{id}/uploads", s.handleTaskUpload)
 	mux.HandleFunc("GET /api/tasks/{id}/artifacts/{artifactID}/content", s.handleArtifactContent)
 	mux.HandleFunc("GET /api/tasks/{id}/artifacts/{artifactID}/download", s.handleArtifactDownload)
 	mux.HandleFunc("PATCH /api/tasks/{id}/artifacts/viewed", s.handleArtifactsViewed)

--- a/internal/web/sessions.go
+++ b/internal/web/sessions.go
@@ -245,6 +245,11 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "agent is currently running"})
 		return
 	}
+	uploadLocked := eng != nil
+	if uploadLocked {
+		eng.uploadMu.Lock()
+		eng.uploadGeneration++
+	}
 	var teardown *Engine
 	if eng != nil && !eng.retired.Load() {
 		if s.Engine == eng {
@@ -272,6 +277,12 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 	if teardown != nil {
 		teardown.teardown()
 	}
+	if deleteErr == nil {
+		removeLocalTaskUploads(id)
+	}
+	if uploadLocked {
+		eng.uploadMu.Unlock()
+	}
 	if deleteErr != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": deleteErr.Error()})
 		return
@@ -281,7 +292,6 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 	} else if err := store.Delete(id); err != nil {
 		config.Logger().Printf("[cloud] failed to remove deleted session %s from sync store: %v", id, err)
 	}
-	removeLocalTaskUploads(id)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 

--- a/internal/web/sessions.go
+++ b/internal/web/sessions.go
@@ -281,6 +281,7 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 	} else if err := store.Delete(id); err != nil {
 		config.Logger().Printf("[cloud] failed to remove deleted session %s from sync store: %v", id, err)
 	}
+	removeLocalTaskUploads(id)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 

--- a/internal/web/uploads.go
+++ b/internal/web/uploads.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -47,6 +48,9 @@ func (s *Server) handleTaskUpload(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "wait for the current turn to finish before uploading files"})
 		return
 	}
+	eng.uploadMu.Lock()
+	uploadGeneration := eng.uploadGeneration
+	eng.uploadMu.Unlock()
 
 	name, data, err := readTaskUpload(w, r, maxTaskUploadBytes)
 	if err != nil {
@@ -59,26 +63,80 @@ func (s *Server) handleTaskUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	safeName, err := uniqueUploadName(name)
+	response, err := s.saveTaskUpload(r.Context(), taskID, eng, uploadGeneration, name, data)
+	if errors.Is(err, errUploadTaskChanged) || errors.Is(err, errUploadTaskRunning) {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	}
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not allocate upload filename"})
-		return
-	}
-	dir, remote := taskUploadDir(eng, taskID)
-	if err := prepareUploadDir(r, eng, dir, remote); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not prepare task upload directory"})
-		return
-	}
-	target := joinUploadPath(dir, safeName, remote)
-	if err := eng.env.Exec.WriteFile(r.Context(), target, data, uploadFileMode); err != nil {
-		config.Logger().Printf("[web] task upload write failed for %s: %v", taskID, err)
+		config.Logger().Printf("[web] task upload save failed for %s: %v", taskID, err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not save uploaded file"})
 		return
 	}
-	writeJSON(w, http.StatusCreated, taskUploadResponse{Path: target, Name: safeName, Size: int64(len(data))})
+	writeJSON(w, http.StatusCreated, response)
 }
 
-var errUploadTooLarge = errors.New("task upload exceeds size limit")
+var (
+	errUploadTooLarge    = errors.New("task upload exceeds size limit")
+	errUploadTaskChanged = errors.New("task changed while the file was uploading")
+	errUploadTaskRunning = errors.New("wait for the current turn to finish before uploading files")
+)
+
+func (s *Server) saveTaskUpload(
+	ctx context.Context,
+	taskID string,
+	expected *Engine,
+	generation uint64,
+	originalName string,
+	data []byte,
+) (taskUploadResponse, error) {
+	eng, ok := s.lockTaskUpload(taskID, expected, generation)
+	if !ok {
+		return taskUploadResponse{}, errUploadTaskChanged
+	}
+	defer eng.uploadMu.Unlock()
+	if eng.running.Load() {
+		return taskUploadResponse{}, errUploadTaskRunning
+	}
+	safeName, err := uniqueUploadName(originalName)
+	if err != nil {
+		return taskUploadResponse{}, fmt.Errorf("allocate upload filename: %w", err)
+	}
+	dir, remote := taskUploadDir(eng, taskID)
+	if err := prepareUploadDir(ctx, eng, dir, remote); err != nil {
+		return taskUploadResponse{}, err
+	}
+	target := joinUploadPath(dir, safeName, remote)
+	if err := eng.env.Exec.WriteFile(ctx, target, data, uploadFileMode); err != nil {
+		return taskUploadResponse{}, fmt.Errorf("write uploaded file %q: %w", target, err)
+	}
+	return taskUploadResponse{Path: target, Name: safeName, Size: int64(len(data))}, nil
+}
+
+// lockTaskUpload follows the lifecycle lock order tasksMu -> mu -> uploadMu,
+// then releases the global locks. Deletion takes the same per-engine lock and
+// bumps uploadGeneration before removing the session and managed files.
+func (s *Server) lockTaskUpload(taskID string, expected *Engine, generation uint64) (*Engine, bool) {
+	s.tasksMu.RLock()
+	s.mu.RLock()
+	eng := s.tasks[taskID]
+	if eng == nil && s.Engine != nil && s.taskID == taskID {
+		eng = s.Engine
+	}
+	if eng == nil {
+		s.mu.RUnlock()
+		s.tasksMu.RUnlock()
+		return nil, false
+	}
+	eng.uploadMu.Lock()
+	s.mu.RUnlock()
+	s.tasksMu.RUnlock()
+	if eng != expected || eng.retired.Load() || eng.uploadGeneration != generation {
+		eng.uploadMu.Unlock()
+		return nil, false
+	}
+	return eng, true
+}
 
 func readTaskUpload(w http.ResponseWriter, r *http.Request, maxBytes int64) (string, []byte, error) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBytes+multipartOverheadCap)
@@ -110,17 +168,20 @@ func taskUploadDir(eng *Engine, taskID string) (string, bool) {
 	return filepath.Join(config.ConfigDir(), "uploads", taskID), false
 }
 
-func prepareUploadDir(r *http.Request, eng *Engine, dir string, remote bool) error {
+func prepareUploadDir(ctx context.Context, eng *Engine, dir string, remote bool) error {
 	if !remote {
 		if err := os.MkdirAll(dir, localUploadDirMode); err != nil {
-			return err
+			return fmt.Errorf("create local upload directory %q: %w", dir, err)
 		}
-		return os.Chmod(dir, localUploadDirMode)
+		if err := os.Chmod(dir, localUploadDirMode); err != nil {
+			return fmt.Errorf("set local upload directory mode %q: %w", dir, err)
+		}
+		return nil
 	}
-	if err := eng.env.Exec.MkdirAll(r.Context(), dir, localUploadDirMode); err != nil {
-		return err
+	if err := eng.env.Exec.MkdirAll(ctx, dir, localUploadDirMode); err != nil {
+		return fmt.Errorf("create remote upload directory %q: %w", dir, err)
 	}
-	_, stderr, err := eng.env.Exec.Exec(r.Context(), "chmod 700 "+tools.ShellQuote(dir), "", 10*time.Second)
+	_, stderr, err := eng.env.Exec.Exec(ctx, "chmod 700 "+tools.ShellQuote(dir), "", 10*time.Second)
 	if err != nil {
 		return fmt.Errorf("secure remote upload directory: %s: %w", strings.TrimSpace(stderr), err)
 	}

--- a/internal/web/uploads.go
+++ b/internal/web/uploads.go
@@ -1,0 +1,182 @@
+package web
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/cnjack/jcode/internal/config"
+	"github.com/cnjack/jcode/internal/session"
+	"github.com/cnjack/jcode/internal/tools"
+)
+
+const (
+	maxTaskUploadBytes   int64 = 100 << 20
+	multipartOverheadCap int64 = 1 << 20
+	localUploadDirMode         = 0o700
+	uploadFileMode             = 0o600
+)
+
+type taskUploadResponse struct {
+	Path string `json:"path"`
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+func (s *Server) handleTaskUpload(w http.ResponseWriter, r *http.Request) {
+	taskID := r.PathValue("id")
+	if err := session.ValidateSessionID(taskID); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid task id"})
+		return
+	}
+	eng := s.resolveEngine(taskID)
+	if eng == nil || eng.env == nil || eng.env.Exec == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task is not available"})
+		return
+	}
+	if eng.running.Load() {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "wait for the current turn to finish before uploading files"})
+		return
+	}
+
+	name, data, err := readTaskUpload(w, r, maxTaskUploadBytes)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) || errors.Is(err, errUploadTooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "file exceeds the 100MB upload limit"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	safeName, err := uniqueUploadName(name)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not allocate upload filename"})
+		return
+	}
+	dir, remote := taskUploadDir(eng, taskID)
+	if err := prepareUploadDir(r, eng, dir, remote); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not prepare task upload directory"})
+		return
+	}
+	target := joinUploadPath(dir, safeName, remote)
+	if err := eng.env.Exec.WriteFile(r.Context(), target, data, uploadFileMode); err != nil {
+		config.Logger().Printf("[web] task upload write failed for %s: %v", taskID, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not save uploaded file"})
+		return
+	}
+	writeJSON(w, http.StatusCreated, taskUploadResponse{Path: target, Name: safeName, Size: int64(len(data))})
+}
+
+var errUploadTooLarge = errors.New("task upload exceeds size limit")
+
+func readTaskUpload(w http.ResponseWriter, r *http.Request, maxBytes int64) (string, []byte, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes+multipartOverheadCap)
+	if err := r.ParseMultipartForm(8 << 20); err != nil {
+		return "", nil, fmt.Errorf("parse multipart upload: %w", err)
+	}
+	if r.MultipartForm != nil {
+		defer func() { _ = r.MultipartForm.RemoveAll() }()
+	}
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		return "", nil, errors.New("multipart field \"file\" is required")
+	}
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return "", nil, fmt.Errorf("read uploaded file: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return "", nil, errUploadTooLarge
+	}
+	return header.Filename, data, nil
+}
+
+func taskUploadDir(eng *Engine, taskID string) (string, bool) {
+	if eng != nil && eng.env != nil && eng.env.IsRemote() {
+		return pathpkg.Join("/tmp", ".jcode-uploads-"+taskID), true
+	}
+	return filepath.Join(config.ConfigDir(), "uploads", taskID), false
+}
+
+func prepareUploadDir(r *http.Request, eng *Engine, dir string, remote bool) error {
+	if !remote {
+		if err := os.MkdirAll(dir, localUploadDirMode); err != nil {
+			return err
+		}
+		return os.Chmod(dir, localUploadDirMode)
+	}
+	if err := eng.env.Exec.MkdirAll(r.Context(), dir, localUploadDirMode); err != nil {
+		return err
+	}
+	_, stderr, err := eng.env.Exec.Exec(r.Context(), "chmod 700 "+tools.ShellQuote(dir), "", 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("secure remote upload directory: %s: %w", strings.TrimSpace(stderr), err)
+	}
+	return nil
+}
+
+func joinUploadPath(dir, name string, remote bool) string {
+	if remote {
+		return pathpkg.Join(dir, name)
+	}
+	return filepath.Join(dir, name)
+}
+
+func uniqueUploadName(original string) (string, error) {
+	name := sanitizeUploadName(original)
+	ext := filepath.Ext(name)
+	stem := strings.TrimSuffix(name, ext)
+	var entropy [3]byte
+	if _, err := rand.Read(entropy[:]); err != nil {
+		return "", err
+	}
+	return stem + "-" + hex.EncodeToString(entropy[:]) + ext, nil
+}
+
+func sanitizeUploadName(name string) string {
+	name = pathpkg.Base(strings.ReplaceAll(name, "\\", "/"))
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), strings.ContainsRune("-_. ", r):
+			b.WriteRune(r)
+		case unicode.IsControl(r):
+			continue
+		default:
+			b.WriteByte('_')
+		}
+	}
+	name = strings.TrimSpace(strings.TrimLeft(b.String(), "."))
+	if name == "" {
+		return "attachment"
+	}
+	runes := []rune(name)
+	if len(runes) > 120 {
+		extRunes := []rune(filepath.Ext(name))
+		if len(extRunes) > 20 {
+			extRunes = extRunes[:20]
+		}
+		keep := 120 - len(extRunes)
+		name = string(runes[:keep]) + string(extRunes)
+	}
+	return name
+}
+
+func removeLocalTaskUploads(taskID string) {
+	if session.ValidateSessionID(taskID) != nil {
+		return
+	}
+	_ = os.RemoveAll(filepath.Join(config.ConfigDir(), "uploads", taskID))
+}

--- a/internal/web/uploads_test.go
+++ b/internal/web/uploads_test.go
@@ -181,3 +181,27 @@ func TestTaskUploadRejectsRunningTask(t *testing.T) {
 		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
 	}
 }
+
+func TestTaskUploadRejectsDeletionAfterMultipartRead(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	env := tools.NewEnv(t.TempDir(), "darwin/arm64")
+	eng := &Engine{taskID: "task-a", pwd: env.Pwd(), env: env}
+	s := &Server{Engine: eng, tasks: map[string]*Engine{eng.taskID: eng}}
+
+	eng.uploadMu.Lock()
+	generation := eng.uploadGeneration
+	// This is the deletion-side invalidation that occurs after the request has
+	// read its multipart bytes but before it enters the persistence gate.
+	eng.uploadGeneration++
+	eng.uploadMu.Unlock()
+
+	_, err := s.saveTaskUpload(context.Background(), eng.taskID, eng, generation, "notes.txt", []byte("hello"))
+	if !errors.Is(err, errUploadTaskChanged) {
+		t.Fatalf("err=%v, want errUploadTaskChanged", err)
+	}
+	uploadDir := filepath.Join(home, ".jcode", "uploads", eng.taskID)
+	if _, err := os.Stat(uploadDir); !os.IsNotExist(err) {
+		t.Fatalf("stale upload created files after deletion: %v", err)
+	}
+}

--- a/internal/web/uploads_test.go
+++ b/internal/web/uploads_test.go
@@ -1,0 +1,183 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cnjack/jcode/internal/tools"
+)
+
+func taskUploadRequest(t *testing.T, taskID, filename string, data []byte) *http.Request {
+	t.Helper()
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	part, err := w.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/"+taskID+"/uploads", &body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.SetPathValue("id", taskID)
+	return req
+}
+
+func TestTaskUploadStoresManagedLocalCopy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	workspace := t.TempDir()
+	env := tools.NewEnv(workspace, "darwin/arm64")
+	eng := &Engine{taskID: "task-a", pwd: workspace, env: env}
+	s := &Server{Engine: eng, tasks: map[string]*Engine{eng.taskID: eng}}
+
+	rec := httptest.NewRecorder()
+	s.handleTaskUpload(rec, taskUploadRequest(t, eng.taskID, `../../report?.pdf`, []byte("pdf-data")))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var response taskUploadResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	wantDir := filepath.Join(home, ".jcode", "uploads", eng.taskID)
+	if filepath.Dir(response.Path) != wantDir || strings.Contains(response.Name, "..") || strings.ContainsAny(response.Name, `/\\?`) {
+		t.Fatalf("unsafe upload response: %#v", response)
+	}
+	got, err := os.ReadFile(response.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "pdf-data" || response.Size != int64(len(got)) {
+		t.Fatalf("content=%q size=%d", got, response.Size)
+	}
+	if info, err := os.Stat(response.Path); err != nil || info.Mode().Perm() != uploadFileMode {
+		t.Fatalf("file mode: info=%v err=%v", info, err)
+	}
+	if info, err := os.Stat(wantDir); err != nil || info.Mode().Perm() != localUploadDirMode {
+		t.Fatalf("dir mode: info=%v err=%v", info, err)
+	}
+}
+
+func TestReadTaskUploadEnforcesLimit(t *testing.T) {
+	req := taskUploadRequest(t, "task-a", "large.bin", []byte("12345"))
+	rec := httptest.NewRecorder()
+	_, _, err := readTaskUpload(rec, req, 4)
+	if !errors.Is(err, errUploadTooLarge) {
+		t.Fatalf("err=%v, want errUploadTooLarge", err)
+	}
+}
+
+func TestSanitizeUploadNameBoundsAndNormalizes(t *testing.T) {
+	name := sanitizeUploadName("../../." + strings.Repeat("a", 140) + "." + strings.Repeat("x", 40))
+	if len([]rune(name)) != 120 || strings.ContainsAny(name, `/\\`) || strings.HasPrefix(name, ".") {
+		t.Fatalf("name=%q runes=%d", name, len([]rune(name)))
+	}
+}
+
+func TestRemoveLocalTaskUploadsIsTaskScoped(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	taskDir := filepath.Join(home, ".jcode", "uploads", "task-a")
+	otherDir := filepath.Join(home, ".jcode", "uploads", "task-b")
+	for _, dir := range []string{taskDir, otherDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	removeLocalTaskUploads("task-a")
+	if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
+		t.Fatalf("task upload dir still exists: %v", err)
+	}
+	if _, err := os.Stat(otherDir); err != nil {
+		t.Fatalf("other task upload dir removed: %v", err)
+	}
+}
+
+type uploadRemoteExecutor struct {
+	mkdirPath string
+	writePath string
+	writeData []byte
+	chmodCmd  string
+}
+
+func (*uploadRemoteExecutor) ReadFile(context.Context, string) ([]byte, error) {
+	return nil, os.ErrNotExist
+}
+func (e *uploadRemoteExecutor) WriteFile(_ context.Context, path string, data []byte, _ os.FileMode) error {
+	e.writePath = path
+	e.writeData = append([]byte(nil), data...)
+	return nil
+}
+func (e *uploadRemoteExecutor) MkdirAll(_ context.Context, path string, _ os.FileMode) error {
+	e.mkdirPath = path
+	return nil
+}
+func (*uploadRemoteExecutor) Stat(context.Context, string) (*tools.FileInfo, error) {
+	return &tools.FileInfo{}, nil
+}
+func (e *uploadRemoteExecutor) Exec(_ context.Context, command, _ string, _ time.Duration) (string, string, error) {
+	e.chmodCmd = command
+	return "", "", nil
+}
+func (*uploadRemoteExecutor) Platform() string { return "linux/amd64" }
+func (*uploadRemoteExecutor) Label() string    { return "remote-test" }
+func (*uploadRemoteExecutor) Probe(context.Context) error {
+	return nil
+}
+func (*uploadRemoteExecutor) Close() error { return nil }
+func (*uploadRemoteExecutor) ProjectLabel(pwd string) string {
+	return "ssh://example" + pwd
+}
+
+func TestTaskUploadWritesIntoRemoteExecutionEnvironment(t *testing.T) {
+	executor := &uploadRemoteExecutor{}
+	env := tools.NewEnv(t.TempDir(), "darwin/arm64")
+	env.SetRemote(executor, "/srv/project")
+	eng := &Engine{taskID: "task-remote", pwd: "/srv/project", env: env}
+	s := &Server{Engine: eng, tasks: map[string]*Engine{eng.taskID: eng}}
+
+	rec := httptest.NewRecorder()
+	s.handleTaskUpload(rec, taskUploadRequest(t, eng.taskID, "notes.txt", []byte("hello")))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	wantDir := "/tmp/.jcode-uploads-" + eng.taskID
+	if executor.mkdirPath != wantDir || filepath.Dir(executor.writePath) != wantDir {
+		t.Fatalf("mkdir=%q write=%q", executor.mkdirPath, executor.writePath)
+	}
+	if string(executor.writeData) != "hello" || executor.chmodCmd != "chmod 700 "+tools.ShellQuote(wantDir) {
+		t.Fatalf("data=%q chmod=%q", executor.writeData, executor.chmodCmd)
+	}
+}
+
+func TestTaskUploadRejectsRunningTask(t *testing.T) {
+	env := tools.NewEnv(t.TempDir(), "darwin/arm64")
+	eng := &Engine{taskID: "task-a", pwd: env.Pwd(), env: env}
+	eng.running.Store(true)
+	s := &Server{Engine: eng, tasks: map[string]*Engine{eng.taskID: eng}}
+
+	rec := httptest.NewRecorder()
+	s.handleTaskUpload(rec, taskUploadRequest(t, eng.taskID, "notes.txt", []byte("hello")))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/packages/jcode-ui/CHANGELOG.md
+++ b/packages/jcode-ui/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- **Any-file composer drops.** The product composer now accepts file drops
+  across Browser Web and Tauri Desktop. Supported images keep the existing
+  visual attachment path; other files become explicit agent prompt context.
+  Desktop hosts preserve the absolute path supplied by Tauri. Browser hosts
+  can upload sandboxed `File` objects into the task execution environment and
+  inject the returned Agent-readable absolute path. This model-facing context
+  stays fixed English like JCode's system reminders; visible drag/drop chrome
+  and upload errors remain localized.
 - **Generated-image surface.** New public `GeneratedImageCard` component and
   `GeneratedImageState` / `GeneratedImageCardProps` /
   `GeneratedImageCardStrings` types render the complete generated-media
@@ -44,6 +52,10 @@
 
 ### Fixed
 
+- Tauri Desktop file drops now use the platform's real coordinate space:
+  macOS Cocoa and Linux GTK points remain logical pixels, while Windows
+  WebView2 physical pixels are scaled before composer hit-testing. This fixes
+  welcome-screen drops being rejected on Retina displays.
 - Ask User submission now disables duplicate actions while pending, surfaces a
   localized inline error when the host rejects the request, and lets the user
   retry without losing answers. Option and custom-text answers are mutually

--- a/packages/jcode-ui/src/product/ChatInput.test.tsx
+++ b/packages/jcode-ui/src/product/ChatInput.test.tsx
@@ -8,12 +8,13 @@
  *   - image attachment limits (10MB cap, image/* only)
  */
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RuntimeProvider, createMockRuntime } from 'jcode-ui-core/runtime'
 import type { ChatRuntime } from 'jcode-ui-core/runtime'
 import { ChatInput } from './ChatInput.js'
 import type { ProductComposerHost } from './host.js'
+import type { FileDropEvent } from './host.js'
 import type { ProviderInfo } from './types.js'
 
 const PROVIDERS: ProviderInfo[] = [
@@ -480,14 +481,14 @@ describe('compact picker anchors', () => {
   })
 })
 
-describe('image attachments', () => {
+describe('file attachments', () => {
   function fileInput(container: HTMLElement): HTMLInputElement {
     const el = container.querySelector('input[type="file"]')
     if (!el) throw new Error('file input not found')
     return el as HTMLInputElement
   }
 
-  it('accepts images under 10MB and skips larger/non-image files', async () => {
+  it('keeps small images inline and stages other selected files for upload', async () => {
     const host = makeHost()
     const { container } = renderComposer(host)
     const input = fileInput(container)
@@ -497,10 +498,9 @@ describe('image attachments', () => {
     const doc = new File([new Uint8Array(128)], 'notes.txt', { type: 'text/plain' })
     fireEvent.change(input, { target: { files: [small, big, doc] } })
 
-    // Only the small image makes it into the pending list.
     await waitFor(() => {
-      const list = container.querySelector('.jcode-attachment-list')
-      expect(list?.getAttribute('data-count')).toBe('1')
+      expect(container.querySelector('.jcode-attachment-list')?.getAttribute('data-count')).toBe('1')
+      expect(container.querySelector('.jcode-pending-attachments')?.getAttribute('data-count')).toBe('2')
     })
   })
 
@@ -528,5 +528,113 @@ describe('image attachments', () => {
       expect(images[0].media_type).toBe('image/png')
       expect(images[0].name).toBe('a.png')
     })
+  })
+
+  it('accepts browser file drops and turns unsupported files into prompt context', async () => {
+    const runtime = createMockRuntime()
+    const uploadDroppedFile = vi.fn(async () => ({
+      path: '/Users/jack/.jcode/uploads/s1/notes-a1b2c3.pdf',
+      name: 'notes-a1b2c3.pdf',
+      size: 128,
+    }))
+    const { container } = renderComposer(makeHost({
+      strings: { attachFiles: '添加附件' },
+      uploadDroppedFile,
+    }), runtime)
+    const composer = container.querySelector('.jcode-product-composer') as HTMLDivElement
+    const doc = new File([new Uint8Array(128)], 'notes.pdf', { type: 'application/pdf' })
+    const dataTransfer = { types: ['Files'], files: [doc], dropEffect: 'none' }
+
+    fireEvent.dragEnter(composer, { dataTransfer })
+    expect(composer.textContent).toContain('添加附件')
+    fireEvent.drop(composer, { dataTransfer })
+
+    const ta = textarea(container)
+    expect(ta.value).toBe('')
+    expect(container.querySelector('.jcode-pending-attachments')?.getAttribute('data-count')).toBe('1')
+    fireEvent.click(screen.getByLabelText('Send'))
+    await waitFor(() => {
+      const send = (runtime as ReturnType<typeof createMockRuntime>).calls.find((call) => call.action === 'sendMessage')
+      expect(send?.args[0]).toContain('[File Drop]')
+      expect(send?.args[0]).toContain('/Users/jack/.jcode/uploads/s1/notes-a1b2c3.pdf')
+    })
+    expect(uploadDroppedFile).toHaveBeenCalledWith('s1', doc)
+  })
+
+  it('keeps a browser file pending when upload fails', async () => {
+    const runtime = createMockRuntime()
+    const uploadDroppedFile = vi.fn(async () => { throw new Error('offline') })
+    const { container } = renderComposer(makeHost({ uploadDroppedFile }), runtime)
+    const composer = container.querySelector('.jcode-product-composer') as HTMLDivElement
+    fireEvent.drop(composer, {
+      dataTransfer: {
+        types: ['Files'],
+        files: [new File([new Uint8Array(8)], 'notes.pdf', { type: 'application/pdf' })],
+        dropEffect: 'none',
+      },
+    })
+
+    fireEvent.click(screen.getByLabelText('Send'))
+    await waitFor(() => expect(container.textContent).toContain('File upload failed'))
+    expect((runtime as ReturnType<typeof createMockRuntime>).calls.some((call) => call.action === 'sendMessage')).toBe(false)
+    expect(container.querySelector('.jcode-pending-attachments')?.getAttribute('data-count')).toBe('1')
+  })
+
+  it('keeps supported browser-dropped images on the image attachment path', async () => {
+    const { container } = renderComposer(makeHost())
+    const composer = container.querySelector('.jcode-product-composer') as HTMLDivElement
+    const image = new File([new Uint8Array(16)], 'drop.png', { type: 'image/png' })
+
+    fireEvent.drop(composer, {
+      dataTransfer: { types: ['Files'], files: [image], dropEffect: 'none' },
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('.jcode-attachment-list')?.getAttribute('data-count')).toBe('1')
+    })
+    expect(textarea(container).value).toBe('')
+  })
+
+  it('uses native absolute paths and only loads supported dropped images', async () => {
+    let onFileDrop: ((event: FileDropEvent) => void) | undefined
+    const unlisten = vi.fn()
+    const readDroppedImage = vi.fn(async (path: string) => path.endsWith('.png') ? {
+      data: 'cG5n',
+      media_type: 'image/png',
+      name: 'screen.png',
+    } : null)
+    const host = makeHost({
+      listenForFileDrops: vi.fn(async (listener) => {
+        onFileDrop = listener
+        return unlisten
+      }),
+      readDroppedImage,
+    })
+    const { container } = renderComposer(host)
+    const composer = container.querySelector('.jcode-product-composer') as HTMLDivElement
+    vi.spyOn(composer, 'getBoundingClientRect').mockReturnValue({
+      left: 10,
+      top: 20,
+      right: 510,
+      bottom: 220,
+      width: 500,
+      height: 200,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+    await waitFor(() => expect(onFileDrop).toBeTypeOf('function'))
+
+    act(() => onFileDrop?.({ type: 'drop', paths: [
+      '/Users/jack/Documents/report.pdf',
+      '/Users/jack/Documents/screen.png',
+    ], x: 100, y: 100 }))
+
+    await waitFor(() => {
+      expect(textarea(container).value).toContain('/Users/jack/Documents/report.pdf')
+      expect(container.querySelector('.jcode-attachment-list')?.getAttribute('data-count')).toBe('1')
+    })
+    expect(readDroppedImage).toHaveBeenCalledTimes(2)
+    expect(textarea(container).value).toContain('dragged a file into the input')
   })
 })

--- a/packages/jcode-ui/src/product/ChatInput.test.tsx
+++ b/packages/jcode-ui/src/product/ChatInput.test.tsx
@@ -97,6 +97,12 @@ function textarea(container: HTMLElement): HTMLTextAreaElement {
   return el
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => { resolve = done })
+  return { promise, resolve }
+}
+
 beforeEach(() => {
   localStorage.clear()
 })
@@ -580,6 +586,31 @@ describe('file attachments', () => {
     expect(container.querySelector('.jcode-pending-attachments')?.getAttribute('data-count')).toBe('1')
   })
 
+  it('drops a delayed browser upload after an s1 to s2 to s1 transition', async () => {
+    const upload = deferred<{ path: string; name: string; size: number }>()
+    const runtime = createMockRuntime()
+    const uploadDroppedFile = vi.fn(() => upload.promise)
+    const host = makeHost({ uploadDroppedFile })
+    const view = renderComposer(host, runtime)
+    const composer = view.container.querySelector('.jcode-product-composer') as HTMLDivElement
+    fireEvent.drop(composer, {
+      dataTransfer: {
+        types: ['Files'],
+        files: [new File(['notes'], 'notes.pdf', { type: 'application/pdf' })],
+        dropEffect: 'none',
+      },
+    })
+    fireEvent.click(screen.getByLabelText('Send'))
+    await waitFor(() => expect(uploadDroppedFile).toHaveBeenCalledTimes(1))
+
+    view.rerender(<RuntimeProvider runtime={runtime}><ChatInput host={{ ...host, sessionId: 's2' }} /></RuntimeProvider>)
+    view.rerender(<RuntimeProvider runtime={runtime}><ChatInput host={{ ...host, sessionId: 's1' }} /></RuntimeProvider>)
+    await act(async () => upload.resolve({ path: '/managed/notes.pdf', name: 'notes.pdf', size: 5 }))
+
+    expect((runtime as ReturnType<typeof createMockRuntime>).calls.some((call) => call.action === 'sendMessage')).toBe(false)
+    expect(view.container.querySelector('.jcode-pending-attachments')).toBeNull()
+  })
+
   it('keeps supported browser-dropped images on the image attachment path', async () => {
     const { container } = renderComposer(makeHost())
     const composer = container.querySelector('.jcode-product-composer') as HTMLDivElement
@@ -636,5 +667,32 @@ describe('file attachments', () => {
     })
     expect(readDroppedImage).toHaveBeenCalledTimes(2)
     expect(textarea(container).value).toContain('dragged a file into the input')
+  })
+
+  it('drops a delayed native image read after an s1 to s2 to s1 transition', async () => {
+    const image = deferred<{ data: string; media_type: string; name: string } | null>()
+    let onFileDrop: ((event: FileDropEvent) => void) | undefined
+    const host = makeHost({
+      listenForFileDrops: vi.fn(async (listener) => {
+        onFileDrop = listener
+        return () => {}
+      }),
+      readDroppedImage: vi.fn(() => image.promise),
+    })
+    const runtime = createMockRuntime()
+    const view = renderComposer(host, runtime)
+    const composer = view.container.querySelector('.jcode-product-composer') as HTMLDivElement
+    vi.spyOn(composer, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, right: 500, bottom: 200, width: 500, height: 200, x: 0, y: 0, toJSON: () => ({}),
+    })
+    await waitFor(() => expect(onFileDrop).toBeTypeOf('function'))
+    act(() => onFileDrop?.({ type: 'drop', paths: ['/tmp/screen.png'], x: 100, y: 100 }))
+
+    view.rerender(<RuntimeProvider runtime={runtime}><ChatInput host={{ ...host, sessionId: 's2' }} /></RuntimeProvider>)
+    view.rerender(<RuntimeProvider runtime={runtime}><ChatInput host={{ ...host, sessionId: 's1' }} /></RuntimeProvider>)
+    await act(async () => image.resolve({ data: 'cG5n', media_type: 'image/png', name: 'screen.png' }))
+
+    expect(view.container.querySelector('.jcode-attachment-list')).toBeNull()
+    expect(textarea(view.container).value).toBe('')
   })
 })

--- a/packages/jcode-ui/src/product/ChatInput.tsx
+++ b/packages/jcode-ui/src/product/ChatInput.tsx
@@ -328,6 +328,12 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
   const containerRef = useRef<HTMLDivElement>(null)
   const dragDepthRef = useRef(0)
   const currentSessionRef = useRef(currentSessionId)
+  const composerSessionRef = useRef(currentSessionId)
+  const composerGenerationRef = useRef(0)
+  if (composerSessionRef.current !== currentSessionId) {
+    composerSessionRef.current = currentSessionId
+    composerGenerationRef.current += 1
+  }
   currentSessionRef.current = currentSessionId
   const addPopup = useViewportPopup(showAddMenu)
   const modePopup = useViewportPopup(showModePicker)
@@ -516,6 +522,7 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
   // ─── Send / queue ─────────────────────────────────────────────────────────
 
   const send = useCallback(async () => {
+    const composerGeneration = composerGenerationRef.current
     const text = input.trim()
     if (!text && pendingImages.length === 0 && pendingBrowserFiles.length === 0) return
     if (isUploadingFiles || (isRunning && pendingBrowserFiles.length > 0)) return
@@ -548,10 +555,10 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
         } else {
           try {
             const uploaded = await host.uploadDroppedFile(targetSessionID, pending.file)
-            if (currentSessionRef.current !== targetSessionID) return
+            if (currentSessionRef.current !== targetSessionID || composerGenerationRef.current !== composerGeneration) return
             next = { ...pending, uploadedPath: uploaded.path, uploading: false, error: undefined }
           } catch {
-            if (currentSessionRef.current !== targetSessionID) return
+            if (currentSessionRef.current !== targetSessionID || composerGenerationRef.current !== composerGeneration) return
             next = { ...pending, uploading: false, error: strings.fileUploadFailed }
             failed = true
           }
@@ -560,7 +567,7 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
         setPendingBrowserFiles(uploadedFiles)
       }
       setIsUploadingFiles(false)
-      if (failed || currentSessionRef.current !== targetSessionID) return
+      if (failed || currentSessionRef.current !== targetSessionID || composerGenerationRef.current !== composerGeneration) return
     }
 
     const images: RuntimeChatImage[] | undefined =
@@ -572,6 +579,7 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
       .filter(Boolean)
       .join('\n\n')
     const body = [text, fileContext].filter(Boolean).join('\n\n') || strings.attachedImages
+    if (currentSessionRef.current !== currentSessionId || composerGenerationRef.current !== composerGeneration) return
     if (isRunning) {
       actions.enqueueMessage(body, images)
     } else {
@@ -668,8 +676,11 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
   // ─── Image attachments ────────────────────────────────────────────────────
 
   const addImageFile = useCallback((file: File) => {
+    const targetSessionID = currentSessionRef.current
+    const composerGeneration = composerGenerationRef.current
     const reader = new FileReader()
     reader.onload = () => {
+      if (currentSessionRef.current !== targetSessionID || composerGenerationRef.current !== composerGeneration) return
       const result = reader.result as string
       const commaIdx = result.indexOf(',')
       if (commaIdx < 0) return
@@ -717,6 +728,8 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
 
   const ingestNativePaths = useCallback(async (paths: string[]) => {
     if (isUploadingFiles) return
+    const targetSessionID = currentSessionRef.current
+    const composerGeneration = composerGenerationRef.current
     const results = await Promise.all(paths.map(async (path) => {
       if (!imageSupport || !host.readDroppedImage) return { path, image: null }
       try {
@@ -725,6 +738,7 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
         return { path, image: null }
       }
     }))
+    if (currentSessionRef.current !== targetSessionID || composerGenerationRef.current !== composerGeneration) return
     const images = results.flatMap(({ image }) => image ? [{
       data: image.data,
       media_type: image.media_type,

--- a/packages/jcode-ui/src/product/ChatInput.tsx
+++ b/packages/jcode-ui/src/product/ChatInput.tsx
@@ -9,7 +9,8 @@
  *     context-limit subline, and a Manage Models dialog)
  *   - EFFORT picker (per-model reasoning effort)
  *   - "+" menu (attach images, slash insert, Goal arming)
- *   - image attachments (paste + file picker + thumbnails)
+ *   - image attachments (paste + picker + drag/drop thumbnails)
+ *   - generic file drops as explicit path context for the agent
  *   - type-ahead queue chips
  *   - keyboard shortcuts (⌘L focus, Esc to close dialogs)
  *   - click-outside handling
@@ -49,11 +50,13 @@ import {
   StarIcon,
   SparklesIcon,
   CpuChipIcon,
+  ArrowUpTrayIcon,
 } from '@heroicons/react/24/outline'
 import { StarIcon as StarIconSolid, CheckCircleIcon } from '@heroicons/react/24/solid'
 import { useRuntimeActions, useRuntimeState } from 'jcode-ui-core/runtime'
 import type { ChatImage as RuntimeChatImage } from 'jcode-ui-core'
-import { AttachmentList } from '../components/Attachment.js'
+import type { PendingAttachmentItem } from 'jcode-ui-core/primitives'
+import { AttachmentList, PendingAttachmentList } from '../components/Attachment.js'
 import type { ProductComposerHost } from './host.js'
 import type { ProductComposerStrings } from './strings.js'
 import { useComposerStrings } from './useComposerStrings.js'
@@ -180,6 +183,31 @@ const MODE_DEFS: ModeDef[] = [
 ]
 
 const STANDARD_EFFORT_OPTIONS = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024
+const MAX_UPLOAD_BYTES = 100 * 1024 * 1024
+
+interface PendingBrowserFile {
+  id: string
+  file: File
+  uploadedPath?: string
+  uploading?: boolean
+  error?: string
+}
+
+let browserFileID = 0
+
+function nextBrowserFileID(): string {
+  browserFileID += 1
+  return `browser_file_${Date.now().toString(36)}_${browserFileID.toString(36)}`
+}
+
+/**
+ * Model-facing metadata stays fixed English, matching JCode's system/reminder
+ * prompts. Only visible composer chrome follows the selected UI locale.
+ */
+function droppedFilePrompt(path: string): string {
+  return `[File Drop]\nThe user dragged a file into the input.\nPath: ${JSON.stringify(path)}`
+}
 
 function modeLabel(strings: ProductComposerStrings, m: string): string {
   const def = MODE_DEFS.find((d) => d.value === m)
@@ -278,6 +306,8 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
   const [input, setInput] = useState(() => readDraft(currentSessionId))
   /** Pending vision images — same shape as the ChatRuntime `ChatImage` / AttachmentList. */
   const [pendingImages, setPendingImages] = useState<RuntimeChatImage[]>([])
+  const [pendingBrowserFiles, setPendingBrowserFiles] = useState<PendingBrowserFile[]>([])
+  const [isUploadingFiles, setIsUploadingFiles] = useState(false)
   const [showSlashMenu, setShowSlashMenu] = useState(false)
   const [slashFilter, setSlashFilter] = useState('')
   const [selectedSlashIdx, setSelectedSlashIdx] = useState(0)
@@ -291,10 +321,14 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
   const [taskStats, setTaskStats] = useState<TaskStats | null>(null)
   const [taskStatsLoading, setTaskStatsLoading] = useState(false)
   const [modelFilter, setModelFilter] = useState('')
+  const [isDroppingFiles, setIsDroppingFiles] = useState(false)
 
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const dragDepthRef = useRef(0)
+  const currentSessionRef = useRef(currentSessionId)
+  currentSessionRef.current = currentSessionId
   const addPopup = useViewportPopup(showAddMenu)
   const modePopup = useViewportPopup(showModePicker)
   const modelPopup = useViewportPopup(showModelPicker)
@@ -467,6 +501,9 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
     writeDraft(prevId, draftLiveRef.current.text)
     draftSessionRef.current = currentSessionId
     setInput(readDraft(currentSessionId))
+    setPendingImages([])
+    setPendingBrowserFiles([])
+    setIsUploadingFiles(false)
   }, [currentSessionId])
 
   // Flush on unmount (app close / panel teardown).
@@ -478,14 +515,63 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
 
   // ─── Send / queue ─────────────────────────────────────────────────────────
 
-  const send = useCallback(() => {
+  const send = useCallback(async () => {
     const text = input.trim()
-    if (!text && pendingImages.length === 0) return
+    if (!text && pendingImages.length === 0 && pendingBrowserFiles.length === 0) return
+    if (isUploadingFiles || (isRunning && pendingBrowserFiles.length > 0)) return
+
+    let uploadedFiles = pendingBrowserFiles
+    if (uploadedFiles.length > 0) {
+      if (!currentSessionId || !host.uploadDroppedFile) {
+        setPendingBrowserFiles((current) => current.map((item) => ({
+          ...item,
+          uploading: false,
+          error: strings.fileUploadUnavailable,
+        })))
+        return
+      }
+      const targetSessionID = currentSessionId
+      setIsUploadingFiles(true)
+      uploadedFiles = uploadedFiles.map((item) => ({
+        ...item,
+        uploading: !item.uploadedPath,
+        error: undefined,
+      }))
+      setPendingBrowserFiles(uploadedFiles)
+      let failed = false
+      for (const pending of uploadedFiles) {
+        if (pending.uploadedPath) continue
+        let next = pending
+        if (pending.file.size > MAX_UPLOAD_BYTES) {
+          next = { ...pending, uploading: false, error: strings.fileTooLarge }
+          failed = true
+        } else {
+          try {
+            const uploaded = await host.uploadDroppedFile(targetSessionID, pending.file)
+            if (currentSessionRef.current !== targetSessionID) return
+            next = { ...pending, uploadedPath: uploaded.path, uploading: false, error: undefined }
+          } catch {
+            if (currentSessionRef.current !== targetSessionID) return
+            next = { ...pending, uploading: false, error: strings.fileUploadFailed }
+            failed = true
+          }
+        }
+        uploadedFiles = uploadedFiles.map((item) => item.id === pending.id ? next : item)
+        setPendingBrowserFiles(uploadedFiles)
+      }
+      setIsUploadingFiles(false)
+      if (failed || currentSessionRef.current !== targetSessionID) return
+    }
+
     const images: RuntimeChatImage[] | undefined =
       pendingImages.length > 0
         ? pendingImages.map((i) => ({ data: i.data, media_type: i.media_type, name: i.name }))
         : undefined
-    const body = text || strings.attachedImages
+    const fileContext = uploadedFiles
+      .map((item) => item.uploadedPath ? droppedFilePrompt(item.uploadedPath) : '')
+      .filter(Boolean)
+      .join('\n\n')
+    const body = [text, fileContext].filter(Boolean).join('\n\n') || strings.attachedImages
     if (isRunning) {
       actions.enqueueMessage(body, images)
     } else {
@@ -494,9 +580,10 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
     setInput('')
     writeDraft(currentSessionId, '')
     setPendingImages([])
+    setPendingBrowserFiles([])
     setShowSlashMenu(false)
     onSent?.()
-  }, [actions, input, isRunning, onSent, pendingImages, currentSessionId, strings])
+  }, [actions, currentSessionId, host.uploadDroppedFile, input, isRunning, isUploadingFiles, onSent, pendingBrowserFiles, pendingImages, strings])
 
   // ─── Model / mode selection ───────────────────────────────────────────────
 
@@ -580,7 +667,7 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
 
   // ─── Image attachments ────────────────────────────────────────────────────
 
-  function addImageFile(file: File) {
+  const addImageFile = useCallback((file: File) => {
     const reader = new FileReader()
     reader.onload = () => {
       const result = reader.result as string
@@ -593,6 +680,118 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
       ])
     }
     reader.readAsDataURL(file)
+  }, [])
+
+  const appendDroppedFilePrompts = useCallback((prompts: string[]) => {
+    if (prompts.length === 0) return
+    setInput((current) => {
+      const separator = current.length === 0 || current.endsWith('\n') ? '' : '\n'
+      return `${current}${separator}${prompts.join('\n')}`
+    })
+    requestAnimationFrame(() => textareaRef.current?.focus())
+  }, [])
+
+  const ingestBrowserFiles = useCallback((files: Iterable<File>) => {
+    if (isUploadingFiles) return
+    const prompts: string[] = []
+    const uploads: PendingBrowserFile[] = []
+    for (const file of files) {
+      if (imageSupport && file.type.startsWith('image/') && file.size <= MAX_IMAGE_BYTES) {
+        addImageFile(file)
+        continue
+      }
+      const exposedPath = (file as File & { path?: string }).path
+      if (exposedPath) {
+        prompts.push(droppedFilePrompt(exposedPath))
+        continue
+      }
+      uploads.push({
+        id: nextBrowserFileID(),
+        file,
+        error: file.size > MAX_UPLOAD_BYTES ? strings.fileTooLarge : undefined,
+      })
+    }
+    appendDroppedFilePrompts(prompts)
+    if (uploads.length > 0) setPendingBrowserFiles((current) => [...current, ...uploads])
+  }, [addImageFile, appendDroppedFilePrompts, imageSupport, isUploadingFiles, strings.fileTooLarge])
+
+  const ingestNativePaths = useCallback(async (paths: string[]) => {
+    if (isUploadingFiles) return
+    const results = await Promise.all(paths.map(async (path) => {
+      if (!imageSupport || !host.readDroppedImage) return { path, image: null }
+      try {
+        return { path, image: await host.readDroppedImage(path) }
+      } catch {
+        return { path, image: null }
+      }
+    }))
+    const images = results.flatMap(({ image }) => image ? [{
+      data: image.data,
+      media_type: image.media_type,
+      name: image.name,
+    }] : [])
+    if (images.length > 0) setPendingImages((current) => [...current, ...images])
+    appendDroppedFilePrompts(
+      results.filter(({ image }) => !image).map(({ path }) => droppedFilePrompt(path)),
+    )
+  }, [appendDroppedFilePrompts, host.readDroppedImage, imageSupport, isUploadingFiles])
+
+  useEffect(() => {
+    if (!host.listenForFileDrops) return
+    let active = true
+    let unlisten: (() => void) | undefined
+    void host.listenForFileDrops((event) => {
+      if (!active) return
+      if (event.type === 'leave') {
+        setIsDroppingFiles(false)
+        return
+      }
+      const rect = containerRef.current?.getBoundingClientRect()
+      const inside = !!rect && event.x >= rect.left && event.x <= rect.right &&
+        event.y >= rect.top && event.y <= rect.bottom
+      if (event.type === 'drop') {
+        setIsDroppingFiles(false)
+        if (inside && event.paths.length > 0) void ingestNativePaths(event.paths)
+        return
+      }
+      setIsDroppingFiles(inside)
+    }).then((dispose) => {
+      if (active) unlisten = dispose
+      else dispose()
+    }).catch(() => {
+      if (active) setIsDroppingFiles(false)
+    })
+    return () => {
+      active = false
+      unlisten?.()
+    }
+  }, [host.listenForFileDrops, ingestNativePaths])
+
+  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+    if (!Array.from(e.dataTransfer.types).includes('Files')) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'copy'
+  }
+
+  function handleDragEnter(e: React.DragEvent<HTMLDivElement>) {
+    if (!Array.from(e.dataTransfer.types).includes('Files')) return
+    e.preventDefault()
+    dragDepthRef.current += 1
+    setIsDroppingFiles(true)
+  }
+
+  function handleDragLeave(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault()
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
+    if (dragDepthRef.current === 0) setIsDroppingFiles(false)
+  }
+
+  function handleFileDrop(e: React.DragEvent<HTMLDivElement>) {
+    if (!Array.from(e.dataTransfer.types).includes('Files')) return
+    e.preventDefault()
+    dragDepthRef.current = 0
+    setIsDroppingFiles(false)
+    if (e.dataTransfer.files.length > 0) ingestBrowserFiles(Array.from(e.dataTransfer.files))
   }
 
   function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
@@ -607,14 +806,10 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
     }
   }
 
-  function handleImageSelect(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
     const files = e.target.files
     if (!files) return
-    for (const file of Array.from(files)) {
-      if (!file.type.startsWith('image/')) continue
-      if (file.size > 10 * 1024 * 1024) continue // 10MB limit
-      addImageFile(file)
-    }
+    ingestBrowserFiles(Array.from(files))
     e.target.value = ''
   }
 
@@ -622,7 +817,21 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
     setPendingImages((prev) => prev.filter((_, i) => i !== index))
   }
 
-  function triggerImageUpload() {
+  function removeBrowserFile(id: string) {
+    if (isUploadingFiles) return
+    setPendingBrowserFiles((current) => current.filter((item) => item.id !== id))
+  }
+
+  function retryBrowserFile(id: string) {
+    if (isUploadingFiles) return
+    setPendingBrowserFiles((current) => current.map((item) => item.id === id ? {
+      ...item,
+      uploadedPath: undefined,
+      error: undefined,
+    } : item))
+  }
+
+  function triggerFileUpload() {
     fileInputRef.current?.click()
   }
 
@@ -714,7 +923,7 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
 
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      send()
+      void send()
     }
   }
 
@@ -815,8 +1024,23 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
     setShowEffortPicker(false)
   }
 
-  const canSend = input.trim().length > 0 || pendingImages.length > 0
-  const showSend = !isRunning || input.trim().length > 0 || pendingImages.length > 0
+  const pendingFileItems = useMemo<PendingAttachmentItem[]>(() => pendingBrowserFiles.map((item) => ({
+    attachment: {
+      id: item.id,
+      kind: 'file',
+      name: item.file.name || 'attachment',
+      size: item.file.size,
+      media_type: item.file.type || undefined,
+      progress: item.uploading ? 0.5 : item.uploadedPath ? 1 : 0,
+      error: item.error,
+    },
+    status: item.error ? 'error' : item.uploading ? 'uploading' : 'done',
+    remove: () => removeBrowserFile(item.id),
+    retry: () => retryBrowserFile(item.id),
+  })), [isUploadingFiles, pendingBrowserFiles])
+  const hasPayload = input.trim().length > 0 || pendingImages.length > 0 || pendingBrowserFiles.length > 0
+  const canSend = hasPayload && !isUploadingFiles && (!isRunning || pendingBrowserFiles.length === 0)
+  const showSend = !isRunning || ((input.trim().length > 0 || pendingImages.length > 0) && pendingBrowserFiles.length === 0)
   const currentModeDef = MODE_DEFS.find((m) => m.value === mode) ?? MODE_DEFS[0]
   // Host-restricted mode list (M20 cloud ceiling): absent ⇒ all four modes.
   const modeDefs = allowedModes ? MODE_DEFS.filter((d) => allowedModes.includes(d.value)) : MODE_DEFS
@@ -834,7 +1058,22 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
       ref={containerRef}
       className="jcode-product-composer relative w-full bg-transparent"
       style={{ padding: '8px 0 14px' }}
+      onDragOver={handleDragOver}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDrop={handleFileDrop}
     >
+      {isDroppingFiles && (
+        <div
+          className="pointer-events-none absolute inset-0 z-[60] grid place-items-center rounded-[var(--radius-2xl)] border-2 border-dashed border-[var(--color-primary)] bg-[color-mix(in_srgb,var(--color-surface)_88%,transparent)] text-[var(--color-primary)] shadow-[var(--shadow-lg)]"
+          aria-hidden="true"
+        >
+          <div className="flex items-center gap-2 rounded-[var(--radius-pill)] bg-[var(--color-surface)] px-4 py-2 text-sm font-medium shadow-[var(--shadow-md)]">
+            <ArrowUpTrayIcon className="h-5 w-5" />
+            <span>{strings.attachFiles}</span>
+          </div>
+        </div>
+      )}
       {/* Type-ahead queue */}
       {queued.length > 0 && (
         <div className="mx-auto mb-1.5 flex flex-col gap-1" style={{ padding: '0 8px 6px' }}>
@@ -930,6 +1169,7 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
               onKeyDown={handleKeyDown}
               onSelect={handleSelect}
               onPaste={handlePaste}
+              disabled={isUploadingFiles}
               placeholder={
                 isRunning
                   ? strings.queuePlaceholder
@@ -947,12 +1187,18 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
               </div>
             )}
 
+            {pendingFileItems.length > 0 && (
+              <div className="mt-2">
+                <PendingAttachmentList items={pendingFileItems} size={56} />
+              </div>
+            )}
+
             <input
               ref={fileInputRef}
               type="file"
-              accept="image/*"
               multiple
-              onChange={handleImageSelect}
+              onChange={handleFileSelect}
+              disabled={isUploadingFiles}
               className="hidden"
             />
           </div>
@@ -992,17 +1238,13 @@ export function ChatInput({ host, onSent, pickerPlacement = 'top', elevated = fa
                     <button
                       type="button"
                       role="menuitem"
-                      disabled={!imageSupport}
-                      title={!imageSupport ? strings.modelNoImages : ''}
-                      onClick={() => { triggerImageUpload(); setShowAddMenu(false) }}
-                      className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)] ${
-                        !imageSupport ? 'cursor-default opacity-50' : ''
-                      }`}
+                      onClick={() => { triggerFileUpload(); setShowAddMenu(false) }}
+                      className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-muted)]"
                     >
                       <PaperClipIcon className="h-3.5 w-3.5 shrink-0 text-[var(--color-muted-foreground)]" />
                       <span>{strings.attachFiles}</span>
-                      {pendingImages.length > 0 && (
-                        <span className="ml-auto font-mono text-[10px] text-[var(--color-primary)]">{pendingImages.length}</span>
+                      {pendingImages.length + pendingBrowserFiles.length > 0 && (
+                        <span className="ml-auto font-mono text-[10px] text-[var(--color-primary)]">{pendingImages.length + pendingBrowserFiles.length}</span>
                       )}
                     </button>
                     <div className="mx-2 my-1 h-px bg-[var(--color-border)]" aria-hidden="true" />

--- a/packages/jcode-ui/src/product/host.ts
+++ b/packages/jcode-ui/src/product/host.ts
@@ -34,6 +34,23 @@ import type {
 } from './types.js'
 import type { ProductComposerStrings } from './strings.js'
 
+export type FileDropEvent =
+  | { type: 'enter' | 'over'; x: number; y: number }
+  | { type: 'drop'; paths: string[]; x: number; y: number }
+  | { type: 'leave' }
+
+export interface DroppedImage {
+  data: string
+  media_type: string
+  name: string
+}
+
+export interface UploadedFile {
+  path: string
+  name: string
+  size: number
+}
+
 export interface ProductComposerHost {
   // ── Model catalog state ───────────────────────────────────────────────────
   providerName: string
@@ -121,6 +138,23 @@ export interface ProductComposerHost {
   pickFolder?: (defaultPath?: string) => Promise<string | null>
   /** Open the host's remote-connect wizard (ssh:// and docker:// workspaces). */
   openRemoteConnect?: (prefill?: RemotePrefill | null) => void
+
+  // ── Native file drops ─────────────────────────────────────────────────────
+  /**
+   * Subscribe to native file drag/drop events. Desktop hosts use this to keep
+   * the absolute paths that browser `File` objects intentionally hide.
+   */
+  listenForFileDrops?: (listener: (event: FileDropEvent) => void) => Promise<() => void>
+  /**
+   * Load a supported, size-bounded local image selected by a native file drop.
+   * Returning null leaves the file on the path-prompt fallback.
+   */
+  readDroppedImage?: (path: string) => Promise<DroppedImage | null>
+  /**
+   * Copy a browser-sandboxed File into the task's execution environment and
+   * return the absolute path the agent can read.
+   */
+  uploadDroppedFile?: (taskID: string, file: File) => Promise<UploadedFile>
 
   // ── Branch actions ────────────────────────────────────────────────────────
   fetchBranches: () => Promise<GitBranchesResult>

--- a/packages/jcode-ui/src/product/index.ts
+++ b/packages/jcode-ui/src/product/index.ts
@@ -25,7 +25,7 @@ export { BranchPicker } from './BranchPicker.js'
 export { GoalBanner } from './GoalBanner.js'
 export { ProviderIcon } from './ProviderIcon.js'
 
-export type { ProductComposerHost } from './host.js'
+export type { DroppedImage, FileDropEvent, ProductComposerHost, UploadedFile } from './host.js'
 export type { ProductComposerStrings } from './strings.js'
 export { defaultProductComposerStrings, resolveProductComposerStrings } from './strings.js'
 export { readDraft, writeDraft } from './drafts.js'

--- a/packages/jcode-ui/src/product/strings.ts
+++ b/packages/jcode-ui/src/product/strings.ts
@@ -34,6 +34,9 @@ export interface ProductComposerStrings {
   goalHintRemove: string
   goalHintReplace: string
   modelNoImages: string
+  fileUploadFailed: string
+  fileUploadUnavailable: string
+  fileTooLarge: string
 
   // ── mode picker ──
   modeApproval: string
@@ -168,6 +171,9 @@ export const defaultProductComposerStrings: ProductComposerStrings = {
   goalHintRemove: 'Remove goal',
   goalHintReplace: 'Setting a new goal replaces the current one',
   modelNoImages: 'Current model does not support images',
+  fileUploadFailed: 'File upload failed',
+  fileUploadUnavailable: 'File upload is unavailable for this task',
+  fileTooLarge: 'File exceeds the 100MB upload limit',
 
   modeApproval: 'Ask for approval',
   modeApprovalSub: 'Pause before each write or command.',

--- a/site/docs/chat-ui/components/attachment.md
+++ b/site/docs/chat-ui/components/attachment.md
@@ -85,6 +85,13 @@ This keeps **library demos**, **docs**, and the **jcode product** (`web/src/comp
 ## Product (jcode web / desktop)
 
 - Attach entry: **+ menu → Image** (and paste into the textarea).
+- Drag/drop accepts any file. Supported images keep the base64 `ChatImage`
+  path; every other file is inserted into the draft as explicit agent context
+  saying that it was dropped and naming its path. Desktop preserves the Tauri
+  absolute path. Browser Web uploads a managed copy into the current task's
+  local, SSH, or Docker execution environment, then injects that returned
+  Agent-readable path. The model-facing block is fixed English, matching JCode
+  system reminders; visible composer chrome and errors follow the UI locale.
 - Capability gate: model `image_support` / settings “Allow image attachments”.
 - Thumbnails: shared `AttachmentList` (preview + remove).
 - Backend contract remains base64 `ChatImage[]` on the user message.

--- a/site/docs/chat-ui/components/attachment.md
+++ b/site/docs/chat-ui/components/attachment.md
@@ -19,7 +19,12 @@ Image attachment tiles for the composer and user messages — thumbnails, remove
 | `ChatInput` + `allowImages` | Paste + paperclip picker + strip above the input |
 | `Message` | Renders `message.images` with the same tiles |
 
-**Not included (by design):** PDF / arbitrary file adapters, upload progress, cloud storage. Those stay host concerns — attach your own chips next to the composer if needed. Most agent models only accept images today.
+The generic `Attachment` / `AttachmentList` API remains image-oriented. The
+generic `ChatInput` can accept arbitrary files only when an integrator supplies
+an `AttachmentAdapter`; storage and Agent context remain that host's concern.
+JCode's built-in product composer is a separate host integration: it ships the
+managed arbitrary-file drag/drop and browser-upload path described below for
+`jcode web` and Desktop.
 
 ## Usage
 

--- a/web/src/app/composerHost.ts
+++ b/web/src/app/composerHost.ts
@@ -24,7 +24,7 @@ import {
 import { api } from '../lib/api'
 import { iconForProvider } from '../lib/providerIcons'
 import { openRemoteConnect } from '../lib/remote'
-import { isTauri, pickFolder } from '../lib/useDesktop'
+import { isTauri, listenForFileDrops, pickFolder, readDroppedImage } from '../lib/useDesktop'
 import type { AgentMode } from '../lib/types'
 
 function buildStrings(t: (key: string, opts?: Record<string, unknown>) => string): ProductComposerStrings {
@@ -50,6 +50,9 @@ function buildStrings(t: (key: string, opts?: Record<string, unknown>) => string
     goalHintRemove: t('chat.goalHint.remove'),
     goalHintReplace: t('chat.goalHint.replace'),
     modelNoImages: t('chat.model.noImages'),
+    fileUploadFailed: t('chat.fileUpload.failed'),
+    fileUploadUnavailable: t('chat.fileUpload.unavailable'),
+    fileTooLarge: t('chat.fileUpload.tooLarge'),
 
     modeApproval: t('chat.modes.approval'),
     modeApprovalSub: t('chat.modes.approvalSub'),
@@ -254,6 +257,10 @@ export const productComposerActions = {
     }
   },
 
+  uploadDroppedFile(taskID: string, file: File) {
+    return api.uploadTaskFile(taskID, file)
+  },
+
   async validateWorkspacePaths(paths: string[]) {
     const res = await api.validatePaths(paths)
     return res.missing || []
@@ -372,6 +379,8 @@ export function useProductComposerHost(): ProductComposerHost {
       strings,
       resolveProviderIcon: iconForProvider,
       pickFolder: isTauri ? pickFolder : undefined,
+      listenForFileDrops: isTauri ? listenForFileDrops : undefined,
+      readDroppedImage: isTauri ? readDroppedImage : undefined,
       ...productComposerActions,
     }),
     [

--- a/web/src/i18n/conversationLoading.test.ts
+++ b/web/src/i18n/conversationLoading.test.ts
@@ -26,4 +26,11 @@ describe('conversation-loading translations', () => {
       expect(leafKeys(locale.remoteConnection)).toEqual(expected)
     }
   })
+
+  it('keeps browser file-upload errors complete in all five locales', () => {
+    const expected = leafKeys(en.chat.fileUpload)
+    for (const locale of [zhHans, zhHant, ja, ko]) {
+      expect(leafKeys(locale.chat.fileUpload)).toEqual(expected)
+    }
+  })
 })

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -219,6 +219,11 @@ export default {
     thinking: 'Thinking…',
     loadingConversation: 'Loading conversation…',
     attachFiles: 'Attach files',
+    fileUpload: {
+      failed: 'File upload failed',
+      unavailable: 'File upload is unavailable for this task',
+      tooLarge: 'File exceeds the 100MB upload limit',
+    },
     goal: 'Goal',
     add: 'Add',
     generatedImage: {

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -212,6 +212,11 @@ export default {
     thinking: '考え中…',
     loadingConversation: '会話を読み込み中…',
     attachFiles: 'ファイルを添付',
+    fileUpload: {
+      failed: 'ファイルのアップロードに失敗しました',
+      unavailable: 'このタスクではファイルをアップロードできません',
+      tooLarge: 'ファイルが 100MB のアップロード上限を超えています',
+    },
     goal: '目標',
     add: '追加',
     copilotHint: 'Enter で送信 · Shift+Enter で改行 · Esc でキャンセル',

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -212,6 +212,11 @@ export default {
     thinking: '생각 중…',
     loadingConversation: '대화 불러오는 중…',
     attachFiles: '파일 첨부',
+    fileUpload: {
+      failed: '파일 업로드에 실패했습니다',
+      unavailable: '이 작업에서는 파일을 업로드할 수 없습니다',
+      tooLarge: '파일이 100MB 업로드 제한을 초과했습니다',
+    },
     goal: '목표',
     add: '추가',
     copilotHint: 'Enter로 전송 · Shift+Enter로 줄바꿈 · Esc로 취소',

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -209,6 +209,11 @@ export default {
     thinking: '思考中…',
     loadingConversation: '加载会话中…',
     attachFiles: '添加附件',
+    fileUpload: {
+      failed: '文件上传失败',
+      unavailable: '当前任务无法上传文件',
+      tooLarge: '文件超过 100MB 上传限制',
+    },
     goal: '目标',
     add: '添加',
     generatedImage: {

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -213,6 +213,11 @@ export default {
     thinking: '思考中…',
     loadingConversation: '載入對話中…',
     attachFiles: '附加檔案',
+    fileUpload: {
+      failed: '檔案上傳失敗',
+      unavailable: '目前任務無法上傳檔案',
+      tooLarge: '檔案超過 100MB 上傳限制',
+    },
     goal: '目標',
     add: '新增',
     copilotHint: 'Enter 傳送 · Shift+Enter 換行 · Esc 取消',

--- a/web/src/lib/api.taskScope.test.ts
+++ b/web/src/lib/api.taskScope.test.ts
@@ -84,4 +84,29 @@ describe('task-scoped API contracts', () => {
       require_idle: true,
     })
   })
+
+  it('uploads browser files as multipart data to the encoded task route', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({
+      path: '/tmp/.jcode-uploads-task/notes-a1b2c3.pdf',
+      name: 'notes-a1b2c3.pdf',
+      size: 3,
+    }), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const file = new File(['pdf'], 'notes.pdf', { type: 'application/pdf' })
+
+    const result = await api.uploadTaskFile('task/one', file)
+
+    expect(result.path).toContain('notes-a1b2c3.pdf')
+    const [input, init] = fetchMock.mock.calls[0] ?? []
+    expect(String(input)).toContain('/api/tasks/task%2Fone/uploads')
+    expect(init?.method).toBe('POST')
+    expect(init?.body).toBeInstanceOf(FormData)
+    const uploaded = (init?.body as FormData).get('file') as File
+    expect(uploaded.name).toBe('notes.pdf')
+    expect(uploaded.size).toBe(file.size)
+    expect(new Headers(init?.headers).has('Content-Type')).toBe(false)
+  })
 })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -63,6 +63,23 @@ async function requestBlob(path: string): Promise<Blob> {
   return resp.blob()
 }
 
+async function requestForm<T>(path: string, form: FormData): Promise<T> {
+  const headers = new Headers()
+  const token = getAuthToken()
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+  const resp = await fetch(`${apiBase}${path}`, { method: 'POST', headers, body: form })
+  if (resp.status === 401) notifyAuthExpired()
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({ error: resp.statusText }))
+    const err = new Error(body.error || `HTTP ${resp.status}`) as APIError
+    err.status = resp.status
+    err.code = typeof body.code === 'string' ? body.code : undefined
+    err.body = body
+    throw err
+  }
+  return resp.json()
+}
+
 async function requestVoid(path: string, method: string, body?: string): Promise<void> {
   const headers = new Headers()
   const token = getAuthToken()
@@ -116,6 +133,14 @@ export const api = {
     }),
   usageStats: (days = 30) => request<UsageStats>(`/api/usage/stats?days=${days}`),
   taskStats: (id: string) => request<TaskStats>(`/api/tasks/${encodeURIComponent(id)}/stats`),
+  uploadTaskFile: (taskId: string, file: File) => {
+    const form = new FormData()
+    form.append('file', file, file.name || 'attachment')
+    return requestForm<{ path: string; name: string; size: number }>(
+      `/api/tasks/${encodeURIComponent(taskId)}/uploads`,
+      form,
+    )
+  },
   todos: (taskId?: string) => request<TodoItem[]>(`/api/todos${taskId ? `?task_id=${encodeURIComponent(taskId)}` : ''}`),
   goal: (taskId?: string) => request<Goal | null>(`/api/goal${taskId ? `?task_id=${encodeURIComponent(taskId)}` : ''}`),
   setGoal: (objective: string, start = true, taskId?: string) =>

--- a/web/src/lib/useDesktop.test.ts
+++ b/web/src/lib/useDesktop.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { isAbsoluteLocalWorkspacePath } from './useDesktop'
+import { isAbsoluteLocalWorkspacePath, normalizeFileDropPosition } from './useDesktop'
 
 const mocks = vi.hoisted(() => ({
   openUrl: vi.fn<() => Promise<void>>(),
@@ -25,6 +25,20 @@ describe('isAbsoluteLocalWorkspacePath', () => {
     expect(isAbsoluteLocalWorkspacePath('\\\\server\\share\\jcode')).toBe(false)
     expect(isAbsoluteLocalWorkspacePath('ssh://host/work/jcode')).toBe(false)
     expect(isAbsoluteLocalWorkspacePath('docker://container/work/jcode')).toBe(false)
+  })
+})
+
+describe('normalizeFileDropPosition', () => {
+  it('keeps macOS Cocoa points unchanged on Retina displays', () => {
+    expect(normalizeFileDropPosition({ x: 960, y: 430 }, 2, 'MacIntel')).toEqual({ x: 960, y: 430 })
+  })
+
+  it('converts Windows physical pixels into CSS pixels', () => {
+    expect(normalizeFileDropPosition({ x: 960, y: 430 }, 2, 'Win32')).toEqual({ x: 480, y: 215 })
+  })
+
+  it('keeps Linux GTK coordinates unchanged', () => {
+    expect(normalizeFileDropPosition({ x: 960, y: 430 }, 1.5, 'Linux x86_64')).toEqual({ x: 960, y: 430 })
   })
 })
 

--- a/web/src/lib/useDesktop.ts
+++ b/web/src/lib/useDesktop.ts
@@ -52,6 +52,17 @@ export interface WorkspaceApplication {
   iconDataUrl?: string
 }
 
+export type DesktopFileDropEvent =
+  | { type: 'enter' | 'over'; x: number; y: number }
+  | { type: 'drop'; paths: string[]; x: number; y: number }
+  | { type: 'leave' }
+
+export interface DroppedImage {
+  data: string
+  media_type: string
+  name: string
+}
+
 let workspaceApplicationsPromise: Promise<WorkspaceApplication[]> | null = null
 
 /**
@@ -161,4 +172,46 @@ export async function pickFolder(defaultPath?: string): Promise<string | null> {
   const { open } = await import('@tauri-apps/plugin-dialog')
   const res = await open({ directory: true, multiple: false, defaultPath })
   return typeof res === 'string' ? res : null
+}
+
+/**
+ * Normalize Tauri drag coordinates to the CSS-pixel coordinate space used by
+ * getBoundingClientRect(). Wry reports Cocoa/GTK points on macOS/Linux even
+ * though Tauri types them as PhysicalPosition; Windows WebView2 reports real
+ * physical pixels and needs the scale-factor conversion.
+ */
+export function normalizeFileDropPosition(
+  position: { x: number; y: number },
+  scaleFactor: number,
+  platform = typeof navigator === 'undefined' ? '' : navigator.platform,
+): { x: number; y: number } {
+  const divisor = /Win/i.test(platform) && scaleFactor > 0 ? scaleFactor : 1
+  return { x: position.x / divisor, y: position.y / divisor }
+}
+
+/** Listen for Tauri's native drag/drop stream in CSS-pixel coordinates. */
+export async function listenForFileDrops(
+  listener: (event: DesktopFileDropEvent) => void,
+): Promise<() => void> {
+  if (!isTauri) throw new Error('native file drop unavailable')
+  const { getCurrentWebview } = await import('@tauri-apps/api/webview')
+  const webview = getCurrentWebview()
+  const scaleFactor = await webview.window.scaleFactor()
+  return webview.onDragDropEvent(({ payload }) => {
+    if (payload.type === 'leave') {
+      listener({ type: 'leave' })
+      return
+    }
+    const position = normalizeFileDropPosition(payload.position, scaleFactor)
+    if (payload.type === 'drop') {
+      listener({ type: 'drop', paths: payload.paths, ...position })
+      return
+    }
+    listener({ type: payload.type, ...position })
+  })
+}
+
+/** Read a supported image after the native drop supplied its absolute path. */
+export function readDroppedImage(path: string): Promise<DroppedImage | null> {
+  return invoke<DroppedImage | null>('read_dropped_image', { path })
 }


### PR DESCRIPTION
## Summary

- accept any file in the product composer via drag/drop or the attachment picker
- keep supported images on the existing multimodal path
- upload Browser Web files into a task-scoped managed directory on the local, SSH, or Docker execution environment and inject the Agent-readable absolute path
- preserve native absolute paths in Tauri Desktop and fix Retina welcome-screen hit testing by normalizing Wry drag coordinates per platform
- add localized upload errors while keeping model-facing file-drop context fixed English
- align the local pre-push lint gate with CI and clear the existing full-lint failures

## Safety

- uploads are task-scoped, size-limited to 100MB per file, safely renamed, and written with 0700 directory / 0600 file permissions
- uploads are rejected while the target task is running
- local managed uploads are removed when their session is deleted
- upload failures remain pending in the composer and do not send a partial prompt

## Validation

- make lint
- go test ./...
- pnpm test (web: 207 tests)
- pnpm test (jcode-ui: 74 tests)
- cargo test --manifest-path desktop/src-tauri/Cargo.toml
- pnpm tauri build --bundles app
- repository pre-push hook (build, vet, incremental golangci-lint, full Go tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file attachments to the chat composer, including browser and desktop drag-and-drop.
  * Images remain available for inline display, while other files are uploaded and provided to the agent as context.
  * Added upload progress, error, retry, size-limit, and unavailable-task states.
  * Added task-scoped file upload support with secure storage and cleanup.
  * Added localized upload messages across supported languages.
* **Bug Fixes**
  * Improved desktop drag-and-drop positioning across display scaling settings.
* **Chores**
  * Updated push validation messaging and behavior for the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->