### PR TITLE
feat(settings): separate Agent and Review sections

### DIFF
--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -1593,6 +1593,8 @@ export type SettingsTab =
   | 'general'
   | 'cloud'
   | 'appearance'
+  | 'agent'
+  | 'review'
   | 'providers'
   | 'mcp'
   | 'skills'

--- a/web/src/components/SettingsView.test.tsx
+++ b/web/src/components/SettingsView.test.tsx
@@ -75,6 +75,8 @@ describe('SettingsView', () => {
       'General',
       'Cloud',
       'Appearance',
+      'Agent',
+      'Review',
       'Providers',
       'MCP Servers',
       'Skills',

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -8,7 +8,8 @@
  * Tabs: General (server/token/auto-approve/language + the M19 cloud-sync
  * default), Cloud (M18: account/connection state, auto-connect, pairing
  * approvals, device-code login and logout — moved out of the
- * CloudBadge popover), Providers (full CRUD + catalog + advanced config),
+ * CloudBadge popover), Agent (tool discovery), Review (Auto approval review),
+ * Providers (full CRUD + catalog + advanced config),
  * Models (state/favorites/effort), MCP (servers CRUD + OAuth login), Skills
  * (enable/disable), Appearance (theme picker), Memory (status + consolidation),
  * Browser (config + site permissions), Computer (config + app permissions +
@@ -137,6 +138,8 @@ const TABS: { id: TabId; Icon: React.ComponentType<{ className?: string }> }[] =
   { id: 'general', Icon: Cog6ToothIcon },
   { id: 'cloud', Icon: CloudIcon },
   { id: 'appearance', Icon: SwatchIcon },
+  { id: 'agent', Icon: BoltIcon },
+  { id: 'review', Icon: ShieldCheckIcon },
   { id: 'providers', Icon: CpuChipIcon },
   { id: 'mcp', Icon: ServerStackIcon },
   { id: 'skills', Icon: SparklesIcon },
@@ -301,6 +304,8 @@ export function SettingsView() {
             {tab === 'general' && <GeneralTab />}
             {tab === 'cloud' && <CloudTab />}
             {tab === 'appearance' && <AppearanceTab />}
+            {tab === 'agent' && <AgentTab />}
+            {tab === 'review' && <ReviewTab />}
             {tab === 'providers' && <ProvidersTab />}
             {tab === 'mcp' && <MCPTab />}
             {tab === 'skills' && <SkillsTab />}
@@ -1967,11 +1972,6 @@ function GeneralTab() {
           ))}
         </select>
       </div>
-
-      {/* Agent behavior and approval review (Auto session mode) */}
-      <ToolSearchSection />
-      <ApprovalReviewSection />
-
     </div>
   )
 }
@@ -2033,6 +2033,28 @@ function VersionUpdateRow() {
       >
         {t('update.checkButton')}
       </button>
+    </div>
+  )
+}
+
+function AgentTab() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-5">
+      <h3 className={SECTION_TITLE}>{t('settings.tabs.agent')}</h3>
+      <ToolSearchSection />
+    </div>
+  )
+}
+
+function ReviewTab() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-5">
+      <h3 className={SECTION_TITLE}>{t('settings.tabs.review')}</h3>
+      <ApprovalReviewSection />
     </div>
   )
 }
@@ -2167,7 +2189,7 @@ function ApprovalReviewSection() {
 
   // The reviewer model picker offers the same enabled-model list as the chat
   // picker and the small_model role picker, so a model is chosen the same way
-  // everywhere. This section lives in the General tab, which does not load the
+  // everywhere. This section lives in the Review tab, which does not load the
   // list itself — refresh it here rather than depend on the Providers tab
   // having been opened first.
   const pickerProviders = useAppSelector((s) => s.model.providers)

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -416,6 +416,8 @@ export default {
     title: 'Settings',
     tabs: {
       general: 'General',
+      agent: 'Agent',
+      review: 'Review',
       cloud: 'Cloud',
       appearance: 'Appearance',
       providers: 'Providers',

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -370,6 +370,8 @@ export default {
     title: '設定',
     tabs: {
       general: '一般',
+      agent: 'エージェント',
+      review: 'レビュー',
       cloud: 'クラウド',
       appearance: '外観',
       providers: 'プロバイダー',

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -370,6 +370,8 @@ export default {
     title: '설정',
     tabs: {
       general: '일반',
+      agent: '에이전트',
+      review: '검토',
       cloud: '클라우드',
       appearance: '모양',
       providers: '프로바이더',

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -399,6 +399,8 @@ export default {
     title: '设置',
     tabs: {
       general: '通用',
+      agent: 'Agent',
+      review: '审阅',
       cloud: '云',
       appearance: '外观',
       providers: '服务商',

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -371,6 +371,8 @@ export default {
     title: '設定',
     tabs: {
       general: '一般',
+      agent: 'Agent',
+      review: '審閱',
       cloud: '雲端',
       appearance: '外觀',
       providers: '服務商',


### PR DESCRIPTION
## Summary

Tool discovery and Auto approval-review settings currently share General with everyday preferences. Give them separate Agent and Review sections so approval policies have a dedicated settings entry point.

## Related Issues / Tickets

None.

## Type of Change

- [x] New feature
- [x] Refactoring / code cleanup
- [x] Test update

## Changes Made

1. Add Agent and Review navigation entries after Appearance, backed by typed settings state.
2. Move progressive tool disclosure to Agent and the approval reviewer to Review, reusing their existing components and load/save handling.
3. Add labels in all five supported locales and update the settings navigation test.

## Testing

- `make lint` — passed with 0 Go lint issues and successful frontend/package type checks.
- `make build-web` — passed.
- `pnpm --dir web test` — 217 tests passed across 44 files.
- Pre-push gate — `go build ./...`, `go vet ./...`, incremental Go lint, and `go test ./...` all passed.
- `git diff --check` — passed.

## Screenshots / Recordings

Not captured.

## Checklist

- [x] Read the project development guidelines.
- [x] Followed the existing settings components, styling, and localization conventions.
- [x] Reviewed the scoped diff.
- [x] Updated the existing navigation test.
- [x] Updated the settings structure comments.
- [x] Local frontend tests, lint, and production build pass.

## Additional Notes

The production build reports the existing large-bundle warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated **Agent** and **Review** tabs to Settings.
  - Moved agent tools and approval review options into their respective tabs for easier navigation.
  - Added localized tab labels in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

- **Tests**
  - Updated Settings coverage to verify the new Agent and Review sections appear in the navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->