### PR TITLE
feat(composer): clear project selection and localize Chat

### DIFF
--- a/packages/jcode-ui/src/product/ChatInput.test.tsx
+++ b/packages/jcode-ui/src/product/ChatInput.test.tsx
@@ -262,7 +262,7 @@ describe('workspace picker', () => {
 
     fireEvent.click(screen.getByText('project'))
     expect(screen.queryByText('2026-08-19-001')).toBeNull()
-    fireEvent.click(screen.getByText('Work without a project'))
+    fireEvent.click(screen.getByText('Chat'))
     await waitFor(() => expect(startScratchWorkspace).toHaveBeenCalledTimes(1))
   })
 
@@ -295,8 +295,8 @@ describe('workspace picker', () => {
       startScratchWorkspace,
     }))
 
-    fireEvent.click(screen.getByText('Work without a project'))
-    const labels = screen.getAllByText('Work without a project')
+    fireEvent.click(screen.getByText('Chat'))
+    const labels = screen.getAllByText('Chat')
     fireEvent.click(labels[labels.length - 1])
     expect(startScratchWorkspace).not.toHaveBeenCalled()
   })

--- a/packages/jcode-ui/src/product/WorkspacePicker.tsx
+++ b/packages/jcode-ui/src/product/WorkspacePicker.tsx
@@ -18,6 +18,7 @@ import {
   MagnifyingGlassIcon,
   PlusIcon,
   ServerIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { useRuntimeState } from 'jcode-ui-core/runtime'
 import type { ProductComposerHost } from './host.js'
@@ -103,6 +104,7 @@ export function WorkspacePicker({ host, placement = 'top' }: { host: ProductComp
     ? strings.workspaceScratchAction
     : activePath ? workspaceName(activePath) : strings.workspaceNone
   const activeRemote = !activeScratch && isRemotePath(activePath)
+  const canClearProject = !!activePath && !activeScratch && !!host.startScratchWorkspace
 
   const validateKnownPaths = useCallback(async () => {
     const localPaths = [...new Set(tasks
@@ -205,6 +207,7 @@ export function WorkspacePicker({ host, placement = 'top' }: { host: ProductComp
   }
 
   async function startScratch() {
+    if (isRunning || switching) return
     if (activeScratch) {
       reset()
       return
@@ -217,6 +220,8 @@ export function WorkspacePicker({ host, placement = 'top' }: { host: ProductComp
       reset()
     } catch (e) {
       setError(e instanceof Error ? e.message : strings.workspaceOpenError)
+      setBrowserOpen(false)
+      setOpen(true)
     } finally {
       setSwitching(false)
     }
@@ -240,27 +245,48 @@ export function WorkspacePicker({ host, placement = 'top' }: { host: ProductComp
 
   return (
     <div ref={rootRef} className={`ws-bar${open ? ' is-open' : ''}`} style={{ position: 'relative' }}>
-      <button
-        type="button"
-        disabled={isRunning || switching}
-        title={activePath}
-        onClick={(e) => {
-          e.stopPropagation()
-          setOpen((v) => {
-            if (!v) void validateKnownPaths()
-            return !v
-          })
-        }}
-        className="ws-pill ws-pill-action"
-      >
-        {activeScratch
-          ? <ChatBubbleLeftRightIcon className="h-3.5 w-3.5 ws-pill-icon" />
-          : activeRemote
-          ? <ServerIcon className="h-3.5 w-3.5 ws-pill-icon" />
-          : <FolderOpenIcon className="h-3.5 w-3.5 ws-pill-icon" />}
-        <span className="ws-name">{activeName}</span>
-        <ChevronDownIcon className={`h-3 w-3 ws-caret${open ? ' open' : ''}`} />
-      </button>
+      <div className={`ws-selection${canClearProject ? ' can-clear' : ''}${isRunning || switching ? ' is-disabled' : ''}`}>
+        {canClearProject && (
+          <button
+            type="button"
+            className="ws-clear"
+            disabled={isRunning || switching}
+            title={strings.workspaceClearProject}
+            aria-label={strings.workspaceClearProject}
+            onClick={(e) => {
+              e.stopPropagation()
+              void startScratch()
+            }}
+          >
+            {activeRemote
+              ? <ServerIcon className="h-3.5 w-3.5 ws-clear-icon" />
+              : <FolderOpenIcon className="h-3.5 w-3.5 ws-clear-icon" />}
+            <XMarkIcon className="h-3.5 w-3.5 ws-clear-hover-icon" />
+          </button>
+        )}
+        <button
+          type="button"
+          disabled={isRunning || switching}
+          title={activeScratch ? activeName : activePath}
+          aria-expanded={open}
+          onClick={(e) => {
+            e.stopPropagation()
+            setOpen((v) => {
+              if (!v) void validateKnownPaths()
+              return !v
+            })
+          }}
+          className="ws-pill ws-pill-action"
+        >
+          {!canClearProject && (activeScratch
+            ? <ChatBubbleLeftRightIcon className="h-3.5 w-3.5 ws-pill-icon" />
+            : activeRemote
+            ? <ServerIcon className="h-3.5 w-3.5 ws-pill-icon" />
+            : <FolderOpenIcon className="h-3.5 w-3.5 ws-pill-icon" />)}
+          <span className="ws-name">{activeName}</span>
+          <ChevronDownIcon className={`h-3 w-3 ws-caret${open ? ' open' : ''}`} />
+        </button>
+      </div>
 
       {open && (
         <div className={`ws-panel ${placement === 'bottom' ? 'place-bottom' : 'place-top'}`}>
@@ -313,6 +339,14 @@ export function WorkspacePicker({ host, placement = 'top' }: { host: ProductComp
                 <MagnifyingGlassIcon className="h-3 w-3 ws-search-icon" />
                 <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder={strings.workspaceSearch} className="ws-search-input" />
               </div>
+              {host.startScratchWorkspace && <div className="ws-chat-option">
+                <button type="button" disabled={isRunning || switching} className={`ws-action${activeScratch ? ' active' : ''}`} onClick={() => void startScratch()}>
+                  <ChatBubbleLeftRightIcon className="h-3.5 w-3.5" />
+                  <span>{strings.workspaceScratchAction}</span>
+                  {activeScratch && <CheckIcon className="ml-auto h-3.5 w-3.5 ws-check" />}
+                </button>
+                <div className="ws-action-separator" />
+              </div>}
               <div className="ws-list">
                 {workspaces.length === 0 ? (
                   <div className="ws-hint">{strings.workspaceNonePlural}</div>
@@ -347,14 +381,6 @@ export function WorkspacePicker({ host, placement = 'top' }: { host: ProductComp
                   <ServerIcon className="h-3.5 w-3.5" />
                   <span>{strings.remoteConnect}</span>
                 </button>}
-                {host.startScratchWorkspace && <>
-                  <div className="ws-action-separator" />
-                  <button type="button" disabled={switching} className={`ws-action${activeScratch ? ' active' : ''}`} onClick={() => void startScratch()}>
-                    <ChatBubbleLeftRightIcon className="h-3.5 w-3.5" />
-                    <span>{strings.workspaceScratchAction}</span>
-                    {activeScratch && <CheckIcon className="ml-auto h-3.5 w-3.5 ws-check" />}
-                  </button>
-                </>}
               </div>
             </div>
           )}
@@ -395,12 +421,45 @@ const WS_CSS = `
   max-width: 230px;
   background: transparent;
   cursor: pointer;
-  transition: background 0.15s, transform 0.06s ease;
 }
 .ws-pill-action .ws-pill-icon { color: var(--color-accent-neutral); }
-.ws-pill-action:hover:not(:disabled) { background: var(--color-muted); }
-.ws-pill-action:active:not(:disabled) { transform: translateY(0.5px); }
 .ws-pill-action:disabled { opacity: 0.55; cursor: not-allowed; }
+.ws-selection {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 230px;
+  border-radius: var(--radius-lg);
+  transition: background 0.15s, transform 0.06s ease;
+}
+.ws-selection:is(:hover, :focus-within):not(.is-disabled),
+.ws-bar.is-open .ws-selection:not(.is-disabled) { background: var(--color-muted); }
+.ws-selection:active:not(.is-disabled) { transform: translateY(0.5px); }
+.ws-selection:has(:focus-visible) { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.ws-selection button:focus-visible { outline: none; }
+.ws-selection.can-clear .ws-pill-action { padding-left: 2px; }
+.ws-clear {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  margin-left: 2px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--color-accent-neutral);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.ws-selection:is(:hover, :focus-within):not(.is-disabled) .ws-clear { color: var(--color-foreground); }
+.ws-clear:disabled { opacity: 0.55; cursor: not-allowed; }
+.ws-clear-icon, .ws-clear-hover-icon { grid-area: 1 / 1; }
+.ws-clear-hover-icon { visibility: hidden; }
+.ws-selection:is(:hover, :focus-within):not(.is-disabled) .ws-clear-icon { visibility: hidden; }
+.ws-selection:is(:hover, :focus-within):not(.is-disabled) .ws-clear-hover-icon { visibility: visible; }
+.ws-chat-option { flex-shrink: 0; }
 .ws-name {
   font-weight: 500;
   white-space: nowrap;

--- a/packages/jcode-ui/src/product/strings.ts
+++ b/packages/jcode-ui/src/product/strings.ts
@@ -98,6 +98,7 @@ export interface ProductComposerStrings {
   workspaceOpenError: string
   workspacePathPlaceholder: string
   workspaceScratchAction: string
+  workspaceClearProject: string
   remoteConnect: string
 
   // ── branch picker ──
@@ -228,7 +229,8 @@ export const defaultProductComposerStrings: ProductComposerStrings = {
   workspaceOpenFolder: 'Open folder',
   workspaceOpenError: 'Failed to open workspace',
   workspacePathPlaceholder: '/path/to/folder',
-  workspaceScratchAction: 'Work without a project',
+  workspaceScratchAction: 'Chat',
+  workspaceClearProject: 'Clear project and switch to Chat',
   remoteConnect: 'Remote connect',
 
   branchesTitle: 'Branches',

--- a/web/src/app/composerHost.ts
+++ b/web/src/app/composerHost.ts
@@ -108,6 +108,7 @@ function buildStrings(t: (key: string, opts?: Record<string, unknown>) => string
     workspaceOpenError: t('workspace.openError'),
     workspacePathPlaceholder: t('projectSwitcher.pathPlaceholder'),
     workspaceScratchAction: t('workspace.workWithoutProject'),
+    workspaceClearProject: t('workspace.clearProject'),
     remoteConnect: t('nav.remoteConnect'),
 
     branchesTitle: t('branches.title'),

--- a/web/src/components/AutomationsView.project.test.tsx
+++ b/web/src/components/AutomationsView.project.test.tsx
@@ -98,7 +98,7 @@ describe('Automation project field', () => {
     fireEvent.click(screen.getByTitle('Edit'))
     const dialog = screen.getByRole('dialog', { name: 'Edit automation' })
 
-    expect(within(dialog).getByRole('textbox', { name: 'Project' }).textContent).toBe('No project')
+    expect(within(dialog).getByRole('textbox', { name: 'Project' }).textContent).toBe('Chat')
     expect(within(dialog).queryByRole('combobox', { name: 'Project' })).toBeNull()
     expect(dialog.textContent).not.toContain(scratchPath)
     expect(dialog.textContent).not.toContain('cannot move')
@@ -149,10 +149,10 @@ describe('Automation project field', () => {
     fireEvent.click(ownerSelect)
     const ownerList = within(dialog).getByRole('listbox', { name: 'Runs in' })
     const scratchOwner = within(ownerList).getByRole('option', { name: /System resource checks/ })
-    expect(scratchOwner.textContent).toContain('No project')
+    expect(scratchOwner.textContent).toContain('Chat')
     fireEvent.click(scratchOwner)
     expect(ownerSelect.textContent).toContain('System resource checks')
-    expect(within(dialog).getByRole('textbox', { name: 'Project' }).textContent).toBe('No project')
+    expect(within(dialog).getByRole('textbox', { name: 'Project' }).textContent).toBe('Chat')
 
     fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
     await waitFor(() => expect(api.automationUpdate).toHaveBeenCalled())

--- a/web/src/components/Sidebar.scratch.test.tsx
+++ b/web/src/components/Sidebar.scratch.test.tsx
@@ -68,10 +68,10 @@ describe('Sidebar no-project grouping', () => {
     )
 
     await waitFor(() => expect(screen.getByText('Second scratch task')).toBeTruthy())
-    expect(screen.getAllByText('No project')).toHaveLength(1)
+    expect(screen.getAllByText('Chat')).toHaveLength(1)
     expect(screen.queryByText('2026-08-19-001')).toBeNull()
     expect(screen.queryByText('2026-08-19-002')).toBeNull()
     const groupNames = [...container.querySelectorAll('.sb-project-name')].map((node) => node.textContent)
-    expect(groupNames).toEqual(['No project', 'jcode'])
+    expect(groupNames).toEqual(['Chat', 'jcode'])
   })
 })

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -79,7 +79,7 @@ export default {
 
   welcome: {
     startIn: 'Start a new task in {project}',
-    startWithoutProject: 'Start a task without a project',
+    startWithoutProject: 'Start a Chat',
     subtitle: 'Send a message to start. {kbd} for commands.',
   },
 
@@ -1228,7 +1228,7 @@ export default {
     running: 'Running',
     untitled: 'New chat',
     newTaskHere: 'New task here',
-    newNoProjectTask: 'New task without a project',
+    newNoProjectTask: 'New Chat',
     filter: {
       title: 'Filters & sorting',
       status: 'Status',
@@ -1534,8 +1534,9 @@ export default {
 
   workspace: {
     none: 'No workspace',
-    noProject: 'No project',
-    workWithoutProject: 'Work without a project',
+    noProject: 'Chat',
+    workWithoutProject: 'Chat',
+    clearProject: 'Clear project and switch to Chat',
     loading: 'Loading…',
     noFolders: 'No folders',
     open: 'Open',

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -182,7 +182,7 @@ export default {
 
   welcome: {
     startIn: '{project} で新しいタスクを開始',
-    startWithoutProject: 'プロジェクトなしでタスクを開始',
+    startWithoutProject: 'チャットを開始',
     subtitle: 'メッセージを送信して開始します。{kbd} でコマンドを表示。',
   },
 
@@ -1115,7 +1115,7 @@ export default {
     running: '実行中',
     untitled: '新しいチャット',
     newTaskHere: 'ここで新規タスク',
-    newNoProjectTask: 'プロジェクトなしで新規タスク',
+    newNoProjectTask: '新しいチャット',
     filter: {
       title: 'フィルターと並べ替え',
       status: 'ステータス',
@@ -1402,8 +1402,9 @@ export default {
 
   workspace: {
     none: 'ワークスペースなし',
-    noProject: 'プロジェクトなし',
-    workWithoutProject: 'プロジェクトを使わずに作業',
+    noProject: 'チャット',
+    workWithoutProject: 'チャット',
+    clearProject: 'プロジェクトを解除してチャットに切り替え',
     loading: '読み込み中…',
     noFolders: 'フォルダーなし',
     open: '開く',

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -182,7 +182,7 @@ export default {
 
   welcome: {
     startIn: '{project}에서 새 작업 시작',
-    startWithoutProject: '프로젝트 없이 작업 시작',
+    startWithoutProject: '채팅 시작',
     subtitle: '메시지를 보내 시작하세요. {kbd}로 명령어를 확인하세요.',
   },
 
@@ -1114,7 +1114,7 @@ export default {
     running: '실행 중',
     untitled: '새 채팅',
     newTaskHere: '여기에 새 작업',
-    newNoProjectTask: '프로젝트 없이 새 작업',
+    newNoProjectTask: '새 채팅',
     filter: {
       title: '필터 및 정렬',
       status: '상태',
@@ -1401,8 +1401,9 @@ export default {
 
   workspace: {
     none: '워크스페이스 없음',
-    noProject: '프로젝트 없음',
-    workWithoutProject: '프로젝트 없이 작업',
+    noProject: '채팅',
+    workWithoutProject: '채팅',
+    clearProject: '프로젝트 선택 해제 후 채팅으로 전환',
     loading: '불러오는 중…',
     noFolders: '폴더 없음',
     open: '열기',

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -179,7 +179,7 @@ export default {
 
   welcome: {
     startIn: '在 {project} 中开始一个新任务',
-    startWithoutProject: '开始一个无项目任务',
+    startWithoutProject: '开始聊天',
     subtitle: '发送消息即可开始。{kbd} 查看命令。',
   },
 
@@ -1205,7 +1205,7 @@ export default {
     running: '运行中',
     untitled: '新会话',
     newTaskHere: '在此新建任务',
-    newNoProjectTask: '新建无项目任务',
+    newNoProjectTask: '新建聊天',
     filter: {
       title: '筛选与排序',
       status: '状态',
@@ -1510,8 +1510,9 @@ export default {
 
   workspace: {
     none: '无工作区',
-    noProject: '无项目',
-    workWithoutProject: '不在项目中工作',
+    noProject: '聊天',
+    workWithoutProject: '聊天',
+    clearProject: '取消项目，切换到聊天',
     loading: '加载中…',
     noFolders: '无文件夹',
     open: '打开',

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -183,7 +183,7 @@ export default {
 
   welcome: {
     startIn: '在 {project} 中開始一項新工作',
-    startWithoutProject: '開始一項無專案工作',
+    startWithoutProject: '開始聊天',
     subtitle: '傳送訊息即可開始。{kbd} 查看指令。',
   },
 
@@ -1109,7 +1109,7 @@ export default {
     running: '執行中',
     untitled: '新對話',
     newTaskHere: '在此新建工作',
-    newNoProjectTask: '新建無專案工作',
+    newNoProjectTask: '新增聊天',
     filter: {
       title: '篩選與排序',
       status: '狀態',
@@ -1396,8 +1396,9 @@ export default {
 
   workspace: {
     none: '無工作區',
-    noProject: '無專案',
-    workWithoutProject: '不在專案中工作',
+    noProject: '聊天',
+    workWithoutProject: '聊天',
+    clearProject: '取消專案，切換到聊天',
     loading: '載入中…',
     noFolders: '無資料夾',
     open: '開啟',


### PR DESCRIPTION
The composer now lets users clear the selected project directly from its leading icon and switch to a fresh Chat workspace. The icon, project name, and dropdown share one rounded control and hover/focus treatment; the name and arrow continue to open the workspace menu.

The Chat entry appears above project choices. No-project labels are localized consistently across the picker, sidebar, welcome screen, and task context labels: Chat in English, 聊天 in Chinese, with Japanese and Korean translations. Clearing the selection preserves project files, is disabled while running or switching, and surfaces failures in the picker.

Validation:
- `make lint`
- `pnpm exec vitest run` in `packages/jcode-ui`: 76 tests passed
- `pnpm exec vitest run` in `web`: 217 tests passed
- `make build-web -o generate` (model/theme generation was unchanged)
- Pre-push hook: Go build, vet, lint, and full test suite
- Isolated browser checks: unified control appearance, clear-to-Chat, reselecting a project, menu Chat selection, Chinese labels, long project names, and no browser console warnings/errors



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace selection now offers a clear action to remove the active project and switch directly to Chat.
  - Starting a project-free conversation is labeled “Chat” throughout the interface.
  - Updated localized labels across English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

- **Bug Fixes**
  - Prevented duplicate workspace actions while a workspace is starting or switching.
  - Workspace selection now reopens appropriately if starting a scratch conversation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->