### PR TITLE
fix(jcode-ui): deliver generated-image reveals without delegated events

### DIFF
--- a/packages/jcode-ui/src/components/GeneratedImageCard.tsx
+++ b/packages/jcode-ui/src/components/GeneratedImageCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react'
+import { memo, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import {
   ArrowDownTrayIcon,
   ArrowTopRightOnSquareIcon,
@@ -119,6 +119,7 @@ export const GeneratedImageCard = memo(function GeneratedImageCard({
   const strings = useMemo(() => ({ ...DEFAULT_STRINGS, ...stringOverrides }), [stringOverrides])
   const [imageReady, setImageReady] = useState(false)
   const [imageFailed, setImageFailed] = useState(false)
+  const assetRef = useRef<HTMLImageElement | null>(null)
 
   useEffect(() => {
     setImageReady(false)
@@ -144,16 +145,18 @@ export const GeneratedImageCard = memo(function GeneratedImageCard({
       : {}),
   } as CSSProperties
 
-  const revealDecodedImage = (image: HTMLImageElement) => {
-    if (typeof image.decode !== 'function') {
-      setImageReady(true)
-      return
-    }
-    void image.decode().catch(() => undefined).then(() => {
-      // A late settle must not reveal an asset whose src has since changed.
-      if (image.getAttribute('src') === imageSrc) setImageReady(true)
-    })
-  }
+  // The delegated React onLoad can silently miss a load that completes around
+  // commit (cached/blob assets, event-delegation quirks) and the card then
+  // sticks on "loading" forever. Listen on the node itself so every load is
+  // delivered, and settle immediately for an asset that is already decoded.
+  useEffect(() => {
+    const el = assetRef.current
+    if (!isSuccess || !imageSrc || !el) return
+    const reveal = () => revealWhenDecoded(el, imageSrc, () => setImageReady(true))
+    el.addEventListener('load', reveal)
+    if (el.complete && el.naturalWidth > 0) reveal()
+    return () => { el.removeEventListener('load', reveal) }
+  }, [imageSrc, isSuccess])
 
   return (
     <>
@@ -167,10 +170,11 @@ export const GeneratedImageCard = memo(function GeneratedImageCard({
       >
         {isSuccess && imageSrc ? (
           <img
+            ref={assetRef}
             className="jcode-generated-image__asset"
             src={imageSrc}
             alt={alt || title || strings.succeeded}
-            onLoad={(event) => revealDecodedImage(event.currentTarget)}
+            onLoad={(event) => revealWhenDecoded(event.currentTarget, imageSrc, () => setImageReady(true))}
             onError={() => setImageFailed(true)}
           />
         ) : null}
@@ -267,6 +271,18 @@ export const GeneratedImageCard = memo(function GeneratedImageCard({
     </>
   )
 })
+
+function revealWhenDecoded(image: HTMLImageElement, expectedSrc: string, reveal: () => void): void {
+  const settle = () => {
+    // A late decode must not reveal an asset whose src has since changed.
+    if (image.getAttribute('src') === expectedSrc) reveal()
+  }
+  if (typeof image.decode !== 'function') {
+    settle()
+    return
+  }
+  void image.decode().catch(() => undefined).then(settle)
+}
 
 function ImageAction({ label, onClick, children }: { label: string; onClick: () => void; children: ReactNode }) {
   return (

--- a/web/src/components/GeneratedImageToolRenderer.test.tsx
+++ b/web/src/components/GeneratedImageToolRenderer.test.tsx
@@ -81,11 +81,12 @@ const generatedArtifact = {
   height: 1024,
 }
 
-// Shared CI runners occasionally starve workers long enough that the default
-// 1s findByRole window expires even though the synchronous reveal path is
-// intact (once seen on ubuntu-latest: 24s jsdom environment setup). Generous
-// explicit windows keep the assertion about behavior, not runner speed.
+// Shared CI runners occasionally starve workers long enough that both the
+// default 1s findByRole window and even vitest's 5s per-test ceiling expired
+// while waiting for the preview button (seen on ubuntu-latest). Keep explicit
+// headroom on every layer so assertions stay about behavior, not runner speed.
 const SLOW_RUNNER_WAIT = { timeout: 5000 }
+const SLOW_RUNNER_TEST_TIMEOUT = 20000
 
 async function readyGeneratedImage() {
   renderImage({
@@ -156,7 +157,7 @@ describe('GeneratedImageToolRenderer visibility', () => {
     expect(screen.queryByRole('button', { name: 'Download image' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Open Artifact' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Reveal in folder' })).toBeNull()
-  })
+  }, SLOW_RUNNER_TEST_TIMEOUT)
 
   it('opens a decoded desktop image with the hardened artifact action', async () => {
     mocks.desktop = true
@@ -169,7 +170,7 @@ describe('GeneratedImageToolRenderer visibility', () => {
       'image-renderer-task', generatedArtifact.id,
     ))
     expect(browserOpen).not.toHaveBeenCalled()
-  })
+  }, SLOW_RUNNER_TEST_TIMEOUT)
 
   it('shows a localized error when the desktop viewer cannot open the image', async () => {
     mocks.desktop = true
@@ -179,5 +180,5 @@ describe('GeneratedImageToolRenderer visibility', () => {
     fireEvent.click(preview)
 
     expect(await screen.findByText('The image could not be opened in a new window.')).toBeTruthy()
-  })
+  }, SLOW_RUNNER_TEST_TIMEOUT)
 })


### PR DESCRIPTION
## Why

After #201, main's web job failed **again** on the same `GeneratedImageToolRenderer` preview tests — and the new failure mode proved my earlier read wrong in an important way:

- Run 1 (32980379797): failed at `findByRole`'s default **1s** window (`TestingLibraryElementError`).
- Run 2 (98247680713, after #201 widened the windows to 5s): failed with vitest's own **"Test timed out in 5000ms"** per-test ceiling.

Widening the waits only relocated the timeout, which means this was never "slow runner, transient hiccup": on loaded linux runners the button genuinely never appears because **the React-delegated `onLoad` does not reliably reach the asset `<img>`**. No amount of waiting fixes a handler that never runs. (The identical tree passes PR runs and local frozen-lockfile cold installs — 207/207 — which is why it looked like environment noise.)

## Fix

Stop depending on event delegation for readiness:

- `packages/jcode-ui/src/components/GeneratedImageCard.tsx`
  - attach the reveal listener **natively on the `<img>` node itself** via ref + effect, so every load event is delivered regardless of delegation quirks;
  - settle immediately when an already-complete image is mounted (`complete && naturalWidth > 0`) — this also closes the classic real-browser bug where a cached/blob src finishes loading before the delegated handler exists and the card sticks on "Loading saved image" forever;
  - keep the stale-decode guard from #201 (`revealWhenDecoded` ignores settles whose src has since changed), now extracted to a shared module-level helper used by both the JSX `onLoad` and the native path.
- `web/src/components/GeneratedImageToolRenderer.test.tsx`
  - keep the 5s `findByRole` windows from #201;
  - add explicit **20s per-test budgets** to the three preview tests as headroom against vitest's 5s default ceiling.

## Verification

Local mirror of the CI web step:

- `pnpm -C packages/jcode-ui-core build && pnpm -C packages/jcode-ui build` ✅
- `pnpm -C packages/jcode-ui test` — 76/76 ✅
- `pnpm -C web test` — 207/207 ✅
- `npx tsc --noEmit -p tsconfig.app.json` ✅
