### PR TITLE
ci: stabilize flaky generated-image test and pin golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,11 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          # Pinned: `latest` floated v2.12.2 -> v2.13.1 between Aug 19 and Aug 24
+          # 2026, and the new staticcheck turned pre-existing test-file debt into
+          # red push-to-main runs. PR runs diff with --new-from-rev (old issues
+          # hidden), so only the main full-run feels toolchain drift — pin it.
+          version: v2.13.1
           # Gate regressions without forcing a flag-day cleanup of the existing
           # lint debt (mostly upstream adk.AgentMiddleware deprecations). New
           # issues introduced by a PR still fail.

--- a/packages/jcode-ui/src/components/GeneratedImageCard.tsx
+++ b/packages/jcode-ui/src/components/GeneratedImageCard.tsx
@@ -149,7 +149,10 @@ export const GeneratedImageCard = memo(function GeneratedImageCard({
       setImageReady(true)
       return
     }
-    void image.decode().catch(() => undefined).then(() => setImageReady(true))
+    void image.decode().catch(() => undefined).then(() => {
+      // A late settle must not reveal an asset whose src has since changed.
+      if (image.getAttribute('src') === imageSrc) setImageReady(true)
+    })
   }
 
   return (

--- a/web/src/components/GeneratedImageToolRenderer.test.tsx
+++ b/web/src/components/GeneratedImageToolRenderer.test.tsx
@@ -81,6 +81,12 @@ const generatedArtifact = {
   height: 1024,
 }
 
+// Shared CI runners occasionally starve workers long enough that the default
+// 1s findByRole window expires even though the synchronous reveal path is
+// intact (once seen on ubuntu-latest: 24s jsdom environment setup). Generous
+// explicit windows keep the assertion about behavior, not runner speed.
+const SLOW_RUNNER_WAIT = { timeout: 5000 }
+
 async function readyGeneratedImage() {
   renderImage({
     status: 'done',
@@ -88,9 +94,9 @@ async function readyGeneratedImage() {
     outcome: 'succeeded',
     artifacts: [generatedArtifact],
   })
-  const image = await screen.findByRole('img', { name: generatedArtifact.title })
+  const image = await screen.findByRole('img', { name: generatedArtifact.title }, SLOW_RUNNER_WAIT)
   fireEvent.load(image)
-  return screen.findByRole('button', { name: 'Open image in a new window' })
+  return screen.findByRole('button', { name: 'Open image in a new window' }, SLOW_RUNNER_WAIT)
 }
 
 describe('GeneratedImageToolRenderer visibility', () => {


### PR DESCRIPTION
## Why

Main went red twice this week for reasons unrelated to the code under review.

**1. Web job (run 32980379797):** `GeneratedImageToolRenderer` preview test failed with `Unable to find role="button" and name "Open image in a new window"`. Same tree passed on its own PR run and passes locally with a frozen-lockfile cold install (207/207); across two weeks of CI history it failed exactly once. The ubuntu-latest worker was heavily starved that run (24s jsdom environment setup vs ~0.3s locally), so the default **1s** `findByRole` window expired even though the synchronous reveal path is intact. Environment/timing, not logic.

**2. Go job (runs of #197–#199):** golangci-lint `version: latest` floated v2.12.2 → v2.13.1 between Aug 19 and Aug 24; new staticcheck rules flagged pre-existing test-file debt (`SA1019` + one `unparam`, dating back to 91ffdda). PR runs use `--new-from-rev` so the drift only surfaced on push-to-main full runs. The debt itself was repaid by #200; this PR removes the float so the next toolchain release can't turn main red overnight.

## Changes

- `web/src/components/GeneratedImageToolRenderer.test.tsx` — widen the two `findByRole` waits in `readyGeneratedImage()` to explicit 5s windows: assertions stay about behavior, not runner speed.
- `packages/jcode-ui/src/components/GeneratedImageCard.tsx` — guard the decode reveal so a late settle cannot flip `imageReady` after the asset src changed (stale-async hygiene found while investigating).
- `.github/workflows/ci.yml` — pin golangci-lint to `v2.13.1` with rationale comment.

## Verification

Full local mirror of the CI web step with frozen lockfile:

- `pnpm -C packages/jcode-ui-core build && pnpm -C packages/jcode-ui build` ✅
- `node --experimental-strip-types --test packages/jcode-ui-core/src/timeline/*.test.ts` ✅
- `pnpm -C packages/jcode-ui test` — 76/76 ✅
- `pnpm -C web test` — 207/207 ✅
- `npx tsc --noEmit -p tsconfig.app.json` ✅
- `node --test script/generate_jcode_ui_api_docs.test.mjs` ✅

Deliberately **not** deleting or skipping the test: it guards the synchronous click-stack `window.open` path that bypasses browser popup blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated images from appearing when a newer image has already been selected.
  - Improved image loading reliability in slower environments.

- **Chores**
  - Pinned the code quality check to a specific version for more consistent build results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->